### PR TITLE
Fix add to cart using itemQty instead of requestedQty

### DIFF
--- a/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
@@ -102,7 +102,7 @@ class CheckQuoteItemQtyPlugin
         $result = $this->objectFactory->create();
         $result->setHasError(false);
 
-        $qty = $this->getNumber($qtyToCheck);
+        $qty = $this->getNumber($itemQty);
 
         $skus = $this->getSkusByProductIds->execute([$productId]);
         $productSku = $skus[$productId];


### PR DESCRIPTION
### Description
Use $itemQty (sum of qty of an item in the cart) instead of $qtyToCheck as it will always be 1 in case of add to cart action in CheckQuoteItemQtyPlugin.

### Fixed Issues (if relevant)
1. magento-engcom/msi#693: I can add to the cart product as many times as i want even if its qty == 1

### Manual testing scenarios
1. Create simple product "Simple 1" and assign it to category "Category 1"
2. Add product to default stock and set its qty to 1.
3. Go to frontend. Locate to "Category 1".
4. Press "Add to Cart" button on "Simple 1". The product will be added to the cart
5.  Press "Add to Cart" button on "Simple 1". The message 'The requested qty is not available' should be displayed.

Same scenario with Add to cart button from product page.

Update quantity in the cart or modal should still work as before.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
