### PR TITLE
Apply PHP 7.1 syntax for all MSI interfaces - Module InventoryCatalogSearch

### DIFF
--- a/app/code/Magento/InventoryCatalogSearch/Plugin/Model/Adapter/Mysql/Aggregation/DataProvider/SelectBuilderForAttribute/AdaptApplyStockConditionToSelectPlugin.php
+++ b/app/code/Magento/InventoryCatalogSearch/Plugin/Model/Adapter/Mysql/Aggregation/DataProvider/SelectBuilderForAttribute/AdaptApplyStockConditionToSelectPlugin.php
@@ -11,6 +11,8 @@ use Magento\CatalogSearch\Model\Adapter\Mysql\Aggregation\DataProvider\SelectBui
 ApplyStockConditionToSelect;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Select;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventoryIndexer\Indexer\IndexStructure;
 use Magento\InventoryIndexer\Model\StockIndexTableNameResolver;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
@@ -65,7 +67,8 @@ class AdaptApplyStockConditionToSelectPlugin
      * @param callable $proceed
      * @param Select $select
      * @return Select
-     *
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function aroundExecute(

--- a/app/code/Magento/InventoryCatalogSearch/Plugin/Model/Search/FilterMapper/TermDropdownStrategy/AdaptApplyStockConditionToSelectPlugin.php
+++ b/app/code/Magento/InventoryCatalogSearch/Plugin/Model/Search/FilterMapper/TermDropdownStrategy/AdaptApplyStockConditionToSelectPlugin.php
@@ -10,6 +10,7 @@ namespace Magento\InventoryCatalogSearch\Plugin\Model\Search\FilterMapper\TermDr
 use Magento\CatalogSearch\Model\Search\FilterMapper\TermDropdownStrategy\ApplyStockConditionToSelect;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Select;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\InventoryIndexer\Model\StockIndexTableNameResolverInterface;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
 use Magento\InventorySalesApi\Api\StockResolverInterface;
@@ -65,7 +66,7 @@ class AdaptApplyStockConditionToSelectPlugin
      * @param string $stockAlias
      * @param Select $select
      * @return void
-     *
+     * @throws LocalizedException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function aroundExecute(
@@ -74,7 +75,7 @@ class AdaptApplyStockConditionToSelectPlugin
         string $alias,
         string $stockAlias,
         Select $select
-    ) {
+    ): void {
         $select->joinInner(
             ['product' => $this->resourceConnection->getTableName('catalog_product_entity')],
             sprintf('product.entity_id = %s.source_id', $alias),


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Module `InventoryCatalogSearch`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#784: Apply PHP 7.1 syntax for all MSI interfaces