### PR TITLE
Apply PHP 7.1 syntax for all MSI interfaces - Module InventoryConfigurableProductIndexer

### DIFF
--- a/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SelectBuilder.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SelectBuilder.php
@@ -80,7 +80,7 @@ class SelectBuilder
         $metadata = $this->metadataPool->getMetadata(ProductInterface::class);
         $linkField = $metadata->getLinkField();
 
-        $select = $connection->select()
+        return $connection->select()
             ->from(
                 ['stock' => $indexTableName],
                 [
@@ -102,7 +102,5 @@ class SelectBuilder
                 []
             )
             ->group(['parent_product_entity.sku']);
-
-        return $select;
     }
 }

--- a/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SourceItem/IndexDataBySkuListProvider.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SourceItem/IndexDataBySkuListProvider.php
@@ -43,6 +43,7 @@ class IndexDataBySkuListProvider
      * @param int $stockId
      * @param array $skuList
      * @return ArrayIterator
+     * @throws \Exception
      */
     public function execute(int $stockId, array $skuList): ArrayIterator
     {

--- a/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SourceItem/SourceItemIndexer.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SourceItem/SourceItemIndexer.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\InventoryConfigurableProductIndexer\Indexer\SourceItem;
 
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\StateException;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\Alias;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\IndexHandlerInterface;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\IndexNameBuilder;
@@ -81,8 +82,11 @@ class SourceItemIndexer
 
     /**
      * @param array $sourceItemIds
+     * @return void
+     * @throws StateException
+     * @throws \Exception
      */
-    public function executeList(array $sourceItemIds)
+    public function executeList(array $sourceItemIds): void
     {
         $skuListInStockList = $this->siblingSkuListInStockProvider->execute($sourceItemIds);
 

--- a/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/Stock/IndexDataByStockIdProvider.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/Stock/IndexDataByStockIdProvider.php
@@ -41,6 +41,7 @@ class IndexDataByStockIdProvider
     /**
      * @param int $stockId
      * @return ArrayIterator
+     * @throws \Exception
      */
     public function execute(int $stockId): ArrayIterator
     {

--- a/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/Stock/StockIndexer.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/Stock/StockIndexer.php
@@ -88,7 +88,7 @@ class StockIndexer
      * @return void
      * @throws StateException
      */
-    public function executeFull()
+    public function executeFull(): void
     {
         $stockIds = $this->getAllStockIds->execute();
         $this->executeList($stockIds);
@@ -99,7 +99,7 @@ class StockIndexer
      * @return void
      * @throws StateException
      */
-    public function executeRow(int $stockId)
+    public function executeRow(int $stockId): void
     {
         $this->executeList([$stockId]);
     }
@@ -108,8 +108,9 @@ class StockIndexer
      * @param array $stockIds
      * @return void
      * @throws StateException
+     * @throws \Exception
      */
-    public function executeList(array $stockIds)
+    public function executeList(array $stockIds): void
     {
         foreach ($stockIds as $stockId) {
             if ($this->defaultStockProvider->getId() === $stockId) {

--- a/app/code/Magento/InventoryConfigurableProductIndexer/Plugin/InventoryIndexer/SourceItemIndexerPlugin.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Plugin/InventoryIndexer/SourceItemIndexerPlugin.php
@@ -22,26 +22,21 @@ class SourceItemIndexerPlugin
     /**
      * @param ConfigurableProductsSourceItemIndexer $configurableProductsSourceItemIndexer
      */
-    public function __construct(
-        ConfigurableProductsSourceItemIndexer $configurableProductsSourceItemIndexer
-    ) {
+    public function __construct(ConfigurableProductsSourceItemIndexer $configurableProductsSourceItemIndexer)
+    {
         $this->configurableProductsSourceItemIndexer = $configurableProductsSourceItemIndexer;
     }
 
     /**
      * @param SourceItemIndexer $subject
-     * @param void $result
+     * @param null $result
      * @param array $sourceItemIds
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @throws StateException
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterExecuteList(
-        SourceItemIndexer $subject,
-        $result,
-        array $sourceItemIds
-    ) {
+    public function afterExecuteList(SourceItemIndexer $subject, $result, array $sourceItemIds): void
+    {
         $this->configurableProductsSourceItemIndexer->executeList($sourceItemIds);
     }
 }

--- a/app/code/Magento/InventoryConfigurableProductIndexer/Plugin/InventoryIndexer/StockIndexerPlugin.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Plugin/InventoryIndexer/StockIndexerPlugin.php
@@ -21,26 +21,21 @@ class StockIndexerPlugin
     /**
      * @param ConfigurableProductsStockIndexer $configurableProductsStockIndexer
      */
-    public function __construct(
-        ConfigurableProductsStockIndexer $configurableProductsStockIndexer
-    ) {
+    public function __construct(ConfigurableProductsStockIndexer $configurableProductsStockIndexer)
+    {
         $this->configurableProductsStockIndexer = $configurableProductsStockIndexer;
     }
 
     /**
      * @param StockIndexer $subject
-     * @param void $result
+     * @param null $result
      * @param array $stockIds
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @throws StateException
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterExecuteList(
-        StockIndexer $subject,
-        $result,
-        array $stockIds
-    ) {
+    public function afterExecuteList(StockIndexer $subject, $result, array $stockIds): void
+    {
         $this->configurableProductsStockIndexer->executeList($stockIds);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Module `InventoryConfigurableProductIndexer`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#784: Apply PHP 7.1 syntax for all MSI interfaces