### PR TITLE
MSI: 510: Could not save Source Item Configuration - error when assig…

### DIFF
--- a/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/ProcessSourceItemsObserver.php
@@ -74,7 +74,9 @@ class ProcessSourceItemsObserver implements ObserverInterface
     {
         /** @var ProductInterface $product */
         $product = $observer->getEvent()->getProduct();
-        if ($product->getTypeId() != Type::TYPE_SIMPLE) {
+        if ($product->getTypeId() != Type::TYPE_SIMPLE
+            && $product->getTypeId() != Type::TYPE_VIRTUAL
+        ) {
             return;
         }
         /** @var Save $controller */


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. https://github.com/magento-engcom/msi/issues/510 : Could not save Source Item Configuration - error when assigning additional source to the Virtual and Downlodable products
