### PR TITLE
Fix issue 774 qty increment decimal

### DIFF
--- a/app/code/Magento/CatalogInventory/Api/StockConfigurationInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockConfigurationInterface.php
@@ -77,7 +77,7 @@ interface StockConfigurationInterface
 
     /**
      * @param int $storeId
-     * @return int
+     * @return float
      */
     public function getQtyIncrements($store = null);
 

--- a/app/code/Magento/CatalogInventory/Model/Configuration.php
+++ b/app/code/Magento/CatalogInventory/Model/Configuration.php
@@ -273,7 +273,7 @@ class Configuration implements StockConfigurationInterface
 
     /**
      * @param null|string|bool|int|\Magento\Store\Model\Store $store
-     * @return int
+     * @return float
      */
     public function getQtyIncrements($store = null)
     {

--- a/app/code/Magento/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Item.php
@@ -401,7 +401,7 @@ class Item extends AbstractExtensibleModel implements StockItemInterface
                 if ($this->getUseConfigQtyIncrements()) {
                     $this->qtyIncrements = $this->stockConfiguration->getQtyIncrements($this->getStoreId());
                 } else {
-                    $this->qtyIncrements = (int) $this->getData(static::QTY_INCREMENTS);
+                    $this->qtyIncrements = (float) $this->getData(static::QTY_INCREMENTS);
                 }
             }
             if ($this->qtyIncrements <= 0) {

--- a/app/code/Magento/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Item.php
@@ -392,7 +392,7 @@ class Item extends AbstractExtensibleModel implements StockItemInterface
     /**
      * Retrieve Quantity Increments
      *
-     * @return int|false
+     * @return int|float|false
      */
     public function getQtyIncrements()
     {
@@ -401,7 +401,13 @@ class Item extends AbstractExtensibleModel implements StockItemInterface
                 if ($this->getUseConfigQtyIncrements()) {
                     $this->qtyIncrements = $this->stockConfiguration->getQtyIncrements($this->getStoreId());
                 } else {
-                    $this->qtyIncrements = (float) $this->getData(static::QTY_INCREMENTS);
+                    $this->qtyIncrements = $this->getData(static::QTY_INCREMENTS);
+                }
+
+                if ($this->getIsQtyDecimal()) { // Cast accordingly to decimal qty usage
+                    $this->qtyIncrements = (float) $this->qtyIncrements;
+                } else {
+                    $this->qtyIncrements = (int) $this->qtyIncrements;
                 }
             }
             if ($this->qtyIncrements <= 0) {

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/Stock/ItemTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/Stock/ItemTest.php
@@ -394,6 +394,7 @@ class ItemTest extends \PHPUnit\Framework\TestCase
         $this->setDataArrayValue('qty_increments', $config['qty_increments']);
         $this->setDataArrayValue('enable_qty_increments', $config['enable_qty_increments']);
         $this->setDataArrayValue('use_config_qty_increments', $config['use_config_qty_increments']);
+        $this->setDataArrayValue('is_qty_decimal', $config['is_qty_decimal']);
         if ($config['use_config_qty_increments']) {
             $this->stockConfiguration->expects($this->once())
                 ->method('getQtyIncrements')
@@ -415,7 +416,26 @@ class ItemTest extends \PHPUnit\Framework\TestCase
                 [
                     'qty_increments' => 1,
                     'enable_qty_increments' => true,
-                    'use_config_qty_increments' => true
+                    'use_config_qty_increments' => true,
+                    'is_qty_decimal' => false,
+                ],
+                1
+            ],
+            [
+                [
+                    'qty_increments' => 1.5,
+                    'enable_qty_increments' => true,
+                    'use_config_qty_increments' => true,
+                    'is_qty_decimal' => true,
+                ],
+                1.5
+            ],
+            [
+                [
+                    'qty_increments' => 1.5,
+                    'enable_qty_increments' => true,
+                    'use_config_qty_increments' => true,
+                    'is_qty_decimal' => false,
                 ],
                 1
             ],
@@ -423,7 +443,8 @@ class ItemTest extends \PHPUnit\Framework\TestCase
                 [
                     'qty_increments' => -2,
                     'enable_qty_increments' => true,
-                    'use_config_qty_increments' => true
+                    'use_config_qty_increments' => true,
+                    'is_qty_decimal' => false,
                 ],
                 false
             ],
@@ -431,7 +452,8 @@ class ItemTest extends \PHPUnit\Framework\TestCase
                 [
                     'qty_increments' => 3,
                     'enable_qty_increments' => true,
-                    'use_config_qty_increments' => false
+                    'use_config_qty_increments' => false,
+                    'is_qty_decimal' => false,
                 ],
                 3
             ],

--- a/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml
@@ -571,7 +571,6 @@
                     <settings>
                         <scopeLabel>[GLOBAL]</scopeLabel>
                         <validation>
-                            <rule name="validate-digits" xsi:type="boolean">true</rule>
                             <rule name="validate-number" xsi:type="boolean">true</rule>
                         </validation>
                         <label translate="true">Qty Increments</label>

--- a/app/code/Magento/CatalogInventory/view/adminhtml/web/js/components/qty-validator-changer.js
+++ b/app/code/Magento/CatalogInventory/view/adminhtml/web/js/components/qty-validator-changer.js
@@ -19,6 +19,7 @@ define([
         handleChanges: function (value) {
             var isDigits = value !== 1;
 
+            this.validation['validate-integer'] = isDigits;
             this.validation['less-than-equals-to'] = isDigits ? 99999999 : 99999999.9999;
             this.validate();
         }

--- a/app/code/Magento/CatalogInventory/view/adminhtml/web/js/components/qty-validator-changer.js
+++ b/app/code/Magento/CatalogInventory/view/adminhtml/web/js/components/qty-validator-changer.js
@@ -19,7 +19,6 @@ define([
         handleChanges: function (value) {
             var isDigits = value !== 1;
 
-            this.validation['validate-integer'] = isDigits;
             this.validation['less-than-equals-to'] = isDigits ? 99999999 : 99999999.9999;
             this.validate();
         }


### PR DESCRIPTION
Enable Magento backend to accept decimal increment qty

### Fixed Issues (if relevant)
1. magento-engcom/msi#774: "Qty Uses Decimals" doesn't work for simple product

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
