### PR TITLE
Apply PHP 7.1 syntax for all MSI interfaces - Module InventoryConfigurableProductAdminUi

### DIFF
--- a/app/code/Magento/InventoryConfigurableProductAdminUi/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryConfigurableProductAdminUi/Observer/ProcessSourceItemsObserver.php
@@ -12,6 +12,8 @@ use Magento\Catalog\Controller\Adminhtml\Product\Save;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\Event\Observer as EventObserver;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
 use Magento\InventoryCatalogApi\Model\GetSkusByProductIdsInterface;
 use Magento\InventoryCatalogAdminUi\Observer\SourceItemsProcessor;
@@ -45,10 +47,11 @@ class ProcessSourceItemsObserver implements ObserverInterface
 
     /**
      * @param EventObserver $observer
-     *
      * @return void
+     * @throws InputException
+     * @throws LocalizedException
      */
-    public function execute(EventObserver $observer)
+    public function execute(EventObserver $observer): void
     {
         /** @var ProductInterface $product */
         $product = $observer->getEvent()->getProduct();
@@ -79,10 +82,10 @@ class ProcessSourceItemsObserver implements ObserverInterface
     /**
      * @param array $sourceItems
      * @param string $productSku
-     *
      * @return void
+     * @throws InputException
      */
-    private function processSourceItems(array $sourceItems, string $productSku)
+    private function processSourceItems(array $sourceItems, string $productSku): void
     {
         foreach ($sourceItems as $key => $sourceItem) {
             if (!isset($sourceItem[SourceItemInterface::STATUS])) {

--- a/app/code/Magento/InventoryConfigurableProductAdminUi/Plugin/Block/AddQuantityPerSourceToVariationsMatrix.php
+++ b/app/code/Magento/InventoryConfigurableProductAdminUi/Plugin/Block/AddQuantityPerSourceToVariationsMatrix.php
@@ -41,16 +41,12 @@ class AddQuantityPerSourceToVariationsMatrix
 
     /**
      * @param Matrix $subject
-     * @param $result
-     *
-     * @return array
-     *
+     * @param array|null $result
+     * @return array|null
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterGetProductMatrix(
-        Matrix $subject,
-        $result
-    ) {
+    public function afterGetProductMatrix(Matrix $subject, ?array $result): ?array
+    {
         if ($this->isSingleSourceMode->execute() === false && is_array($result)) {
             foreach ($result as $key => $variation) {
                 $result[$key]['quantityPerSource'] = $this->getQuantityInformationPerSource->execute($variation['sku']);

--- a/app/code/Magento/InventoryConfigurableProductAdminUi/Plugin/Block/BulkStepChangeTemplate.php
+++ b/app/code/Magento/InventoryConfigurableProductAdminUi/Plugin/Block/BulkStepChangeTemplate.php
@@ -40,11 +40,10 @@ class BulkStepChangeTemplate
     /**
      * @param Bulk $bulk
      * @param string $template
-     *
      * @return string
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeSetTemplate(Bulk $bulk, string $template)
+    public function beforeSetTemplate(Bulk $bulk, string $template): string
     {
         if ($this->isSingleSourceMode->execute() === false) {
             $template = $this->multiSourceTemplate;

--- a/app/code/Magento/InventoryConfigurableProductAdminUi/Plugin/Block/SummaryStepChangeTemplate.php
+++ b/app/code/Magento/InventoryConfigurableProductAdminUi/Plugin/Block/SummaryStepChangeTemplate.php
@@ -40,11 +40,10 @@ class SummaryStepChangeTemplate
     /**
      * @param Summary $bulk
      * @param string $template
-     *
      * @return string
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeSetTemplate(Summary $bulk, string $template)
+    public function beforeSetTemplate(Summary $bulk, string $template): string
     {
         if ($this->isSingleSourceMode->execute() === false) {
             $template = $this->multiSourceTemplate;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Module `InventoryConfigurableProductAdminUi`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#784: Apply PHP 7.1 syntax for all MSI interfaces
