### PR TITLE
MSI-988: Fatal Error on Admin Manage Stock Page.

### DIFF
--- a/app/code/Magento/InventorySales/etc/di.xml
+++ b/app/code/Magento/InventorySales/etc/di.xml
@@ -10,7 +10,6 @@
     <preference for="Magento\InventorySalesApi\Api\Data\SalesChannelInterface" type="Magento\InventorySales\Model\SalesChannel"/>
     <preference for="Magento\InventorySales\Model\GetAssignedSalesChannelsForStockInterface" type="Magento\InventorySales\Model\GetAssignedSalesChannelsForStock"/>
     <preference for="Magento\InventorySales\Model\ReplaceSalesChannelsForStockInterface" type="Magento\InventorySales\Model\ResourceModel\ReplaceSalesChannelsDataForStock"/>
-    <preference for="Magento\InventorySales\Ui\SalesChannelNameResolverInterface" type="Magento\InventorySales\Ui\WebsiteNameResolver"/>
     <preference for="Magento\InventorySales\Model\GetAssignedStockIdForWebsiteInterface" type="Magento\InventorySales\Model\ResourceModel\GetAssignedStockIdForWebsite"/>
     <preference for="Magento\InventorySales\Model\DeleteSalesChannelToStockLinkInterface" type="Magento\InventorySales\Model\ResourceModel\DeleteSalesChannelToStockLink"/>
     <preference for="Magento\InventorySalesApi\Api\StockResolverInterface" type="Magento\InventorySales\Model\StockResolver"/>

--- a/app/code/Magento/InventorySalesAdminUi/etc/adminhtml/di.xml
+++ b/app/code/Magento/InventorySalesAdminUi/etc/adminhtml/di.xml
@@ -6,6 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\InventorySalesAdminUi\Ui\SalesChannelNameResolverInterface" type="Magento\InventorySalesAdminUi\Ui\WebsiteNameResolver"/>
     <!-- Stock delete button -->
     <type name="Magento\InventorySalesAdminUi\Ui\Component\Control\Stock\DeleteButton">
         <arguments>


### PR DESCRIPTION
### Description
Fix preference for SalesChannelNameResolverInterface

### Fixed Issues (if relevant)
1. magento-engcom/msi#988: Fatal Error on Admin Manage Stock Page.

### Manual testing scenarios
1. Login to admin area.
2. Navigate to Stores > Manage Stocks
3. Check page opened without any errors.
