### PR TITLE
468 : fix ui component initialization

### DIFF
--- a/app/code/Magento/Inventory/view/adminhtml/ui_component/inventory_stock_form.xml
+++ b/app/code/Magento/Inventory/view/adminhtml/ui_component/inventory_stock_form.xml
@@ -112,6 +112,7 @@
                 <label translate="true">Assigned Sources</label>
                 <defaultRecord>false</defaultRecord>
                 <addButton>false</addButton>
+                <deleteProperty>true</deleteProperty>
                 <recordTemplate>record</recordTemplate>
                 <identificationProperty>source_code</identificationProperty>
                 <links>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
changed xml initialization of UI component for admin form for Stock 

### Fixed Issues (if relevant)
https://github.com/magento-engcom/msi/issues/468

### Manual testing scenarios
1. Create Stock in admin panel
2. Create 2 Sources in admin panel
3. Add Sources to Stock
4. Go to Stock Edit Form and Remove Sources from it

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
