### PR TITLE
Add default Stock in Data Install

### DIFF
--- a/app/code/Magento/InventoryCatalog/Setup/InstallData.php
+++ b/app/code/Magento/InventoryCatalog/Setup/InstallData.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\InventoryCatalog\Setup;
+
+use Magento\Framework\Setup\InstallDataInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\InventoryApi\Api\Data\StockInterfaceFactory;
+use Magento\InventoryApi\Api\Data\StockInterface;
+use Magento\InventoryApi\Api\StockRepositoryInterface;
+use Magento\Framework\Api\DataObjectHelper;
+
+/**
+ * Class InstallData
+ */
+class InstallData implements InstallDataInterface
+{
+    /**
+     * @var StockRepositoryInterface
+     */
+    private $stockRepository;
+
+    /**
+     * @var StockInterfaceFactory
+     */
+    private $stockFactory;
+
+    /**
+     * @var DataObjectHelper
+     */
+    private $dataObjectHelper;
+
+    /**
+     * @param StockRepositoryInterface $stockRepository
+     * @param StockInterfaceFactory $stockFactory
+     * @param DataObjectHelper $dataObjectHelper
+     */
+    public function __construct(
+        StockRepositoryInterface $stockRepository,
+        StockInterfaceFactory $stockFactory,
+        DataObjectHelper $dataObjectHelper
+    ) {
+        $this->stockRepository = $stockRepository;
+        $this->stockFactory = $stockFactory;
+        $this->dataObjectHelper = $dataObjectHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $this->addDefaultStock();
+    }
+
+    /**
+     * Add default stock
+     *
+     * @return void
+     */
+    private function addDefaultStock()
+    {
+        $data = [
+            StockInterface::STOCK_ID => 1,
+            StockInterface::NAME => 'Default Stock'
+        ];
+        $source = $this->stockFactory->create();
+        $this->dataObjectHelper->populateWithArray($source, $data, StockInterface::class);
+        $this->stockRepository->save($source);
+    }
+}

--- a/app/code/Magento/InventoryCatalog/Setup/InstallData.php
+++ b/app/code/Magento/InventoryCatalog/Setup/InstallData.php
@@ -51,6 +51,7 @@ class InstallData implements InstallDataInterface
 
     /**
      * {@inheritdoc}
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {

--- a/app/code/Magento/InventoryCatalog/Test/Api/GetDefaultStock.php
+++ b/app/code/Magento/InventoryCatalog/Test/Api/GetDefaultStock.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\InventoryCatalog\Test\Api;
+
+use Magento\InventoryApi\Api\Data\StockInterface;
+use Magento\TestFramework\TestCase\WebapiAbstract;
+use Magento\Framework\Webapi\Rest\Request;
+
+/**
+ * Class GetDefaultStock
+ */
+class GetDefaultStock extends WebapiAbstract
+{
+    /**
+     * Get default stock from WebApi test
+     */
+    public function testGetDefaultSource()
+    {
+        $defaultStockId = 1;
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => '/V1/inventory/stock/' . $defaultStockId,
+                'httpMethod' => Request::HTTP_METHOD_GET,
+            ],
+            'soap' => [
+                'service' => 'inventoryApiStockRepositoryV1',
+                'operation' => 'inventoryApiStockRepositoryV1Get',
+            ],
+        ];
+        if (self::ADAPTER_REST == TESTS_WEB_API_ADAPTER) {
+            $stock = $this->_webApiCall($serviceInfo);
+        } else {
+            $stock = $this->_webApiCall($serviceInfo, ['stockId' => $defaultStockId]);
+        }
+        $this->assertEquals($defaultStockId, $stock[StockInterface::STOCK_ID]);
+    }
+}

--- a/app/code/Magento/InventoryCatalog/Test/Api/GetDefaultStockTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Api/GetDefaultStockTest.php
@@ -11,12 +11,12 @@ use Magento\TestFramework\TestCase\WebapiAbstract;
 use Magento\Framework\Webapi\Rest\Request;
 
 /**
- * Class GetDefaultStock
+ * Class GetDefaultStockTest
  */
-class GetDefaultStock extends WebapiAbstract
+class GetDefaultStockTest extends WebapiAbstract
 {
     /**
-     * Get default stock from WebApi test
+     * Test that default Stock is present after installation
      */
     public function testGetDefaultSource()
     {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#95: Add default Stock in Data Install

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Remove data version from table "setup_module", Magento_InventoryCatalog module
2. Run bin/magento setup:upgrade
3. Default stock should be visible in table "inventory_stock" with id: 1

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
