### PR TITLE
MSI: 427: Add new modules related to MSI to 'strict_type' whitelist

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/whitelist/strict_type.txt
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/whitelist/strict_type.txt
@@ -2,6 +2,11 @@
 app/code/Magento/Inventory
 app/code/Magento/InventoryApi
 app/code/Magento/InventoryCatalog
+app/code/Magento/InventoryCatalogSearch
+app/code/Magento/InventoryConfiguration
+app/code/Magento/InventoryConfigurationApi
 app/code/Magento/InventoryImportExport
+app/code/Magento/InventoryIndexer
 app/code/Magento/InventorySales
 app/code/Magento/InventorySalesApi
+app/code/Magento/InventoryShipping


### PR DESCRIPTION
Issue: https://github.com/magento-engcom/msi/issues/427