### PR TITLE
MSI-1062: Divide Magento\InventoryCatalog\Model\StockSourceLink\Validator\AssignToDefaultStockDefaultSourceValidator into two separate validators.

### DIFF
--- a/app/code/Magento/InventoryCatalog/Model/StockSourceLink/Validator/AssignDefaultSourceToNonDefaultStockValidator.php
+++ b/app/code/Magento/InventoryCatalog/Model/StockSourceLink/Validator/AssignDefaultSourceToNonDefaultStockValidator.php
@@ -12,9 +12,8 @@ use Magento\Framework\Validation\ValidationResultFactory;
 use Magento\Inventory\Model\StockSourceLink\Validator\StockSourceLinkValidatorInterface;
 use Magento\InventoryApi\Api\Data\StockSourceLinkInterface;
 use Magento\InventoryCatalog\Api\DefaultSourceProviderInterface;
-use Magento\InventoryCatalog\Api\DefaultStockProviderInterface;
 
-class AssignToDefaultStockDefaultSourceValidator implements StockSourceLinkValidatorInterface
+class AssignDefaultSourceToNonDefaultStockValidator implements StockSourceLinkValidatorInterface
 {
     /**
      * @var ValidationResultFactory
@@ -27,23 +26,15 @@ class AssignToDefaultStockDefaultSourceValidator implements StockSourceLinkValid
     private $defaultSourceProvider;
 
     /**
-     * @var DefaultStockProviderInterface
-     */
-    private $defaultStockProvider;
-
-    /**
      * @param ValidationResultFactory $validationResultFactory
      * @param DefaultSourceProviderInterface $defaultSourceProvider
-     * @param DefaultStockProviderInterface $defaultStockProvider
      */
     public function __construct(
         ValidationResultFactory $validationResultFactory,
-        DefaultSourceProviderInterface $defaultSourceProvider,
-        DefaultStockProviderInterface $defaultStockProvider
+        DefaultSourceProviderInterface $defaultSourceProvider
     ) {
         $this->validationResultFactory = $validationResultFactory;
         $this->defaultSourceProvider = $defaultSourceProvider;
-        $this->defaultStockProvider = $defaultStockProvider;
     }
 
     /**
@@ -52,9 +43,8 @@ class AssignToDefaultStockDefaultSourceValidator implements StockSourceLinkValid
     public function validate(StockSourceLinkInterface $link): ValidationResult
     {
         $errors = [];
-        if ($link->getStockId() === $this->defaultStockProvider->getId()
-        || $link->getSourceCode() === $this->defaultSourceProvider->getCode()) {
-            $errors[] = __('Can not save link related to Default Source or Default Stock');
+        if ($link->getSourceCode() === $this->defaultSourceProvider->getCode()) {
+            $errors[] = __('Can not save link related to Default Source');
         }
 
         return $this->validationResultFactory->create(['errors' => $errors]);

--- a/app/code/Magento/InventoryCatalog/Model/StockSourceLink/Validator/AssignNonDefaultSourceToDefaultStockValidator.php
+++ b/app/code/Magento/InventoryCatalog/Model/StockSourceLink/Validator/AssignNonDefaultSourceToDefaultStockValidator.php
@@ -49,5 +49,4 @@ class AssignNonDefaultSourceToDefaultStockValidator implements StockSourceLinkVa
 
         return $this->validationResultFactory->create(['errors' => $errors]);
     }
-
 }

--- a/app/code/Magento/InventoryCatalog/Model/StockSourceLink/Validator/AssignNonDefaultSourceToDefaultStockValidator.php
+++ b/app/code/Magento/InventoryCatalog/Model/StockSourceLink/Validator/AssignNonDefaultSourceToDefaultStockValidator.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Model\StockSourceLink\Validator;
+
+use Magento\Framework\Validation\ValidationResult;
+use Magento\Framework\Validation\ValidationResultFactory;
+use Magento\Inventory\Model\StockSourceLink\Validator\StockSourceLinkValidatorInterface;
+use Magento\InventoryApi\Api\Data\StockSourceLinkInterface;
+use Magento\InventoryCatalog\Api\DefaultStockProviderInterface;
+
+class AssignNonDefaultSourceToDefaultStockValidator implements StockSourceLinkValidatorInterface
+{
+    /**
+     * @var ValidationResultFactory
+     */
+    private $validationResultFactory;
+
+    /**
+     * @var DefaultStockProviderInterface
+     */
+    private $defaultStockProvider;
+
+    /**
+     * @param ValidationResultFactory $validationResultFactory
+     * @param DefaultStockProviderInterface $defaultStockProvider
+     */
+    public function __construct(
+        ValidationResultFactory $validationResultFactory,
+        DefaultStockProviderInterface $defaultStockProvider
+    ) {
+        $this->validationResultFactory = $validationResultFactory;
+        $this->defaultStockProvider = $defaultStockProvider;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function validate(StockSourceLinkInterface $link): ValidationResult
+    {
+        $errors = [];
+        if ($link->getStockId() === $this->defaultStockProvider->getId()) {
+            $errors[] = __('Can not save link related to Default Stock');
+        }
+
+        return $this->validationResultFactory->create(['errors' => $errors]);
+    }
+
+}

--- a/app/code/Magento/InventoryCatalog/Test/Api/StockSourceLink/PreventAssignSourcesToDefaultStockTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Api/StockSourceLink/PreventAssignSourcesToDefaultStockTest.php
@@ -99,11 +99,15 @@ class PreventAssignSourcesToDefaultStockTest extends WebapiAbstract
                     'message' => 'Validation Failed',
                     'errors' => [
                         [
-                            'message' => 'Can not save link related to Default Source or Default Stock',
+                            'message' => 'Can not save link related to Default Stock',
                             'parameters' => [],
                         ],
                         [
-                            'message' => 'Can not save link related to Default Source or Default Stock',
+                            'message' => 'Can not save link related to Default Source',
+                            'parameters' => [],
+                        ],
+                        [
+                            'message' => 'Can not save link related to Default Stock',
                             'parameters' => [],
                         ],
                     ],
@@ -116,7 +120,7 @@ class PreventAssignSourcesToDefaultStockTest extends WebapiAbstract
                     'message' => 'Validation Failed',
                     'errors' => [
                         [
-                            'message' => 'Can not save link related to Default Source or Default Stock',
+                            'message' => 'Can not save link related to Default Stock',
                             'parameters' => [],
                         ],
                     ],

--- a/app/code/Magento/InventoryCatalog/etc/di.xml
+++ b/app/code/Magento/InventoryCatalog/etc/di.xml
@@ -47,8 +47,11 @@
     <type name="Magento\Inventory\Model\StockSourceLink\Validator\ValidatorChain">
         <arguments>
             <argument name="validators" xsi:type="array">
-                <item name="default_stock_default_source" xsi:type="object">
-                    Magento\InventoryCatalog\Model\StockSourceLink\Validator\AssignToDefaultStockDefaultSourceValidator
+                <item name="default_stock" xsi:type="object">
+                    Magento\InventoryCatalog\Model\StockSourceLink\Validator\AssignNonDefaultSourceToDefaultStockValidator
+                </item>
+                <item name="default_source" xsi:type="object">
+                    Magento\InventoryCatalog\Model\StockSourceLink\Validator\AssignDefaultSourceToNonDefaultStockValidator
                 </item>
             </argument>
         </arguments>


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento-engcom/msi#1062: Divide Magento\InventoryCatalog\Model\StockSourceLink\Validator\AssignToDefaultStockDefaultSourceValidator into two separate validators.

### Manual testing scenarios
1. make API request http://magento-domain/rest/V1/inventory/stock-source-link with body:
```
{
  "links": [
    {
      "stock_id": "1",
      "source_code": "default",
      "priority": 1
    }
  ]
}
```
2. Check, response body should contain errors:
{"message":"Validation Failed","errors":[{"message":"Can not save link related to Default Stock","parameters":[]},{"message":"Can not save link related to Default Source","parameters":[]}]}
3. run API-Functional test InventoryCatalog/Test/Api/StockSourceLink/PreventAssignSourcesToDefaultStockTest.php for SOAP and REST
4. Test should passed successfully.

