### PR TITLE
Apply PHP 7.1 syntax for all MSI interfaces - Module InventoryConfiguration

### DIFF
--- a/app/code/Magento/InventoryConfiguration/Model/GetStockItemConfiguration.php
+++ b/app/code/Magento/InventoryConfiguration/Model/GetStockItemConfiguration.php
@@ -11,13 +11,16 @@ use Magento\CatalogInventory\Api\StockItemRepositoryInterface;
 use Magento\CatalogInventory\Api\Data\StockItemInterface;
 use Magento\CatalogInventory\Api\StockItemCriteriaInterfaceFactory;
 use Magento\CatalogInventory\Model\Stock;
+use Magento\Framework\Exception\InputException;
 use Magento\InventoryCatalogApi\Model\GetProductIdsBySkusInterface;
 use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
+use Magento\InventoryConfigurationApi\Api\Data\StockItemConfigurationInterface;
 use Magento\InventorySalesApi\Model\GetStockItemDataInterface;
 use Magento\Framework\Exception\LocalizedException;
 
 /**
  * @inheritdoc
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class GetStockItemConfiguration implements GetStockItemConfigurationInterface
 {
@@ -70,7 +73,7 @@ class GetStockItemConfiguration implements GetStockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function execute(string $sku, int $stockId)
+    public function execute(string $sku, int $stockId): ?StockItemConfigurationInterface
     {
         $stockItemData = $this->getStockItemData->execute($sku, $stockId);
         if (null === $stockItemData) {
@@ -88,7 +91,9 @@ class GetStockItemConfiguration implements GetStockItemConfigurationInterface
     /**
      * @param string $sku
      * @return StockItemInterface
+     * @throws InputException
      * @throws LocalizedException
+     * @throws \RuntimeException
      */
     private function getLegacyStockItem(string $sku): StockItemInterface
     {
@@ -108,7 +113,6 @@ class GetStockItemConfiguration implements GetStockItemConfigurationInterface
         }
 
         $stockItems = $stockItemCollection->getItems();
-        $stockItem = reset($stockItems);
-        return $stockItem;
+        return reset($stockItems);
     }
 }

--- a/app/code/Magento/InventoryConfiguration/Model/SaveStockItemConfiguration.php
+++ b/app/code/Magento/InventoryConfiguration/Model/SaveStockItemConfiguration.php
@@ -51,10 +51,8 @@ class SaveStockItemConfiguration implements SaveStockItemConfigurationInterface
 
     /**
      * @inheritdoc
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function execute(string $sku, int $stockId, StockItemConfigurationInterface $stockItemConfiguration)
+    public function execute(string $sku, int $stockId, StockItemConfigurationInterface $stockItemConfiguration): void
     {
         $productId = $this->getProductIdsBySkus->execute([$sku])[$sku];
 
@@ -75,7 +73,6 @@ class SaveStockItemConfiguration implements SaveStockItemConfigurationInterface
 
     /**
      * @param StockItemConfigurationInterface $stockItemConfiguration
-     *
      * @return array
      */
     private function getBinds(StockItemConfigurationInterface $stockItemConfiguration): array

--- a/app/code/Magento/InventoryConfigurationApi/Api/GetStockItemConfigurationInterface.php
+++ b/app/code/Magento/InventoryConfigurationApi/Api/GetStockItemConfigurationInterface.php
@@ -23,6 +23,8 @@ interface GetStockItemConfigurationInterface
      * @param int $stockId
      * @return StockItemConfigurationInterface|null
      * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \RuntimeException
      */
     public function execute(string $sku, int $stockId);
 }

--- a/app/code/Magento/InventoryConfigurationApi/Api/SaveStockItemConfigurationInterface.php
+++ b/app/code/Magento/InventoryConfigurationApi/Api/SaveStockItemConfigurationInterface.php
@@ -18,8 +18,10 @@ interface SaveStockItemConfigurationInterface
 {
     /**
      * @param string $sku
+     * @param int $stockId
      * @param StockItemConfigurationInterface $stockItemConfiguration
      * @return void
+     * @throws \Magento\Framework\Exception\InputException
      */
     public function execute(string $sku, int $stockId, StockItemConfigurationInterface $stockItemConfiguration);
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Module `InventoryConfiguration`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#784: Apply PHP 7.1 syntax for all MSI interfaces