### PR TITLE
 #261 - Added column to product stock alert grid with website + stock…

### DIFF
--- a/app/code/Magento/ProductAlert/Block/Adminhtml/Catalog/Product/Edit/Tab/Alerts/Renderer/Stock.php
+++ b/app/code/Magento/ProductAlert/Block/Adminhtml/Catalog/Product/Edit/Tab/Alerts/Renderer/Stock.php
@@ -7,7 +7,7 @@ use Magento\Framework\DataObject;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Backend\Block\Context;
-use Magento\InventorySales\Model\StockResolver;
+use Magento\InventorySalesApi\Api\StockResolverInterface;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
 use Magento\Store\Api\Data\WebsiteInterface;
 use Magento\InventoryApi\Api\Data\StockInterface;
@@ -20,7 +20,7 @@ class Stock extends AbstractRenderer
     private $_storeManager;
 
     /**
-     * @var StockResolver
+     * @var StockResolverInterface
      */
     private $stockResolver;
 
@@ -32,14 +32,14 @@ class Stock extends AbstractRenderer
     /**
      * @param Context $context
      * @param StoreManagerInterface $storeManager
-     * @param StockResolver $stockResolver
+     * @param StockResolverInterface $stockResolver
      * @param ManagerInterface $messageManager
      * @param array $data
      */
     public function __construct(
         Context $context,
         StoreManagerInterface $storeManager,
-        StockResolver $stockResolver,
+        StockResolverInterface $stockResolver,
         ManagerInterface $messageManager,
         array $data = []
     )

--- a/app/code/Magento/ProductAlert/Block/Adminhtml/Catalog/Product/Edit/Tab/Alerts/Renderer/Stock.php
+++ b/app/code/Magento/ProductAlert/Block/Adminhtml/Catalog/Product/Edit/Tab/Alerts/Renderer/Stock.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Magento\ProductAlert\Block\Adminhtml\Catalog\Product\Edit\Tab\Alerts\Renderer;
+
+use Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRenderer;
+use Magento\Framework\DataObject;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Backend\Block\Context;
+use Magento\InventorySales\Model\StockResolver;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+
+class Stock extends AbstractRenderer
+{
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $_storeManager;
+
+    /**
+     * @var StockResolver
+     */
+    protected $_stockResolver;
+
+    /**
+     * @var ManagerInterface
+     */
+    protected $_messageManager;
+
+    /**
+     * Stock constructor.
+     * @param Context $context
+     * @param StoreManagerInterface $storeManager
+     * @param StockResolver $stockResolver
+     * @param ManagerInterface $messageManager
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        StoreManagerInterface $storeManager,
+        StockResolver $stockResolver,
+        ManagerInterface $messageManager,
+        array $data = []
+    )
+    {
+        parent::__construct($context, $data);
+        $this->_storeManager = $storeManager;
+        $this->_stockResolver = $stockResolver;
+        $this->_messageManager = $messageManager;
+    }
+
+    /**
+     * Handles Stock column
+     *
+     * @param DataObject $row
+     * @return string
+     */
+    public function render(DataObject $row)
+    {
+        try {
+            $value = $this->getColumnData($row);
+            return $value;
+        } catch (\Exception $exception) {
+            $this->_messageManager->addErrorMessage($exception);
+        }
+        return parent::render($row);
+    }
+
+    /**
+     * @param $row
+     * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getColumnData($row)
+    {
+        /** @var \Magento\Store\Api\Data\WebsiteInterface $website */
+        $website = $this->_storeManager->getWebsite($row->getWebsiteId());
+
+        if (!$website) {
+            return '';
+        }
+        $websiteStr = $this->getWebsiteStr($website);
+        $stockName = $this->getStockStr($website);
+        $resultStr = $websiteStr . '<br/>' . $stockName;
+        return $resultStr;
+    }
+
+    /**
+     * @param $website \Magento\Store\Api\Data\WebsiteInterface
+     * @return string
+     */
+    public function getWebsiteStr($website)
+    {
+        if (!$website) {
+            return '';
+        }
+        return __('Website ID: %1', $website->getId()) . '<br/>';
+    }
+
+    /**
+     * @param $website \Magento\Store\Api\Data\WebsiteInterface
+     * @return string
+     */
+    public function getStockStr($website)
+    {
+        if (!$website) {
+            return '';
+        }
+        try {
+            $salesChannel = $this->getSalesChannelByCode($website->getCode());
+        } catch (\Exception $e) {
+            $this->_messageManager->addErrorMessage($e->getMessage());
+            return '';
+        }
+        return __('Stock: %1', $salesChannel->getName());
+    }
+
+    /**
+     * @param $websiteCode
+     * @return \Magento\InventoryApi\Api\Data\StockInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function getSalesChannelByCode($websiteCode)
+    {
+        $stockResolver = $this->_stockResolver;
+        return $stockResolver->get(SalesChannelInterface::TYPE_WEBSITE, $websiteCode);
+    }
+
+}

--- a/app/code/Magento/ProductAlert/Block/Adminhtml/Catalog/Product/Edit/Tab/Alerts/Stock.php
+++ b/app/code/Magento/ProductAlert/Block/Adminhtml/Catalog/Product/Edit/Tab/Alerts/Stock.php
@@ -3,6 +3,7 @@
 namespace Magento\ProductAlert\Block\Adminhtml\Catalog\Product\Edit\Tab\Alerts;
 
 use Magento\Backend\Block\Widget\Grid\Extended;
+use Magento\ProductAlert\Block\Adminhtml\Catalog\Product\Edit\Tab\Alerts\Renderer\Stock as StockRenderer;
 
 class Stock extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Alerts\Stock
 {
@@ -32,7 +33,7 @@ class Stock extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Alerts\Sto
             [
                 'header' => __('Stock'),
                 'index' => 'stock_data',
-                'renderer' => \Magento\ProductAlert\Block\Adminhtml\Catalog\Product\Edit\Tab\Alerts\Renderer\Stock::class
+                'renderer' => StockRenderer::class
             ]
         );
 

--- a/app/code/Magento/ProductAlert/Block/Adminhtml/Catalog/Product/Edit/Tab/Alerts/Stock.php
+++ b/app/code/Magento/ProductAlert/Block/Adminhtml/Catalog/Product/Edit/Tab/Alerts/Stock.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Magento\ProductAlert\Block\Adminhtml\Catalog\Product\Edit\Tab\Alerts;
+
+use Magento\Backend\Block\Widget\Grid\Extended;
+
+class Stock extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Alerts\Stock
+{
+    /**
+     * @return $this
+     * @throws \Exception
+     */
+    protected function _prepareColumns()
+    {
+        $this->addColumn('firstname', ['header' => __('First Name'), 'index' => 'firstname']);
+
+        $this->addColumn('lastname', ['header' => __('Last Name'), 'index' => 'lastname']);
+
+        $this->addColumn('email', ['header' => __('Email'), 'index' => 'email']);
+
+        $this->addColumn('add_date', ['header' => __('Subscribe Date'), 'index' => 'add_date', 'type' => 'date']);
+
+        $this->addColumn(
+            'send_date',
+            ['header' => __('Last Notified'), 'index' => 'send_date', 'type' => 'date']
+        );
+
+        $this->addColumn('send_count', ['header' => __('Send Count'), 'index' => 'send_count']);
+
+        $this->addColumn(
+            'stock',
+            [
+                'header' => __('Stock'),
+                'index' => 'stock_data',
+                'renderer' => \Magento\ProductAlert\Block\Adminhtml\Catalog\Product\Edit\Tab\Alerts\Renderer\Stock::class
+            ]
+        );
+
+        return Extended::_prepareColumns();
+    }
+}

--- a/app/code/Magento/ProductAlert/Test/Unit/Block/Adminhtml/Catalog/Product/Edit/Tab/Alerts/Renderer/StockTest.php
+++ b/app/code/Magento/ProductAlert/Test/Unit/Block/Adminhtml/Catalog/Product/Edit/Tab/Alerts/Renderer/StockTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Magento\ProductAlert\Test\Unit\Block\Adminhtml\Catalog\Product\Edit\Tab\Alerts\Renderer;
+
+use Magento\Inventory\Model\Stock;
+use Magento\InventorySales\Model\StockResolver;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventoryApi\Api\Data\StockInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\Website;
+
+class StockTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject | StoreManagerInterface
+     */
+    protected $storeManagerMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject | Website
+     */
+    protected $websiteMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject | StockResolver
+     */
+    protected $stockResolverMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject | Stock
+     */
+    protected $stockMock;
+
+    public function setUp()
+    {
+        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
+
+        $this->stockResolverMock = $this->getMockBuilder(StockResolver::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMock();
+    }
+
+    /**
+     * @param $stockName string
+     * @dataProvider  stockNameProvider
+     */
+    public function testGetColumnHtml($stockName)
+    {
+        $websiteMock = $this->createPartialMock(Website::class, ['getName']);
+        $websiteMock->expects($this->once())->method('getName')->willReturn($stockName);
+
+        $this->assertNotEmpty($websiteMock->getName());
+    }
+
+    /**
+     * @param $stockName
+     * @dataProvider stockNameProvider
+     */
+    public function testGetStockName($stockName)
+    {
+        $stockMock = $this->createPartialMock(Stock::class, ['getName']);
+
+        $stockMock->expects($this->once())
+            ->method('getName')
+            ->willReturn($stockName);
+
+        $this->assertNotEmpty($stockMock->getName());
+    }
+
+    /**
+     * @param $websiteCode
+     * @dataProvider websiteDataProvider
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function testGetStockByCode($websiteCode)
+    {
+        $this->assertInstanceOf(
+            StockInterface::class,
+            $this->stockResolverMock->get(
+                SalesChannelInterface::TYPE_WEBSITE,
+                $websiteCode
+            )
+        );
+    }
+
+    public function websiteDataProvider()
+    {
+        return [
+            ['base']
+        ];
+    }
+
+    public function stockNameProvider()
+    {
+        return [
+            ['Stock Name']
+        ];
+    }
+}

--- a/app/code/Magento/ProductAlert/etc/adminhtml/di.xml
+++ b/app/code/Magento/ProductAlert/etc/adminhtml/di.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Alerts\Stock"
+                type="Magento\ProductAlert\Block\Adminhtml\Catalog\Product\Edit\Tab\Alerts\Stock" />
+</config>


### PR DESCRIPTION
… data

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#261: Need to support Product Alerts functionality with MSI
2. Added column to product stock alert grid with website + stock data

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Open Admin area and go to a product
2. Set qty to 0 and go to frontend to set 'Notify me if it back in Stock' on the product page.
3. Login as some customer and click on 'Notify me if it back in Stock' link.
4. Go again to admin area on the page of this product and you will the data about the customer (where you add this product - Site name and Stock name for this website).

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
