### PR TITLE
Fix Magento\InventoryCatalog\Plugin\InventoryApi\ApplyDataToLegacyCatalogInventoryAtReservationPlacingPlugin

### DIFF
--- a/app/code/Magento/InventoryCatalog/Plugin/InventoryReservationsApi/ApplyDataToLegacyCatalogInventoryAtReservationPlacingPlugin.php
+++ b/app/code/Magento/InventoryCatalog/Plugin/InventoryReservationsApi/ApplyDataToLegacyCatalogInventoryAtReservationPlacingPlugin.php
@@ -86,8 +86,6 @@ class ApplyDataToLegacyCatalogInventoryAtReservationPlacingPlugin
      */
     public function afterExecute(AppendReservationsInterface $subject, $result, array $reservations)
     {
-        // TODO: 'https://github.com/magento-engcom/msi/issues/368'
-        return;
         if ($this->stockConfiguration->canSubtractQty()) {
             foreach ($reservations as $reservation) {
                 if ($this->defaultStockProvider->getId() !== $reservation->getStockId()) {

--- a/app/code/Magento/InventoryCatalog/Test/Integration/InventoryReservationsApi/ApplyDataToLegacyStockItemAtReservationPlacingTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/InventoryReservationsApi/ApplyDataToLegacyStockItemAtReservationPlacingTest.php
@@ -57,7 +57,6 @@ class ApplyDataToLegacyStockItemAtReservationPlacingTest extends TestCase
 
     protected function setUp()
     {
-        $this->markTestIncomplete('https://github.com/magento-engcom/msi/issues/368');
         $this->productRepository = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class);
 
         $this->legacyStockItemCriteriaFactory = Bootstrap::getObjectManager()->get(

--- a/app/code/Magento/InventoryCatalog/Test/Integration/InventoryReservationsApi/ApplyDataToLegacyStockStatusAtReservationPlacingTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/InventoryReservationsApi/ApplyDataToLegacyStockStatusAtReservationPlacingTest.php
@@ -57,7 +57,6 @@ class ApplyDataToLegacyStockStatusAtReservationPlacingTest extends TestCase
 
     protected function setUp()
     {
-        $this->markTestIncomplete('https://github.com/magento-engcom/msi/issues/368');
         $this->productRepository = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class);
 
         $this->legacyStockStatusCriteriaFactory = Bootstrap::getObjectManager()->get(

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/CreditmemoTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/CreditmemoTest.php
@@ -16,6 +16,7 @@ class CreditmemoTest extends \Magento\TestFramework\TestCase\AbstractBackendCont
      */
     public function testAddCommentAction()
     {
+        $this->markTestIncomplete('https://github.com/magento-engcom/msi/issues/393');
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         /** @var \Magento\CatalogInventory\Api\StockIndexInterface $stockIndex */
         $stockIndex = $objectManager->get(\Magento\CatalogInventory\Api\StockIndexInterface::class);

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/CreditmemoTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/CreditmemoTest.php
@@ -16,7 +16,6 @@ class CreditmemoTest extends \Magento\TestFramework\TestCase\AbstractBackendCont
      */
     public function testAddCommentAction()
     {
-        $this->markTestIncomplete('https://github.com/magento-engcom/msi/issues/368');
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         /** @var \Magento\CatalogInventory\Api\StockIndexInterface $stockIndex */
         $stockIndex = $objectManager->get(\Magento\CatalogInventory\Api\StockIndexInterface::class);


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento-engcom/msi#368: Fix Magento\InventoryCatalog\Plugin\InventoryApi\ApplyDataToLegacyCatalogInventoryAtReservationPlacingPlugin

### Manual testing scenarios

### Contribution checklist
