### PR TITLE
MSI-890: Notify for Qty below in Assigned sources grid not selected to use default configuration value for new created product

### DIFF
--- a/app/code/Magento/Inventory/Ui/DataProvider/SourceDataProvider.php
+++ b/app/code/Magento/Inventory/Ui/DataProvider/SourceDataProvider.php
@@ -15,6 +15,8 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider;
 use Magento\InventoryApi\Api\Data\SourceInterface;
 use Magento\InventoryApi\Api\SourceRepositoryInterface;
+use Magento\Ui\DataProvider\Modifier\ModifierInterface;
+use Magento\Ui\DataProvider\Modifier\PoolInterface;
 use Magento\Ui\DataProvider\SearchResultFactory;
 
 /**
@@ -38,6 +40,11 @@ class SourceDataProvider extends DataProvider
     private $session;
 
     /**
+     * @var PoolInterface
+     */
+    private $modifiersPool;
+
+    /**
      * @param string $name
      * @param string $primaryFieldName
      * @param string $requestFieldName
@@ -48,6 +55,7 @@ class SourceDataProvider extends DataProvider
      * @param SourceRepositoryInterface $sourceRepository
      * @param SearchResultFactory $searchResultFactory
      * @param Session $session
+     * @param PoolInterface $modifiersPool
      * @param array $meta
      * @param array $data
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) All parameters are needed for backward compatibility
@@ -63,6 +71,7 @@ class SourceDataProvider extends DataProvider
         SourceRepositoryInterface $sourceRepository,
         SearchResultFactory $searchResultFactory,
         Session $session,
+        PoolInterface $modifiersPool,
         array $meta = [],
         array $data = []
     ) {
@@ -80,6 +89,7 @@ class SourceDataProvider extends DataProvider
         $this->sourceRepository = $sourceRepository;
         $this->searchResultFactory = $searchResultFactory;
         $this->session = $session;
+        $this->modifiersPool = $modifiersPool;
     }
 
     /**
@@ -110,6 +120,12 @@ class SourceDataProvider extends DataProvider
                 }
             }
         }
+
+        /** @var ModifierInterface $modifier */
+        foreach ($this->modifiersPool->getModifiersInstances() as $modifier) {
+            $data = $modifier->modifyData($data);
+        }
+
         return $data;
     }
 
@@ -146,5 +162,20 @@ class SourceDataProvider extends DataProvider
             }
         }
         return $carrierCodes;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMeta()
+    {
+        $meta = parent::getMeta();
+
+        /** @var ModifierInterface $modifier */
+        foreach ($this->modifiersPool->getModifiersInstances() as $modifier) {
+            $meta = $modifier->modifyMeta($meta);
+        }
+
+        return $meta;
     }
 }

--- a/app/code/Magento/Inventory/etc/di.xml
+++ b/app/code/Magento/Inventory/etc/di.xml
@@ -86,4 +86,10 @@
             <argument name="stockSourceLinkValidator" xsi:type="object">Magento\Inventory\Model\StockSourceLink\Validator\ValidatorChain</argument>
         </arguments>
     </type>
+    <virtualType name="Magento\Inventory\Ui\DataProvider\SourceDataProvider\Modifier\Pool" type="Magento\Ui\DataProvider\Modifier\Pool"/>
+    <type name="Magento\Inventory\Ui\DataProvider\SourceDataProvider">
+        <arguments>
+            <argument name="modifiersPool" xsi:type="object">Magento\Inventory\Ui\DataProvider\SourceDataProvider\Modifier\Pool</argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/InventoryLowQuantityNotification/Ui/DataProvider/Product/Form/Modifier/SourceItemConfiguration.php
+++ b/app/code/Magento/InventoryLowQuantityNotification/Ui/DataProvider/Product/Form/Modifier/SourceItemConfiguration.php
@@ -100,7 +100,7 @@ class SourceItemConfiguration extends AbstractModifier
 
             if ($source[SourceItemConfigurationInterface::INVENTORY_NOTIFY_QTY] === null) {
                 $source[SourceItemConfigurationInterface::INVENTORY_NOTIFY_QTY] = $this->getNotifyQtyConfigValue();
-                $source['notify_stock_qty_use_default'] = "1";
+                $source['notify_stock_qty_use_default'] = '1';
             }
         }
         unset($source);

--- a/app/code/Magento/InventoryLowQuantityNotification/Ui/DataProvider/Source/Listing/Modifier/NotifyStockQuantity.php
+++ b/app/code/Magento/InventoryLowQuantityNotification/Ui/DataProvider/Source/Listing/Modifier/NotifyStockQuantity.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryLowQuantityNotification\Ui\DataProvider\Source\Listing\Modifier;
+
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
+use Magento\CatalogInventory\Model\Source\StockConfiguration;
+
+/**
+ * Notify stock quantity modifier. To add default value for "notify_stock_qty_use_default" and "notify_stock_qty"
+ * when map it from source modal window in product edit page to source grid.
+ */
+class NotifyStockQuantity extends AbstractModifier
+{
+    /**
+     * @var StockConfiguration
+     */
+    private $stockConfiguration;
+
+    /**
+     * @param StockConfiguration $stockConfiguration
+     */
+    public function __construct(StockConfiguration $stockConfiguration)
+    {
+        $this->stockConfiguration = $stockConfiguration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function modifyData(array $data)
+    {
+        if ($data['totalRecords'] > 0) {
+            foreach ($data['items'] as &$item) {
+                $item['notify_stock_qty_use_default'] = '1';
+                $item['notify_stock_qty'] = $this->stockConfiguration->getValue('notify_stock_qty');
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function modifyMeta(array $meta)
+    {
+        return $meta;
+    }
+}

--- a/app/code/Magento/InventoryLowQuantityNotification/etc/di.xml
+++ b/app/code/Magento/InventoryLowQuantityNotification/etc/di.xml
@@ -14,4 +14,14 @@
                 type="Magento\InventoryLowQuantityNotification\Model\SourceItemConfiguration\Command\Get"/>
     <preference for="Magento\InventoryLowQuantityNotificationApi\Api\DeleteSourceItemConfigurationInterface"
                 type="Magento\InventoryLowQuantityNotification\Model\SourceItemConfiguration\Command\Delete"/>
+    <virtualType name="Magento\Inventory\Ui\DataProvider\SourceDataProvider\Modifier\Pool">
+        <arguments>
+            <argument name="modifiers" xsi:type="array">
+                <item name="notify_stock_quantity" xsi:type="array">
+                    <item name="class" xsi:type="string">Magento\InventoryLowQuantityNotification\Ui\DataProvider\Source\Listing\Modifier\NotifyStockQuantity</item>
+                    <item name="sortOrder" xsi:type="number">50</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>

--- a/app/code/Magento/InventoryLowQuantityNotification/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/InventoryLowQuantityNotification/view/adminhtml/ui_component/product_form.xml
@@ -12,7 +12,7 @@
                 <item name="config" xsi:type="array">
                     <item name="map" xsi:type="array">
                         <item name="notify_stock_qty" xsi:type="string">notify_stock_qty</item>
-                        <item name="notify_stock_qty_use_default" xsi:type="string">notify_stock_qty_use_default_value</item>
+                        <item name="notify_stock_qty_use_default" xsi:type="string">notify_stock_qty_use_default</item>
                     </item>
                     <item name="identificationDRProperty" xsi:type="string">source_code</item>
                 </item>


### PR DESCRIPTION
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/magento-engcom/msi/issues/890

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create new source.
2. Go to create simple product.
3. Press Assign Sources.
4. Check all sources and press "Done"

Expected result:
- "Notify Quantity Use default" is checked.
- "Notify Quantity" field has value from Magento configuration.

