### PR TITLE
Disable existing source code editing

### DIFF
--- a/app/code/Magento/Inventory/Ui/DataProvider/SourceDataProvider.php
+++ b/app/code/Magento/Inventory/Ui/DataProvider/SourceDataProvider.php
@@ -86,6 +86,7 @@ class SourceDataProvider extends DataProvider
                 $sourceCode = $data['items'][0][SourceInterface::SOURCE_CODE];
                 $sourceGeneralData = $data['items'][0];
                 $sourceGeneralData['carrier_codes'] =  $this->getAssignedCarrierCodes($sourceCode);
+                $sourceGeneralData['disable_source_code'] = !empty($sourceGeneralData['source_code']);
                 $dataForSingle[$sourceCode] = [
                     'general' => $sourceGeneralData,
                 ];

--- a/app/code/Magento/Inventory/view/adminhtml/ui_component/inventory_source_form.xml
+++ b/app/code/Magento/Inventory/view/adminhtml/ui_component/inventory_source_form.xml
@@ -50,16 +50,6 @@
             <opened>true</opened>
             <dataScope>general</dataScope>
         </settings>
-        <field name="disable_source_code" formElement="hidden">
-            <argument name="data" xsi:type="array">
-                <item name="config" xsi:type="array">
-                    <item name="default" xsi:type="boolean">false</item>
-                </item>
-            </argument>
-            <settings>
-                <dataType>boolean</dataType>
-            </settings>
-        </field>
         <field name="source_code" formElement="input" sortOrder="20">
             <settings>
                 <validation>
@@ -68,7 +58,7 @@
                 <dataType>text</dataType>
                 <label translate="true">Code</label>
                 <imports>
-                    <link name="disabled">${ $.provider }:${ $.parentScope }.disable_source_code</link>
+                    <link name="disabled">${ $.provider }:data.general.disable_source_code</link>
                 </imports>
             </settings>
         </field>

--- a/app/code/Magento/Inventory/view/adminhtml/ui_component/inventory_source_form.xml
+++ b/app/code/Magento/Inventory/view/adminhtml/ui_component/inventory_source_form.xml
@@ -50,6 +50,16 @@
             <opened>true</opened>
             <dataScope>general</dataScope>
         </settings>
+        <field name="disable_source_code" formElement="hidden">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="default" xsi:type="boolean">false</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>boolean</dataType>
+            </settings>
+        </field>
         <field name="source_code" formElement="input" sortOrder="20">
             <settings>
                 <validation>
@@ -57,6 +67,9 @@
                 </validation>
                 <dataType>text</dataType>
                 <label translate="true">Code</label>
+                <imports>
+                    <link name="disabled">${ $.provider }:${ $.parentScope }.disable_source_code</link>
+                </imports>
             </settings>
         </field>
         <field name="name" formElement="input" sortOrder="20">

--- a/app/code/Magento/Inventory/view/adminhtml/ui_component/inventory_source_listing.xml
+++ b/app/code/Magento/Inventory/view/adminhtml/ui_component/inventory_source_listing.xml
@@ -93,7 +93,6 @@
                 <filter>text</filter>
                 <label translate="true">Code</label>
                 <editor>
-                    <editorType>text</editorType>
                     <validation>
                         <rule name="required-entry" xsi:type="boolean">true</rule>
                     </validation>


### PR DESCRIPTION
This PR is intended to disable source code editing when the entity is not new, as required by issue #452. 

This is obtained setting an additional value in the source data provider which is used to distinguish b/w new and existing entity.

To obtain the same result in the inline editing, the `editorType` element is removed so that the value becomes read-only.