### PR TITLE
stock status of duplicated product

### DIFF
--- a/app/code/Magento/InventoryCatalog/Model/UpdateSourceItemBasedOnLegacyStockItem.php
+++ b/app/code/Magento/InventoryCatalog/Model/UpdateSourceItemBasedOnLegacyStockItem.php
@@ -62,7 +62,6 @@ class UpdateSourceItemBasedOnLegacyStockItem
      * @param DefaultSourceProviderInterface $defaultSourceProvider
      * @param ResourceConnection $resourceConnection
      * @param GetSkusByProductIdsInterface $getSkusByProductIds
-
      */
     public function __construct(
         SourceItemRepositoryInterface $sourceItemRepository,
@@ -106,7 +105,7 @@ class UpdateSourceItemBasedOnLegacyStockItem
             $sourceItem->setSku($productSku);
         }
 
-        if ($legacyStockItem->getData(StockItemInterface::USE_CONFIG_MANAGE_STOCK) === null){
+        if ($legacyStockItem->getData(StockItemInterface::USE_CONFIG_MANAGE_STOCK) === null) {
             $legacyStockItem->setData(StockItemInterface::USE_CONFIG_MANAGE_STOCK, 1);
         }
 

--- a/app/code/Magento/InventoryCatalog/Model/UpdateSourceItemBasedOnLegacyStockItem.php
+++ b/app/code/Magento/InventoryCatalog/Model/UpdateSourceItemBasedOnLegacyStockItem.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\InventoryCatalog\Model;
 
 use Magento\CatalogInventory\Model\Stock\Item;
+use Magento\CatalogInventory\Api\Data\StockItemInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\ResourceConnection;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
@@ -103,6 +104,10 @@ class UpdateSourceItemBasedOnLegacyStockItem
             $sourceItem = $this->sourceItemFactory->create();
             $sourceItem->setSourceCode($this->defaultSourceProvider->getCode());
             $sourceItem->setSku($productSku);
+        }
+
+        if ($legacyStockItem->getData(StockItemInterface::USE_CONFIG_MANAGE_STOCK) === null){
+            $legacyStockItem->setData(StockItemInterface::USE_CONFIG_MANAGE_STOCK, 1);
         }
 
         $sourceItem->setQuantity((float)$legacyStockItem->getQty());


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento-engcom/msi#666: When we apply "Save & Duplicate" for existing Simple product - stock status for new product should be "Out of stock"

### Manual testing scenarios
1. Create simple product 
2. Press Save & Duplicate button
3. Check Stock Status of duplicated product

