### PR TITLE
Fix issue msi#316: Extend stock indexer

### DIFF
--- a/app/code/Magento/Inventory/Indexer/SelectBuilder.php
+++ b/app/code/Magento/Inventory/Indexer/SelectBuilder.php
@@ -65,7 +65,8 @@ class SelectBuilder
                 ['source_item' => $sourceItemTable],
                 [
                     SourceItemInterface::SKU,
-                    SourceItemInterface::QUANTITY => 'SUM(' . SourceItemInterface::QUANTITY . ')',
+                    SourceItemInterface::QUANTITY => 'SUM(IF(source_item.' . SourceItemInterface::STATUS . ' = '
+                        . SourceItemInterface::STATUS_OUT_OF_STOCK . ', 0, ' . SourceItemInterface::QUANTITY . '))',
                 ]
             )
             ->joinLeft(
@@ -73,7 +74,6 @@ class SelectBuilder
                 'source_item.' . SourceItemInterface::SOURCE_ID . ' = stock_source_link.' . StockSourceLink::SOURCE_ID,
                 []
             )
-            ->where('source_item.' . SourceItemInterface::STATUS . ' = ?', SourceItemInterface::STATUS_IN_STOCK)
             ->where('stock_source_link.' . StockSourceLink::STOCK_ID . ' = ?', $stockId)
             ->where('stock_source_link.' . StockSourceLink::SOURCE_ID . ' IN (?)', $sourceIds)
             ->group([SourceItemInterface::SKU]);

--- a/app/code/Magento/Inventory/Test/Integration/Indexer/SourceItemIndexerTest.php
+++ b/app/code/Magento/Inventory/Test/Integration/Indexer/SourceItemIndexerTest.php
@@ -113,4 +113,18 @@ class SourceItemIndexerTest extends TestCase
         self::assertEquals(5, $this->getProductQuantityInStock->execute('SKU-2', 20));
         self::assertEquals(5, $this->getProductQuantityInStock->execute('SKU-2', 30));
     }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_link.php
+     */
+    public function testStockItemsHasZeroQuantityIfSourceItemsAreOutOfStock()
+    {
+        $this->indexer->reindexAll();
+
+        self::assertEquals(0, $this->getProductQuantityInStock->execute('SKU-3', 10));
+    }
 }

--- a/app/code/Magento/Inventory/Test/Integration/Indexer/StockIndexerTest.php
+++ b/app/code/Magento/Inventory/Test/Integration/Indexer/StockIndexerTest.php
@@ -99,4 +99,18 @@ class StockIndexerTest extends TestCase
         self::assertEquals(5, $this->getProductQuantityInStock->execute('SKU-2', 20));
         self::assertEquals(5, $this->getProductQuantityInStock->execute('SKU-2', 30));
     }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_link.php
+     */
+    public function testReindexZeroQuantityIfSourceItemIsOutOfStock()
+    {
+        $this->indexer->reindexAll();
+
+        self::assertEquals(0, $this->getProductQuantityInStock->execute('SKU-3', 10));
+    }
 }

--- a/app/code/Magento/Inventory/Test/Integration/Indexer/StockIndexerTest.php
+++ b/app/code/Magento/Inventory/Test/Integration/Indexer/StockIndexerTest.php
@@ -99,18 +99,4 @@ class StockIndexerTest extends TestCase
         self::assertEquals(5, $this->getProductQuantityInStock->execute('SKU-2', 20));
         self::assertEquals(5, $this->getProductQuantityInStock->execute('SKU-2', 30));
     }
-
-    /**
-     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
-     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
-     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
-     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items.php
-     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_link.php
-     */
-    public function testStockItemsHasZeroQuantityIfSourceItemsAreOutOfStock()
-    {
-        $this->indexer->reindexAll();
-
-        self::assertEquals(0, $this->getProductQuantityInStock->execute('SKU-3', 10));
-    }
 }

--- a/app/code/Magento/Inventory/Test/Integration/Indexer/StockIndexerTest.php
+++ b/app/code/Magento/Inventory/Test/Integration/Indexer/StockIndexerTest.php
@@ -107,7 +107,7 @@ class StockIndexerTest extends TestCase
      * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items.php
      * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_link.php
      */
-    public function testReindexZeroQuantityIfSourceItemIsOutOfStock()
+    public function testStockItemsHasZeroQuantityIfSourceItemsAreOutOfStock()
     {
         $this->indexer->reindexAll();
 

--- a/app/code/Magento/InventoryApi/Test/_files/source_items.php
+++ b/app/code/Magento/InventoryApi/Test/_files/source_items.php
@@ -25,6 +25,8 @@ $sourceItemsSave = Bootstrap::getObjectManager()->get(SourceItemsSaveInterface::
  * SKU-1 - EU-source-4(id:40) - 10qty (disabled source)
  *
  * SKU-2 - US-source-1(id:30) - 5qty
+ *
+ * SKU-3 - EU-source-2(id:20) - 6qty (out of stock)
  */
 $sourcesItemsData = [
     [

--- a/app/code/Magento/InventoryApi/Test/_files/source_items.php
+++ b/app/code/Magento/InventoryApi/Test/_files/source_items.php
@@ -57,6 +57,12 @@ $sourcesItemsData = [
         SourceItemInterface::QUANTITY => 5,
         SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
     ],
+    [
+        SourceItemInterface::SOURCE_ID => 20, // EU-source-2
+        SourceItemInterface::SKU => 'SKU-3',
+        SourceItemInterface::QUANTITY => 6,
+        SourceItemInterface::STATUS => SourceItemInterface::STATUS_OUT_OF_STOCK,
+    ],
 ];
 
 $sourceItems = [];


### PR DESCRIPTION
Extends stock indexer in order to create entries with amount 0 for source_items which are out-of-stock.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#316: Extend Indexer to hold entities with quantity 0.0000 in index tables

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Set on particular SKU out of stock in all sources
2. Run reindexation
3. SKU is still present in stock index table with amount 0

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
