### PR TITLE
Fixed a js bug where ui_component labels have the wrong sort order.

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
+++ b/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
@@ -548,6 +548,13 @@ define([
                     });
 
                     this.labels.push(data);
+
+                    /**
+                     * Sort the array after an element was added to fix an bug where
+                     * additional added field labels in ui_components haven't the right
+                     * sort order.
+                     */
+                    this.labels.sort(this._compare);
                 }, this);
             }
         },
@@ -912,6 +919,23 @@ define([
             this.elems(this.elems().sort(function (propOne, propTwo) {
                 return ~~propOne.position - ~~propTwo.position;
             }));
+        },
+
+        /**
+         * Compare two objects by the sortOrder property.
+         * @param {Object} $object1
+         * @param {Object} $object2
+         * @returns {number}
+         * @private
+         */
+        _compare: function ($object1, $object2) {
+            if ($object1.sortOrder > $object2.sortOrder) {
+                return 1;
+            } else if ($object1.sortOrder < $object2.sortOrder) {
+                return -1;
+            }
+
+            return 0;
         },
 
         /**

--- a/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
+++ b/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
@@ -923,9 +923,10 @@ define([
 
         /**
          * Compare two objects by the sortOrder property.
+         *
          * @param {Object} $object1
          * @param {Object} $object2
-         * @returns {number}
+         * @returns {Number}
          * @private
          */
         _compare: function ($object1, $object2) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
If you extend an dynamic-row element in a ui_component and add a sort order attribute with a amount between the others, the Fields are in the correct order but the label is always the last one.

### Manual testing scenarios
1. Extend an dynamic-row in a ui_component with a sort order so your element isn't the last one.
Result: The label are in the correct sort order (your Field Label isn't the last one).

