### PR TITLE
FIX MSI magento-engcom/magento#70:

### DIFF
--- a/app/code/Magento/Inventory/Indexer/IndexHandlerInterface.php
+++ b/app/code/Magento/Inventory/Indexer/IndexHandlerInterface.php
@@ -19,7 +19,7 @@ interface IndexHandlerInterface
      * @param \Traversable $documents
      * @return void
      */
-    public function saveIndex(IndexName $indexName, \Traversable $documents): void;
+    public function saveIndex(IndexName $indexName, \Traversable $documents);
 
     /**
      * Remove data from index
@@ -28,5 +28,5 @@ interface IndexHandlerInterface
      * @param \Traversable $documents
      * @return void
      */
-    public function deleteIndex(IndexName $indexName, \Traversable $documents): void;
+    public function deleteIndex(IndexName $indexName, \Traversable $documents);
 }

--- a/app/code/Magento/Inventory/Indexer/IndexStructureInterface.php
+++ b/app/code/Magento/Inventory/Indexer/IndexStructureInterface.php
@@ -21,12 +21,12 @@ interface IndexStructureInterface
      * @param string $connectionName
      * @return void
      */
-    public function create(IndexName $indexName, string $connectionName = ResourceConnection::DEFAULT_CONNECTION): void;
+    public function create(IndexName $indexName, string $connectionName = ResourceConnection::DEFAULT_CONNECTION);
 
     /**
      * @param IndexName $indexName
      * @param string $connectionName
      * @return void
      */
-    public function delete(IndexName $indexName, string $connectionName = ResourceConnection::DEFAULT_CONNECTION): void;
+    public function delete(IndexName $indexName, string $connectionName = ResourceConnection::DEFAULT_CONNECTION);
 }

--- a/app/code/Magento/Inventory/Indexer/IndexTableSwitcherInterface.php
+++ b/app/code/Magento/Inventory/Indexer/IndexTableSwitcherInterface.php
@@ -19,8 +19,5 @@ interface IndexTableSwitcherInterface
      * @param string $connectionName
      * @return void
      */
-    public function switch(
-        IndexName $indexName,
-        string $connectionName = ResourceConnection::DEFAULT_CONNECTION
-    ): void;
+    public function switch(IndexName $indexName, string $connectionName = ResourceConnection::DEFAULT_CONNECTION);
 }

--- a/app/code/Magento/Inventory/Indexer/StockItem/IndexHandler.php
+++ b/app/code/Magento/Inventory/Indexer/StockItem/IndexHandler.php
@@ -57,7 +57,7 @@ class IndexHandler implements IndexHandlerInterface
     /**
      * @inheritdoc
      */
-    public function saveIndex(IndexName $indexName, \Traversable $documents): void
+    public function saveIndex(IndexName $indexName, \Traversable $documents)
     {
         $tableName = $this->indexNameResolver->resolveName($indexName);
 
@@ -73,7 +73,7 @@ class IndexHandler implements IndexHandlerInterface
     /**
      * @inheritdoc
      */
-    public function deleteIndex(IndexName $indexName, \Traversable $documents): void
+    public function deleteIndex(IndexName $indexName, \Traversable $documents)
     {
         $tableName = $this->indexNameResolver->resolveName($indexName);
 

--- a/app/code/Magento/Inventory/Indexer/StockItem/IndexStructure.php
+++ b/app/code/Magento/Inventory/Indexer/StockItem/IndexStructure.php
@@ -42,7 +42,7 @@ class IndexStructure implements IndexStructureInterface
     /**
      * @inheritdoc
      */
-    public function create(IndexName $indexName, string $connectionName = ResourceConnection::DEFAULT_CONNECTION): void
+    public function create(IndexName $indexName, string $connectionName = ResourceConnection::DEFAULT_CONNECTION)
     {
         $connection = $this->resourceConnection->getConnection($connectionName);
         $tableName = $this->indexNameResolver->resolveName($indexName);
@@ -93,7 +93,7 @@ class IndexStructure implements IndexStructureInterface
     /**
      * @inheritdoc
      */
-    public function delete(IndexName $indexName, string $connectionName = ResourceConnection::DEFAULT_CONNECTION): void
+    public function delete(IndexName $indexName, string $connectionName = ResourceConnection::DEFAULT_CONNECTION)
     {
         $connection = $this->resourceConnection->getConnection($connectionName);
         $tableName = $this->indexNameResolver->resolveName($indexName);

--- a/app/code/Magento/Inventory/Indexer/StockItem/IndexTableSwitcher.php
+++ b/app/code/Magento/Inventory/Indexer/StockItem/IndexTableSwitcher.php
@@ -49,10 +49,8 @@ class IndexTableSwitcher implements IndexTableSwitcherInterface
     /**
      * @inheritdoc
      */
-    public function switch(
-        IndexName $indexName,
-        string $connectionName = ResourceConnection::DEFAULT_CONNECTION
-    ): void {
+    public function switch(IndexName $indexName, string $connectionName = ResourceConnection::DEFAULT_CONNECTION)
+    {
         $connection = $this->resourceConnection->getConnection($connectionName);
         $tableName = $this->indexNameResolver->resolveName($indexName);
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Return type `void` was introduced only in PHP 7.1. In Magento 2.2 PHP 7.0 is supported as well, so all usages of return type void must be removed for compatibility.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/magento2#70: Can not install develop branch

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
