### PR TITLE
Adapt current logic of Product Qty Update on the Product Form in admin panel to save data in default Source #169

### DIFF
--- a/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
@@ -27,19 +27,19 @@ class ProcessSourceItemsObserver implements ObserverInterface
     /**
      * @var SourceItemsProcessor
      */
-    protected $sourceItemsProcessor;
+    private $sourceItemsProcessor;
     /**
      * @var DefaultSourceProviderInterface
      */
-    protected $defaultSourceProvider;
+    private $defaultSourceProvider;
     /**
      * @var SourceItemInterfaceFactory
      */
-    protected $sourceItemInterfaceFactory;
+    private $sourceItemInterfaceFactory;
     /**
      * @var SourceItemsSaveInterface
      */
-    protected $sourceItemsSave;
+    private $sourceItemsSave;
 
     /**
      * @param SourceItemsProcessor $sourceItemsProcessor
@@ -87,22 +87,25 @@ class ProcessSourceItemsObserver implements ObserverInterface
 
     /**
      * @param $controller Save
+     * @return void
      */
-    public function updateDefaultSourceQty($controller)
+    private function updateDefaultSourceQty($controller)
     {
-        /** @var  $sourceItem SourceItemInterface */
-        $sourceItem = $this->sourceItemInterfaceFactory->create();
         $productParams = $controller->getRequest()->getParam('product');
 
         $sku = $productParams['sku'];
-        $sourceItem->setSku($sku);
         $qtyAndStockStatus = $productParams['quantity_and_stock_status'];
         $qty = $qtyAndStockStatus['qty'];
-        $sourceItem->setQuantity($qty);
         $stockStatus = $qtyAndStockStatus['is_in_stock'];
-        $sourceItem->setStatus($stockStatus);
         $defaultSourceId = $this->defaultSourceProvider->getId();
-        $sourceItem->setSourceId($defaultSourceId);
+
+        /** @var  $sourceItem SourceItemInterface */
+        $sourceItem = $this->sourceItemInterfaceFactory->create([
+            SourceItemInterface::SKU => $sku,
+            SourceItemInterface::QUANTITY => $qty,
+            SourceItemInterface::STATUS => $stockStatus,
+            SourceItemInterface::SOURCE_ID => $defaultSourceId
+        ]);
 
         $this->sourceItemsSave->execute([$sourceItem]);
     }

--- a/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
@@ -83,7 +83,6 @@ class ProcessSourceItemsObserver implements ObserverInterface
         );
 
         $productParams = $controller->getRequest()->getParam('product');
-
         $this->updateDefaultSourceQty($productParams);
     }
 
@@ -106,7 +105,8 @@ class ProcessSourceItemsObserver implements ObserverInterface
                 SourceItemInterface::QUANTITY => $qty,
                 SourceItemInterface::STATUS => $stockStatus,
                 SourceItemInterface::SOURCE_ID => $defaultSourceId
-            ]]);
+            ]
+        ]);
 
         $this->sourceItemsSave->execute([$sourceItem]);
     }

--- a/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
@@ -3,12 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\InventoryCatalog\Observer;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Controller\Adminhtml\Product\Save;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer as EventObserver;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\SourceItemsSaveInterface;
+use Magento\InventoryCatalog\Api\DefaultSourceProviderInterface;
+use Magento\InventoryApi\Api\Data\SourceItemInterfaceFactory;
 
 /**
  * Save source product relations during product persistence via controller
@@ -21,14 +27,36 @@ class ProcessSourceItemsObserver implements ObserverInterface
     /**
      * @var SourceItemsProcessor
      */
-    private $sourceItemsProcessor;
+    protected $sourceItemsProcessor;
+    /**
+     * @var DefaultSourceProviderInterface
+     */
+    protected $defaultSourceProvider;
+    /**
+     * @var SourceItemInterfaceFactory
+     */
+    protected $sourceItemInterfaceFactory;
+    /**
+     * @var SourceItemsSaveInterface
+     */
+    protected $sourceItemsSave;
 
     /**
      * @param SourceItemsProcessor $sourceItemsProcessor
+     * @param DefaultSourceProviderInterface $defaultSourceProvider
+     * @param SourceItemInterfaceFactory $sourceItemInterfaceFactory
+     * @param SourceItemsSaveInterface $sourceItemsSave
      */
-    public function __construct(SourceItemsProcessor $sourceItemsProcessor)
-    {
+    public function __construct(
+        SourceItemsProcessor $sourceItemsProcessor,
+        DefaultSourceProviderInterface $defaultSourceProvider,
+        SourceItemInterfaceFactory $sourceItemInterfaceFactory,
+        SourceItemsSaveInterface $sourceItemsSave
+    ) {
         $this->sourceItemsProcessor = $sourceItemsProcessor;
+        $this->defaultSourceProvider = $defaultSourceProvider;
+        $this->sourceItemInterfaceFactory = $sourceItemInterfaceFactory;
+        $this->sourceItemsSave = $sourceItemsSave;
     }
 
     /**
@@ -53,5 +81,29 @@ class ProcessSourceItemsObserver implements ObserverInterface
             $product->getSku(),
             $assignedSources
         );
+
+        $this->updateDefaultSourceQty($controller);
+    }
+
+    /**
+     * @param $controller Save
+     */
+    public function updateDefaultSourceQty($controller)
+    {
+        /** @var  $sourceItem SourceItemInterface */
+        $sourceItem = $this->sourceItemInterfaceFactory->create();
+        $productParams = $controller->getRequest()->getParam('product');
+
+        $sku = $productParams['sku'];
+        $sourceItem->setSku($sku);
+        $qtyAndStockStatus = $productParams['quantity_and_stock_status'];
+        $qty = $qtyAndStockStatus['qty'];
+        $sourceItem->setQuantity($qty);
+        $stockStatus = $qtyAndStockStatus['is_in_stock'];
+        $sourceItem->setStatus($stockStatus);
+        $defaultSourceId = $this->defaultSourceProvider->getId();
+        $sourceItem->setSourceId($defaultSourceId);
+
+        $this->sourceItemsSave->execute([$sourceItem]);
     }
 }

--- a/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
@@ -82,17 +82,17 @@ class ProcessSourceItemsObserver implements ObserverInterface
             $assignedSources
         );
 
-        $this->updateDefaultSourceQty($controller);
+        $productParams = $controller->getRequest()->getParam('product');
+
+        $this->updateDefaultSourceQty($productParams);
     }
 
     /**
-     * @param Save $controller
+     * @param array $productParams
      * @return void
      */
-    private function updateDefaultSourceQty($controller)
+    private function updateDefaultSourceQty($productParams)
     {
-        $productParams = $controller->getRequest()->getParam('product');
-
         $sku = $productParams['sku'];
         $qtyAndStockStatus = $productParams['quantity_and_stock_status'];
         $qty = $qtyAndStockStatus['qty'];

--- a/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
@@ -91,7 +91,7 @@ class ProcessSourceItemsObserver implements ObserverInterface
      * @param array $productParams
      * @return void
      */
-    private function updateDefaultSourceQty($productParams)
+    private function updateDefaultSourceQty(array $productParams)
     {
         $sku = $productParams['sku'];
         $qtyAndStockStatus = $productParams['quantity_and_stock_status'];

--- a/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
@@ -86,7 +86,7 @@ class ProcessSourceItemsObserver implements ObserverInterface
     }
 
     /**
-     * @param $controller Save
+     * @param Save $controller
      * @return void
      */
     private function updateDefaultSourceQty($controller)

--- a/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
@@ -101,11 +101,12 @@ class ProcessSourceItemsObserver implements ObserverInterface
 
         /** @var  $sourceItem SourceItemInterface */
         $sourceItem = $this->sourceItemInterfaceFactory->create([
-            SourceItemInterface::SKU => $sku,
-            SourceItemInterface::QUANTITY => $qty,
-            SourceItemInterface::STATUS => $stockStatus,
-            SourceItemInterface::SOURCE_ID => $defaultSourceId
-        ]);
+            'data' => [
+                SourceItemInterface::SKU => $sku,
+                SourceItemInterface::QUANTITY => $qty,
+                SourceItemInterface::STATUS => $stockStatus,
+                SourceItemInterface::SOURCE_ID => $defaultSourceId
+            ]]);
 
         $this->sourceItemsSave->execute([$sourceItem]);
     }


### PR DESCRIPTION
Adapt current logic of Product Qty Update on the Product Form in admin panel to save data in default Source.

Extend/Pluginize CatalogInventory Save stock item logic to update Default Source Qty in MSI

#169 