### PR TITLE
Add linkage between Default Source and Stock

### DIFF
--- a/app/code/Magento/InventoryCatalog/Setup/InstallData.php
+++ b/app/code/Magento/InventoryCatalog/Setup/InstallData.php
@@ -15,6 +15,7 @@ use Magento\InventoryApi\Api\SourceRepositoryInterface;
 use Magento\InventoryApi\Api\Data\StockInterfaceFactory;
 use Magento\InventoryApi\Api\Data\StockInterface;
 use Magento\InventoryApi\Api\StockRepositoryInterface;
+use Magento\InventoryApi\Api\AssignSourcesToStockInterface;
 use Magento\Framework\Api\DataObjectHelper;
 
 /**
@@ -48,10 +49,16 @@ class InstallData implements InstallDataInterface
     private $dataObjectHelper;
 
     /**
+     * @var AssignSourcesToStockInterface
+     */
+    private $assignSourcesToStock;
+
+    /**
      * @param SourceRepositoryInterface $sourceRepository
      * @param SourceInterfaceFactory $sourceFactory
      * @param StockRepositoryInterface $stockRepository
      * @param StockInterfaceFactory $stockFactory
+     * @param AssignSourcesToStockInterface $assignSourcesToStock
      * @param DataObjectHelper $dataObjectHelper
      */
     public function __construct(
@@ -59,12 +66,14 @@ class InstallData implements InstallDataInterface
         SourceInterfaceFactory $sourceFactory,
         StockRepositoryInterface $stockRepository,
         StockInterfaceFactory $stockFactory,
+        AssignSourcesToStockInterface $assignSourcesToStock,
         DataObjectHelper $dataObjectHelper
     ) {
         $this->sourceRepository = $sourceRepository;
         $this->sourceFactory = $sourceFactory;
         $this->stockRepository = $stockRepository;
         $this->stockFactory = $stockFactory;
+        $this->assignSourcesToStock = $assignSourcesToStock;
         $this->dataObjectHelper = $dataObjectHelper;
     }
 
@@ -76,6 +85,7 @@ class InstallData implements InstallDataInterface
     {
         $this->addDefaultSource();
         $this->addDefaultStock();
+        $this->assignStockToSource();
     }
 
     /**
@@ -115,5 +125,15 @@ class InstallData implements InstallDataInterface
         $source = $this->stockFactory->create();
         $this->dataObjectHelper->populateWithArray($source, $data, StockInterface::class);
         $this->stockRepository->save($source);
+    }
+
+    /**
+     * Assign default stock to default source
+     *
+     * @return void
+     */
+    private function assignStockToSource()
+    {
+        $this->assignSourcesToStock->execute([1], 1);
     }
 }

--- a/app/code/Magento/InventoryCatalog/Test/Api/GetDefaultStockToSourceLinkTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Api/GetDefaultStockToSourceLinkTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\InventoryCatalog\Test\Api;
+
+use Magento\InventoryApi\Api\Data\SourceInterface;
+use Magento\TestFramework\TestCase\WebapiAbstract;
+use Magento\Framework\Webapi\Rest\Request;
+
+/**
+ * Class GetDefaultStockToSourceLinkTest
+ */
+class GetDefaultStockToSourceLinkTest extends WebapiAbstract
+{
+    /**
+     * Test that default Stock is present after installation
+     */
+    public function testGetDefaultStockToSourceLink()
+    {
+        $defaultStockId = 1;
+        $defaultSourceId = 1;
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => '/V1/inventory/stock/get-assigned-sources/' . $defaultStockId,
+                'httpMethod' => Request::HTTP_METHOD_GET,
+            ],
+            'soap' => [
+                'service' => 'inventoryApiGetAssignedSourcesForStockV1',
+                'operation' => 'inventoryApiStockRepositoryV1Get',
+            ],
+        ];
+        if (self::ADAPTER_REST == TESTS_WEB_API_ADAPTER) {
+            $source = $this->_webApiCall($serviceInfo);
+        } else {
+            $source = $this->_webApiCall($serviceInfo, ['stockId' => $defaultStockId]);
+        }
+        $this->assertEquals([$defaultSourceId], array_column($source, SourceInterface::SOURCE_ID));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#117: Add linkage between Default Source and Stock

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Remove data version from table "setup_module", Magento_InventoryCatalog module
2. Run bin/magento setup:upgrade
3. Default stock should be link to default source in table "inventory_source_stock_link"


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
