### PR TITLE
"Could not receive Stock Item data" Line Appear Instead of Admin Product Grid.

### DIFF
--- a/app/code/Magento/InventoryIndexer/Model/GetStockItemData.php
+++ b/app/code/Magento/InventoryIndexer/Model/GetStockItemData.php
@@ -58,7 +58,11 @@ class GetStockItemData implements GetStockItemDataInterface
             ->where(IndexStructure::SKU . ' = ?', $sku);
 
         try {
-            return $connection->fetchRow($select) ?: null;
+            if ($connection->isTableExists($stockItemTableName)) {
+                return $connection->fetchRow($select) ?: null;
+            }
+
+            return null;
         } catch (\Exception $e) {
             throw new LocalizedException(__(
                 'Could not receive Stock Item data'

--- a/app/code/Magento/InventorySales/Test/Integration/GetStockItemData/GetStockItemDataTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/GetStockItemData/GetStockItemDataTest.php
@@ -48,10 +48,10 @@ class GetStockItemDataTest extends TestCase
         self::assertEquals($expectedData, $stockItemData);
     }
 
-    public function testGetStockItemDataReturnNullWhenTableDoesNotExists()
+    public function testGetStockItemDataReturnNullWhenTableDoesNotExist()
     {
         $stockItemData = $this->getStockItemData->execute('SKU-1', 10);
-        self::assertEquals(null, $stockItemData);
+        self::assertNull($stockItemData);
     }
 
     /**

--- a/app/code/Magento/InventorySales/Test/Integration/GetStockItemData/GetStockItemDataTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/GetStockItemData/GetStockItemDataTest.php
@@ -48,13 +48,10 @@ class GetStockItemDataTest extends TestCase
         self::assertEquals($expectedData, $stockItemData);
     }
 
-    /**
-     * @expectedException \Magento\Framework\Exception\LocalizedException
-     * @expectedExceptionMessage Could not receive Stock Item data
-     */
-    public function testGetStockItemDataException()
+    public function testGetStockItemDataReturnNullWhenTableDoesNotExists()
     {
-        $this->getStockItemData->execute('SKU-1', 10);
+        $stockItemData = $this->getStockItemData->execute('SKU-1', 10);
+        self::assertEquals(null, $stockItemData);
     }
 
     /**

--- a/dev/tests/integration/phpunit.xml.dist
+++ b/dev/tests/integration/phpunit.xml.dist
@@ -54,7 +54,7 @@
         <!-- Semicolon-separated 'glob' patterns, that match global XML configuration files -->
         <const name="TESTS_GLOBAL_CONFIG_DIR" value="../../../app/etc"/>
         <!-- Whether to cleanup the application before running tests or not -->
-        <const name="TESTS_CLEANUP" value="enabled"/>
+        <const name="TESTS_CLEANUP" value="disabled"/>
         <!-- Memory usage and estimated leaks thresholds -->
         <!--<const name="TESTS_MEM_USAGE_LIMIT" value="1024M"/>-->
         <const name="TESTS_MEM_LEAK_LIMIT" value=""/>

--- a/dev/tests/integration/phpunit.xml.dist
+++ b/dev/tests/integration/phpunit.xml.dist
@@ -54,7 +54,7 @@
         <!-- Semicolon-separated 'glob' patterns, that match global XML configuration files -->
         <const name="TESTS_GLOBAL_CONFIG_DIR" value="../../../app/etc"/>
         <!-- Whether to cleanup the application before running tests or not -->
-        <const name="TESTS_CLEANUP" value="disabled"/>
+        <const name="TESTS_CLEANUP" value="enabled"/>
         <!-- Memory usage and estimated leaks thresholds -->
         <!--<const name="TESTS_MEM_USAGE_LIMIT" value="1024M"/>-->
         <const name="TESTS_MEM_LEAK_LIMIT" value=""/>


### PR DESCRIPTION
This pull-request is to make sure we can see the product grid, when a new stock was created but that the stock index table has not be created.

We are using https://github.com/magento-engcom/msi/pull/655 to remove the `[Object object, Object object]` error in the grid.

### Description
We are returning `null` in `Magento/InventoryIndexer/Model/GetStockItemData::execute()` when the stock index table does not exits. This result in showing quantity 0 for that stock in the product grid.
