### PR TITLE
MSI-689: Unskip and Fix Integration Test for PlaceOrderForConfigurableProduct

### DIFF
--- a/dev/tests/integration/testsuite/Magento/InstantPurchase/Model/PlaceOrderTest.php
+++ b/dev/tests/integration/testsuite/Magento/InstantPurchase/Model/PlaceOrderTest.php
@@ -55,9 +55,6 @@ class PlaceOrderTest extends TestCase
      */
     public function testPlaceOrderForConfigurableProduct()
     {
-        $this->markTestSkipped(
-            'Fix Integration Test PlaceOrder for ConfigurableProduct https://github.com/magento-engcom/msi/issues/689'
-        );
         $configurable = $this->getFixtureProduct('configurable');
         $simple = $this->getFixtureProduct('simple_10');
         $configurableAttributes = $configurable->getTypeInstance()->getConfigurableAttributes($configurable);


### PR DESCRIPTION
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#689: Unskip and Fix Integration Test for PlaceOrderForConfigurableProduct
