### PR TITLE
Fix issue #311 - Unable to unassign a source from stock

### DIFF
--- a/app/code/Magento/Inventory/Controller/Adminhtml/Stock/StockSourceLinkProcessor.php
+++ b/app/code/Magento/Inventory/Controller/Adminhtml/Stock/StockSourceLinkProcessor.php
@@ -94,7 +94,7 @@ class StockSourceLinkProcessor
         }
         if ($sourceIdsForDelete) {
             foreach ($sourceIdsForDelete as $sourceIdForDelete) {
-                $this->unassignSourceFromStock->execute($sourceIdForDelete, $stockId);
+                $this->unassignSourceFromStock->execute((int) $sourceIdForDelete, $stockId);
             }
         }
     }


### PR DESCRIPTION
### Description
A critical PHP error is raised in adminhtml while trying to unassign any source from any stock.

### Fixed Issues (if relevant)
FIX for issue #311 

### Manual testing scenarios
1. Open any stock page
2. Unassign a source from an existing stock
3. No errors should be raised

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
