### PR TITLE
Change qty save behavior

### DIFF
--- a/app/code/Magento/CatalogInventory/Ui/DataProvider/Product/Form/Modifier/AdvancedInventory.php
+++ b/app/code/Magento/CatalogInventory/Ui/DataProvider/Product/Form/Modifier/AdvancedInventory.php
@@ -226,7 +226,8 @@ class AdvancedInventory extends AbstractModifier
                 ) - 1,
             ];
             $qty['arguments']['data']['config'] = [
-                'component' => 'Magento_CatalogInventory/js/components/qty-validator-changer',
+                'component' => 'Magento_CatalogInventory/js/components/qty',
+                'group' => 'quantity_and_stock_status_qty',
                 'dataType' => 'number',
                 'formElement' => 'input',
                 'componentType' => 'field',

--- a/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml
@@ -99,6 +99,9 @@
                     </validation>
                     <label translate="true">Qty</label>
                     <dataScope>quantity_and_stock_status.qty</dataScope>
+                    <links>
+                        <link name="value">ns = ${ $.ns }, index = qty, group = quantity_and_stock_status_qty:value</link>
+                    </links>
                     <imports>
                         <link name="handleChanges">${$.provider}:data.product.stock_data.is_qty_decimal</link>
                         <link name="visible">${$.provider}:data.product.stock_data.manage_stock</link>

--- a/app/code/Magento/CatalogInventory/view/adminhtml/web/js/components/qty.js
+++ b/app/code/Magento/CatalogInventory/view/adminhtml/web/js/components/qty.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'Magento_CatalogInventory/js/components/qty-validator-changer'
+], function (Abstract) {
+    'use strict';
+
+    return Abstract.extend({
+        defaults: {
+            links: {
+                value: false
+            }
+        },
+
+        /** @inheritdoc */
+        getInitialValue: function () {
+            var values = [this.source.get(this.dataScope), this.default],
+                value;
+
+            values.some(function (v) {
+                if (v !== null && v !== undefined) {
+                    value = v;
+
+                    return true;
+                }
+
+                return false;
+            });
+
+            return this.normalizeData(value);
+        },
+
+        /** @inheritdoc */
+        setDifferedFromDefault: function () {
+            this._super();
+
+            if (parseFloat(this.initialValue) !== parseFloat(this.value())) {
+                this.source.set(this.dataScope, this.value());
+            } else {
+                this.source.remove(this.dataScope);
+            }
+        }
+    });
+});


### PR DESCRIPTION
Don't send qty value if it wasn't changed during product edit.
Note: Backend must be adapted on case when qty does not present in request data.