### PR TITLE
add sorting by source name to the source item grid dataprovider

### DIFF
--- a/app/code/Magento/InventoryCatalogAdminUi/Ui/DataProvider/Product/Form/Modifier/SourceItems.php
+++ b/app/code/Magento/InventoryCatalogAdminUi/Ui/DataProvider/Product/Form/Modifier/SourceItems.php
@@ -112,6 +112,8 @@ class SourceItems extends AbstractModifier
             ['source_name' => SourceInterface::NAME, 'source_status' => SourceInterface::ENABLED]
         );
 
+        $collection->setOrder(SourceInterface::NAME, Collection::SORT_ORDER_ASC);
+
         $sourceItemsData = [];
         foreach ($collection->getData() as $row) {
             $sourceItemsData[] = [


### PR DESCRIPTION
### Description
To easily find and keep track of many sources in the Source list when creating or editing products we sort the list by Source Name which is more intuitive than database table ID

### Fixed Issues (if relevant)
1. magento-engcom/msi#892: No sorting in Source Items grid

### Manual testing scenarios
1. create multiple new sources under Store > Manage Sources
2. start creating a new product
3. click on "Advanced Inventory"
4. check all sources and add
5. verify sources are ordered by Source Name

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
