### PR TITLE
#199 - Assign main website to default stock

### DIFF
--- a/app/code/Magento/Inventory/composer.json
+++ b/app/code/Magento/Inventory/composer.json
@@ -3,12 +3,12 @@
     "description": "N/A",
     "require": {
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
-        "magento/framework": "100.2.*",
+        "magento/framework": "100.3.*",
         "magento/module-inventory-api": "100.0.*",
-        "magento/module-backend": "100.2.*",
-        "magento/module-directory": "100.2.*",
-        "magento/module-shipping": "100.2.*",
-        "magento/module-ui": "100.2.*"
+        "magento/module-backend": "100.3.*",
+        "magento/module-directory": "100.3.*",
+        "magento/module-shipping": "100.3.*",
+        "magento/module-ui": "100.3.*"
     },
     "type": "magento2-module",
     "version": "100.0.0-dev",

--- a/app/code/Magento/InventoryApi/composer.json
+++ b/app/code/Magento/InventoryApi/composer.json
@@ -3,7 +3,7 @@
     "description": "N/A",
     "require": {
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
-        "magento/framework": "100.2.*"
+        "magento/framework": "100.3.*"
     },
     "type": "magento2-module",
     "version": "100.0.0-dev",

--- a/app/code/Magento/InventoryCatalog/composer.json
+++ b/app/code/Magento/InventoryCatalog/composer.json
@@ -3,13 +3,13 @@
     "description": "N/A",
     "require": {
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
-        "magento/framework": "100.2.*",
+        "magento/framework": "100.3.*",
         "magento/module-inventory-api": "100.0.*",
-        "magento/module-backend": "100.2.*",
-        "magento/module-catalog": "100.2.*",
-        "magento/module-directory": "100.2.*",
-        "magento/module-shipping": "100.2.*",
-        "magento/module-ui": "100.2.*"
+        "magento/module-backend": "100.3.*",
+        "magento/module-catalog": "100.3.*",
+        "magento/module-directory": "100.3.*",
+        "magento/module-shipping": "100.3.*",
+        "magento/module-ui": "100.3.*"
     },
     "type": "magento2-module",
     "version": "100.0.0-dev",

--- a/app/code/Magento/InventoryImportExport/composer.json
+++ b/app/code/Magento/InventoryImportExport/composer.json
@@ -3,13 +3,13 @@
     "description": "N/A",
     "require": {
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
-        "magento/framework": "100.2.*",
+        "magento/framework": "100.3.*",
         "magento/module-inventory-api": "100.0.*",
-        "magento/module-backend": "100.2.*",
-        "magento/module-catalog": "100.2.*",
-        "magento/module-directory": "100.2.*",
-        "magento/module-shipping": "100.2.*",
-        "magento/module-ui": "100.2.*"
+        "magento/module-backend": "100.3.*",
+        "magento/module-catalog": "100.3.*",
+        "magento/module-directory": "100.3.*",
+        "magento/module-shipping": "100.3.*",
+        "magento/module-ui": "100.3.*"
     },
     "type": "magento2-module",
     "version": "100.0.0-dev",

--- a/app/code/Magento/InventorySales/Setup/InstallData.php
+++ b/app/code/Magento/InventorySales/Setup/InstallData.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventorySales\Setup;
+
+use Magento\Framework\Setup\InstallDataInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\InventorySales\Setup\Operation\AssignWebsiteToDefaultStock;
+
+/**
+ * Assigns Main website to the Default stock
+ */
+class InstallData implements InstallDataInterface
+{
+    /**
+     * @var AssignWebsiteToDefaultStock
+     */
+    private $assignWebsiteToDefaultStock;
+
+    /**
+     * @param AssignWebsiteToDefaultStock $assignWebsiteToDefaultStock
+     */
+    public function __construct(
+        AssignWebsiteToDefaultStock $assignWebsiteToDefaultStock
+    ) {
+        $this->assignWebsiteToDefaultStock = $assignWebsiteToDefaultStock;
+    }
+
+    /**
+     * {@inheritdoc}
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $this->assignWebsiteToDefaultStock->execute();
+    }
+}

--- a/app/code/Magento/InventorySales/Setup/Operation/AssignWebsiteToDefaultStock.php
+++ b/app/code/Magento/InventorySales/Setup/Operation/AssignWebsiteToDefaultStock.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventorySales\Setup\Operation;
+
+use Magento\InventoryApi\Api\StockRepositoryInterface;
+use Magento\InventoryCatalog\Api\DefaultStockProviderInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Assigns Main website to the Default stock
+ */
+class AssignWebsiteToDefaultStock
+{
+    /**
+     * @var StockRepositoryInterface
+     */
+    private $stockRepository;
+
+    /**
+     * @var DefaultStockProviderInterface
+     */
+    private $defaultStockProvider;
+
+    /**
+     * @var SalesChannelInterfaceFactory
+     */
+    private $salesChannelFactory;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @param StockRepositoryInterface $stockRepository
+     * @param DefaultStockProviderInterface $defaultStockProvider
+     * @param SalesChannelInterfaceFactory $salesChannelFactory
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        StockRepositoryInterface $stockRepository,
+        DefaultStockProviderInterface $defaultStockProvider,
+        SalesChannelInterfaceFactory $salesChannelFactory,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->stockRepository = $stockRepository;
+        $this->defaultStockProvider = $defaultStockProvider;
+        $this->salesChannelFactory = $salesChannelFactory;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @inheritdoc
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @throws \Magento\Framework\Validation\ValidationException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function execute()
+    {
+        $websiteCode = $this->storeManager->getWebsite()->getCode();
+
+        $defaultStockId = $this->defaultStockProvider->getId();
+        $defaultStock = $this->stockRepository->get($defaultStockId);
+
+        $extensionAttributes = $defaultStock->getExtensionAttributes();
+        $salesChannels = $extensionAttributes->getSalesChannels();
+        $salesChannels[] = $this->createSalesChannelByWebsiteCode($websiteCode);
+
+        $extensionAttributes->setSalesChannels($salesChannels);
+        $this->stockRepository->save($defaultStock);
+    }
+
+    /**
+     * Create the sales channel by given website code
+     *
+     * @param string $websiteCode
+     * @return SalesChannelInterface
+     */
+    private function createSalesChannelByWebsiteCode(string $websiteCode): SalesChannelInterface
+    {
+        $salesChannel = $this->salesChannelFactory->create();
+        $salesChannel->setCode($websiteCode);
+        $salesChannel->setType(SalesChannelInterface::TYPE_WEBSITE);
+        return $salesChannel;
+    }
+}

--- a/app/code/Magento/InventorySales/Test/Integration/Website/AssignWebsiteToDefaultStockTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/Website/AssignWebsiteToDefaultStockTest.php
@@ -10,6 +10,7 @@ namespace Magento\InventorySales\Test\Integration\Website;
 use Magento\InventoryApi\Api\StockRepositoryInterface;
 use Magento\InventoryCatalog\Api\DefaultStockProviderInterface;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Website;
 use Magento\Store\Model\WebsiteFactory;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -32,11 +33,37 @@ class AssignWebsiteToDefaultStockTest extends TestCase
      */
     private $defaultStockProvider;
 
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
     protected function setUp()
     {
         $this->websiteFactory = Bootstrap::getObjectManager()->get(WebsiteFactory::class);
         $this->stockRepository = Bootstrap::getObjectManager()->get(StockRepositoryInterface::class);
         $this->defaultStockProvider = Bootstrap::getObjectManager()->get(DefaultStockProviderInterface::class);
+        $this->storeManager = Bootstrap::getObjectManager()->get(StoreManagerInterface::class);
+    }
+
+    /**
+     * Test if Main website is associated to Default stock
+     */
+    public function testIfWebsiteIsAssignedToDefaultStock()
+    {
+        $websiteCode = $this->storeManager->getWebsite()->getCode();
+
+        $defaultStockId = $this->defaultStockProvider->getId();
+        $defaultStock = $this->stockRepository->get($defaultStockId);
+
+        $extensionAttributes = $defaultStock->getExtensionAttributes();
+        $salesChannels = $extensionAttributes->getSalesChannels();
+        self::assertContainsOnlyInstancesOf(SalesChannelInterface::class, $salesChannels);
+        self::assertCount(1, $salesChannels);
+
+        $salesChannel = reset($salesChannels);
+        self::assertEquals($websiteCode, $salesChannel->getCode());
+        self::assertEquals(SalesChannelInterface::TYPE_WEBSITE, $salesChannel->getType());
     }
 
     /**
@@ -59,10 +86,15 @@ class AssignWebsiteToDefaultStockTest extends TestCase
         $extensionAttributes = $defaultStock->getExtensionAttributes();
         $salesChannels = $extensionAttributes->getSalesChannels();
         self::assertContainsOnlyInstancesOf(SalesChannelInterface::class, $salesChannels);
-        self::assertCount(1, $salesChannels);
 
-        $salesChannel = reset($salesChannels);
-        self::assertEquals($website->getCode(), $salesChannel->getCode());
-        self::assertEquals(SalesChannelInterface::TYPE_WEBSITE, $salesChannel->getType());
+        $salesChannelsWhichBelongToCreatedWebsite = array_filter($salesChannels, function($aSalesChannel) use ($websiteCode) {
+            return $aSalesChannel->getCode() === $websiteCode;
+        });
+
+        self::assertCount(1, $salesChannelsWhichBelongToCreatedWebsite);
+
+        $aSalesChannelWhichBelongToCreatedWebsite = reset($salesChannelsWhichBelongToCreatedWebsite);
+        self::assertEquals($website->getCode(), $aSalesChannelWhichBelongToCreatedWebsite->getCode());
+        self::assertEquals(SalesChannelInterface::TYPE_WEBSITE, $aSalesChannelWhichBelongToCreatedWebsite->getType());
     }
 }

--- a/app/code/Magento/InventorySales/Test/Integration/Website/AssignWebsiteToDefaultStockTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/Website/AssignWebsiteToDefaultStockTest.php
@@ -87,14 +87,14 @@ class AssignWebsiteToDefaultStockTest extends TestCase
         $salesChannels = $extensionAttributes->getSalesChannels();
         self::assertContainsOnlyInstancesOf(SalesChannelInterface::class, $salesChannels);
 
-        $salesChannelsWhichBelongToCreatedWebsite = array_filter($salesChannels, function($aSalesChannel) use ($websiteCode) {
+        $salesChannelsOfCreatedWebsite = array_filter($salesChannels, function ($aSalesChannel) use ($websiteCode) {
             return $aSalesChannel->getCode() === $websiteCode;
         });
 
-        self::assertCount(1, $salesChannelsWhichBelongToCreatedWebsite);
+        self::assertCount(1, $salesChannelsOfCreatedWebsite);
 
-        $aSalesChannelWhichBelongToCreatedWebsite = reset($salesChannelsWhichBelongToCreatedWebsite);
-        self::assertEquals($website->getCode(), $aSalesChannelWhichBelongToCreatedWebsite->getCode());
-        self::assertEquals(SalesChannelInterface::TYPE_WEBSITE, $aSalesChannelWhichBelongToCreatedWebsite->getType());
+        $aSalesChannelOfCreatedWebsite = reset($salesChannelsOfCreatedWebsite);
+        self::assertEquals($website->getCode(), $aSalesChannelOfCreatedWebsite->getCode());
+        self::assertEquals(SalesChannelInterface::TYPE_WEBSITE, $aSalesChannelOfCreatedWebsite->getType());
     }
 }

--- a/app/code/Magento/InventorySales/composer.json
+++ b/app/code/Magento/InventorySales/composer.json
@@ -3,9 +3,10 @@
     "description": "N/A",
     "require": {
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
-        "magento/framework": "100.2.*",
-        "magento/module-ui": "100.2.*",
-        "magento/module-inventory-sales-api": "100.0.*"
+        "magento/framework": "100.3.*",
+        "magento/module-ui": "100.3.*",
+        "magento/module-inventory-sales-api": "100.0.*",
+        "magento/module-store": "100.3.*"
     },
     "type": "magento2-module",
     "version": "100.0.0-dev",

--- a/app/code/Magento/InventorySalesApi/composer.json
+++ b/app/code/Magento/InventorySalesApi/composer.json
@@ -3,7 +3,7 @@
     "description": "N/A",
     "require": {
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
-        "magento/framework": "100.2.*"
+        "magento/framework": "100.3.*"
     },
     "type": "magento2-module",
     "version": "100.0.0-dev",


### PR DESCRIPTION
Implemented assign of Main Website to Default stock

### Description
We have already plugin which serves for creation of sales channel between created website and default stock (\Magento\InventorySales\Observer\Website\AssignWebsiteToDefaultStock).

However, because core of Magento doesn't use API for website creation, we're not able to plug in there and associate it with Default Stock. 

In order to fix the issue, we have to create data install script which adds missing relation between Main website and Default stock.
(reference: https://github.com/magento-engcom/msi/blob/develop/app/code/Magento/Store/Setup/InstallSchema.php#L258)

### Fixed Issues (if relevant)
magento-engcom/msi#199: Assign main website to default stock

### Manual testing scenarios
1. Run fresh install of Magento within develop branch
2. Check if inventory_stock_sales_channel table contains relation between Main Website (base) and Default stock (1).

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
