### PR TITLE
FIX issue #33 - Returning void on method makes the whole class unable…

### DIFF
--- a/lib/internal/Magento/Framework/Interception/Code/Generator/Interceptor.php
+++ b/lib/internal/Magento/Framework/Interception/Code/Generator/Interceptor.php
@@ -102,17 +102,20 @@ class Interceptor extends \Magento\Framework\Code\Generator\EntityAbstract
             $parameters[] = $this->_getMethodParameterInfo($parameter);
         }
 
+        // Void methods must not use the return statement with any value
+        $return = ((string) $method->getReturnType() === 'void') ? '' : 'return ';
+
         $methodInfo = [
             'name' => ($method->returnsReference() ? '& ' : '') . $method->getName(),
             'parameters' => $parameters,
             'body' => "\$pluginInfo = \$this->pluginList->getNext(\$this->subjectType, '{$method->getName()}');\n" .
                 "if (!\$pluginInfo) {\n" .
-                "    return parent::{$method->getName()}({$this->_getParameterList(
+                "    {$return}parent::{$method->getName()}({$this->_getParameterList(
                 $parameters
             )});\n" .
-            "} else {\n" .
-            "    return \$this->___callPlugins('{$method->getName()}', func_get_args(), \$pluginInfo);\n" .
-            "}",
+                "} else {\n" .
+                "    {$return}\$this->___callPlugins('{$method->getName()}', func_get_args(), \$pluginInfo);\n" .
+                "}",
             'returnType' => $method->getReturnType(),
             'docblock' => ['shortDescription' => '{@inheritdoc}'],
         ];

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Code/Generator/_files/TInterceptor.txt
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Code/Generator/_files/TInterceptor.txt
@@ -15,6 +15,19 @@ class Interceptor extends \Magento\Framework\Interception\Code\Generator\TSample
     /**
      * {@inheritdoc}
      */
+    public function returnVoid() : void
+    {
+        $pluginInfo = $this->pluginList->getNext($this->subjectType, 'returnVoid');
+        if (!$pluginInfo) {
+            parent::returnVoid();
+        } else {
+            $this->___callPlugins('returnVoid', func_get_args(), $pluginInfo);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getValue() : string
     {
         $pluginInfo = $this->pluginList->getNext($this->subjectType, 'getValue');

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Code/Generator/_files/TSample.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Code/Generator/_files/TSample.php
@@ -10,6 +10,11 @@ class TSample
     private $value;
     private $variadicValue;
 
+    public function returnVoid() : void
+    {
+        // Nothing to do here
+    }
+
     public function getValue() : string
     {
         return $this->value;


### PR DESCRIPTION
FIx for issue https://github.com/magento-engcom/php-7.2-support/issues/33

### Description
Void methods were breaking Interceptor classes due to a return statement.
PHP7.2 forbids the presence of a return statement with parameters in void methods, even if returning null.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#33: Returning void on method makes the whole class unable to use plugins

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
