### PR TITLE
GitHub issue 754: unskip and fix Magento\Cms\Model\PageTest integrati…

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Cms/Model/PageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Model/PageTest.php
@@ -78,7 +78,6 @@ class PageTest extends \PHPUnit\Framework\TestCase
      */
     public function testUpdateTime()
     {
-        $this->markTestSkipped('https://github.com/magento-engcom/msi/issues/754');
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         /** @var \Magento\Cms\Model\Page $page */
         $page = $objectManager->create(\Magento\Cms\Model\Page::class);


### PR DESCRIPTION
Unskipped Integration test for Page Builder


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#754: Unskip and fix Magento\Cms\Model\PageTest
2. fix integration test under PHP 7.1

