### PR TITLE
MSI#320: fixed sort by "Sales Channels" in the backend

### DIFF
--- a/app/code/Magento/InventorySales/view/adminhtml/ui_component/inventory_stock_listing.xml
+++ b/app/code/Magento/InventorySales/view/adminhtml/ui_component/inventory_stock_listing.xml
@@ -13,6 +13,7 @@
                 sortOrder="40">
             <settings>
                 <label translate="true">Sales Channels</label>
+                <sortable>false</sortable>
             </settings>
         </column>
     </columns>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Fixed so sort by "Sales Channel" now works in Manage Stock grid.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
I added a join to store_website + order by name

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#320: Error of sorting by Sales Channels column in Manage Stock grid


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
See linked issue

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
