### PR TITLE
Apply PHP 7.1 syntax for all MSI interfaces - Module InventoryConfigurableProduct

### DIFF
--- a/app/code/Magento/InventoryConfigurableProduct/Model/GetQuantityInformationPerSource.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Model/GetQuantityInformationPerSource.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\InventoryConfigurableProduct\Model;
 
 use Magento\Framework\Api\SearchCriteriaBuilderFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
 use Magento\InventoryApi\Api\SourceItemRepositoryInterface;
 use Magento\InventoryApi\Api\SourceRepositoryInterface;
@@ -46,8 +47,8 @@ class GetQuantityInformationPerSource
 
     /**
      * @param string $sku
-     *
      * @return array
+     * @throws NoSuchEntityException
      */
     public function execute(string $sku): array
     {

--- a/app/code/Magento/InventoryConfigurableProduct/Model/ResourceModel/IsStockItemSalableCondition/GetConfigurableCondition.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Model/ResourceModel/IsStockItemSalableCondition/GetConfigurableCondition.php
@@ -22,8 +22,6 @@ class GetConfigurableCondition implements GetIsStockItemSalableConditionInterfac
      */
     public function execute(Select $select): string
     {
-        $condition = 'product_entity.type_id = \'configurable\'';
-
-        return $condition;
+        return 'product_entity.type_id = \'configurable\'';
     }
 }

--- a/app/code/Magento/InventoryConfigurableProduct/Model/ResourceModel/Product/StockStatusBaseSelectProcessor.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Model/ResourceModel/Product/StockStatusBaseSelectProcessor.php
@@ -10,6 +10,8 @@ namespace Magento\InventoryConfigurableProduct\Model\ResourceModel\Product;
 use Magento\Catalog\Model\ResourceModel\Product\BaseSelectProcessorInterface;
 use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\Framework\DB\Select;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventoryIndexer\Model\StockIndexTableNameResolverInterface;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
 use Magento\InventorySalesApi\Api\StockResolverInterface;
@@ -61,8 +63,10 @@ class StockStatusBaseSelectProcessor implements BaseSelectProcessorInterface
     /**
      * @param Select $select
      * @return Select
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
      */
-    public function process(Select $select)
+    public function process(Select $select): Select
     {
         if (!$this->stockConfig->isShowOutOfStock()) {
             $websiteCode = $this->storeManager->getWebsite()->getCode();
@@ -71,7 +75,6 @@ class StockStatusBaseSelectProcessor implements BaseSelectProcessorInterface
 
             $stockTable = $this->stockIndexTableNameResolver->execute($stockId);
 
-            /** @var Select $select */
             $select->join(
                 ['stock' => $stockTable],
                 sprintf('stock.sku = %s.sku', BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS),

--- a/app/code/Magento/InventoryConfigurableProduct/Plugin/Model/ResourceModel/Attribute/IsSalableOptionSelectBuilder.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Plugin/Model/ResourceModel/Attribute/IsSalableOptionSelectBuilder.php
@@ -9,6 +9,7 @@ namespace Magento\InventoryConfigurableProduct\Plugin\Model\ResourceModel\Attrib
 
 use Magento\ConfigurableProduct\Model\ResourceModel\Attribute\OptionSelectBuilderInterface;
 use Magento\Framework\DB\Select;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\InventoryIndexer\Model\StockIndexTableNameResolverInterface;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
 use Magento\InventorySalesApi\Api\StockResolverInterface;
@@ -55,13 +56,13 @@ class IsSalableOptionSelectBuilder
      * @param OptionSelectBuilderInterface $subject
      * @param Select $select
      * @return Select
-     *
+     * @throws LocalizedException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterGetSelect(
         OptionSelectBuilderInterface $subject,
         Select $select
-    ) {
+    ): Select {
         $websiteCode = $this->storeManager->getWebsite()->getCode();
         $stock = $this->stockResolver->get(SalesChannelInterface::TYPE_WEBSITE, $websiteCode);
         $stockId = (int)$stock->getStockId();


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Module `InventoryConfigurableProduct`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#784: Apply PHP 7.1 syntax for all MSI interfaces