### PR TITLE
Apply PHP 7.1 syntax for all MSI interfaces - Module InventoryCache

### DIFF
--- a/app/code/Magento/InventoryCache/Model/FlushCacheByProductIds.php
+++ b/app/code/Magento/InventoryCache/Model/FlushCacheByProductIds.php
@@ -44,7 +44,7 @@ class FlushCacheByProductIds
      * @param array $productIds
      * @return void
      */
-    public function execute(array $productIds)
+    public function execute(array $productIds): void
     {
         if ($productIds) {
             $this->cacheContext->registerEntities(Product::CACHE_TAG, $productIds);

--- a/app/code/Magento/InventoryCache/Plugin/InventoryIndexer/Indexer/Source/SourceItemIndexer/CacheFlush.php
+++ b/app/code/Magento/InventoryCache/Plugin/InventoryIndexer/Indexer/Source/SourceItemIndexer/CacheFlush.php
@@ -44,10 +44,11 @@ class CacheFlush
      * @param SourceItemIndexer $subject
      * @param array $sourceItemIds
      * @param null $result
+     * @return void
      * @throws \Exception in case catalog product entity type hasn't been initialize.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterExecuteList(SourceItemIndexer $subject, $result, array $sourceItemIds)
+    public function afterExecuteList(SourceItemIndexer $subject, $result, array $sourceItemIds): void
     {
         $productIds = $this->getProductIdsBySourceItemIds->execute($sourceItemIds);
         $this->flushCacheByIds->execute($productIds);

--- a/app/code/Magento/InventoryCache/Plugin/InventoryIndexer/Indexer/Stock/StockIndexer/CacheFlush.php
+++ b/app/code/Magento/InventoryCache/Plugin/InventoryIndexer/Indexer/Stock/StockIndexer/CacheFlush.php
@@ -48,7 +48,7 @@ class CacheFlush
      * @throws \Exception in case product entity type hasn't been initialize.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundExecuteList(StockIndexer $subject, callable $proceed, array $stockIds)
+    public function aroundExecuteList(StockIndexer $subject, callable $proceed, array $stockIds): void
     {
         $beforeReindexProductIds = $this->getProductIdsByStockIds->execute($stockIds);
         $proceed($stockIds);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Module `InventoryCache`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#784: Apply PHP 7.1 syntax for all MSI interfaces