### PR TITLE
Apply PHP 7.1 syntax for all MSI interfaces - Module InventoryImportExport

### DIFF
--- a/app/code/Magento/InventoryImportExport/Model/Export/ColumnProvider.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/ColumnProvider.php
@@ -9,7 +9,7 @@ namespace Magento\InventoryImportExport\Model\Export;
 
 use Magento\Framework\Data\Collection as AttributeCollection;
 use Magento\ImportExport\Model\Export;
-use \Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\LocalizedException;
 
 /**
  * @inheritdoc

--- a/app/code/Magento/InventoryImportExport/Model/Export/ColumnProviderInterface.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/ColumnProviderInterface.php
@@ -20,6 +20,7 @@ interface ColumnProviderInterface
      * @param AttributeCollection $attributeCollection
      * @param array $filters
      * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getHeaders(AttributeCollection $attributeCollection, array $filters): array;
 
@@ -29,6 +30,7 @@ interface ColumnProviderInterface
      * @param AttributeCollection $attributeCollection
      * @param array $filters
      * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getColumns(AttributeCollection $attributeCollection, array $filters): array;
 }

--- a/app/code/Magento/InventoryImportExport/Model/Export/Filter/IntFilter.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/Filter/IntFilter.php
@@ -21,7 +21,7 @@ class IntFilter implements FilterProcessorInterface
      * @param array|string $value
      * @return void
      */
-    public function process(Collection $collection, $columnName, $value)
+    public function process(Collection $collection, string $columnName, $value): void
     {
         if (is_array($value)) {
             $from = $value[0] ?? null;

--- a/app/code/Magento/InventoryImportExport/Model/Export/Filter/VarcharFilter.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/Filter/VarcharFilter.php
@@ -21,7 +21,7 @@ class VarcharFilter implements FilterProcessorInterface
      * @param array|string $value
      * @return void
      */
-    public function process(Collection $collection, $columnName, $value)
+    public function process(Collection $collection, string $columnName, $value): void
     {
         $collection->addFieldToFilter($columnName, ['like' => '%' . $value . '%']);
     }

--- a/app/code/Magento/InventoryImportExport/Model/Export/FilterProcessorAggregator.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/FilterProcessorAggregator.php
@@ -9,7 +9,6 @@ namespace Magento\InventoryImportExport\Model\Export;
 
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Inventory\Model\ResourceModel\SourceItem\Collection;
-use Magento\InventoryImportExport\Model\Export\FilterProcessorInterface;
 
 /**
  * @api
@@ -44,9 +43,10 @@ class FilterProcessorAggregator
      * @param Collection $collection
      * @param string $columnName
      * @param string|array $value
+     * @return void
      * @throws LocalizedException
      */
-    public function process($type, Collection $collection, $columnName, $value)
+    public function process($type, Collection $collection, string $columnName, $value): void
     {
         if (!isset($this->handler[$type])) {
             throw new LocalizedException(__(

--- a/app/code/Magento/InventoryImportExport/Model/Export/FilterProcessorInterface.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/FilterProcessorInterface.php
@@ -24,5 +24,5 @@ interface FilterProcessorInterface
      * @param array|string $value
      * @return void
      */
-    public function process(Collection $collection, $columnName, $value);
+    public function process(Collection $collection, string $columnName, $value): void;
 }

--- a/app/code/Magento/InventoryImportExport/Model/Export/SourceItemCollectionFactory.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/SourceItemCollectionFactory.php
@@ -7,16 +7,10 @@ declare(strict_types=1);
 
 namespace Magento\InventoryImportExport\Model\Export;
 
-use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Data\Collection as AttributeCollection;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
-use Magento\Inventory\Model\ResourceModel\Source as SourceResourceModel;
 use Magento\Inventory\Model\ResourceModel\SourceItem\Collection;
-use Magento\InventoryApi\Api\Data\SourceInterface;
-use Magento\InventoryApi\Api\Data\SourceItemInterface;
-use Magento\InventoryImportExport\Model\Export\ColumnProviderInterface;
-use Magento\InventoryImportExport\Model\Export\SourceItemCollectionFactoryInterface;
 use Magento\ImportExport\Model\Export;
 
 /**
@@ -24,11 +18,6 @@ use Magento\ImportExport\Model\Export;
  */
 class SourceItemCollectionFactory implements SourceItemCollectionFactoryInterface
 {
-    /**
-     * Source code field name
-     */
-    const SOURCE_CODE_FIELD = 'source_' . SourceInterface::SOURCE_CODE;
-
     /**
      * @var ObjectManagerInterface
      */
@@ -98,7 +87,7 @@ class SourceItemCollectionFactory implements SourceItemCollectionFactoryInterfac
      * @param array $filters
      * @return array
      */
-    private function retrieveFilterData(array $filters)
+    private function retrieveFilterData(array $filters): array
     {
         return array_filter(
             $filters[Export::FILTER_ELEMENT_GROUP] ?? [],

--- a/app/code/Magento/InventoryImportExport/Model/Export/Sources.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/Sources.php
@@ -7,14 +7,11 @@ declare(strict_types=1);
 
 namespace Magento\InventoryImportExport\Model\Export;
 
-use Exception;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\ImportExport\Model\Export\Factory as ExportFactory;
 use Magento\ImportExport\Model\Export\AbstractEntity;
 use Magento\Inventory\Model\ResourceModel\SourceItem;
 use Magento\Inventory\Model\ResourceModel\SourceItem\Collection as SourceItemCollection;
-use Magento\InventoryImportExport\Model\Export\SourceItemCollectionFactoryInterface;
-use Magento\InventoryImportExport\Model\Export\ColumnProviderInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\ImportExport\Model\ResourceModel\CollectionByPagesIteratorFactory;
 
@@ -75,7 +72,7 @@ class Sources extends AbstractEntity
 
     /**
      * @inheritdoc
-     * @throws Exception
+     * @throws \Exception
      */
     public function export()
     {
@@ -98,7 +95,7 @@ class Sources extends AbstractEntity
 
     /**
      * @inheritdoc
-     * @throws Exception
+     * @throws \Exception
      */
     protected function _getHeaderColumns()
     {

--- a/app/code/Magento/InventoryImportExport/Model/Import/Command/Append.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Command/Append.php
@@ -40,7 +40,7 @@ class Append implements CommandInterface
     /**
      * @inheritdoc
      */
-    public function execute(array $bunch)
+    public function execute(array $bunch): void
     {
         $sourceItems = $this->sourceItemConvert->convert($bunch);
         $this->sourceItemsSave->execute($sourceItems);

--- a/app/code/Magento/InventoryImportExport/Model/Import/Command/CommandInterface.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Command/CommandInterface.php
@@ -19,6 +19,9 @@ interface CommandInterface
      *
      * @param array $bunch
      * @return void
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Validation\ValidationException
      */
-    public function execute(array $bunch);
+    public function execute(array $bunch): void;
 }

--- a/app/code/Magento/InventoryImportExport/Model/Import/Command/Delete.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Command/Delete.php
@@ -41,7 +41,7 @@ class Delete implements CommandInterface
     /**
      * @inheritdoc
      */
-    public function execute(array $bunch)
+    public function execute(array $bunch): void
     {
         $sourceItems = $this->sourceItemConvert->convert($bunch);
         $this->sourceItemsDelete->execute($sourceItems);

--- a/app/code/Magento/InventoryImportExport/Model/Import/Command/Replace.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Command/Replace.php
@@ -52,7 +52,7 @@ class Replace implements CommandInterface
      * If an SKU and SOURCE_CODE in the import data matches the SKU and SOURCE_CODE of an existing entity,
      * all fields are deleted and new a record is created.
      */
-    public function execute(array $bunch)
+    public function execute(array $bunch): void
     {
         $sourceItems = $this->sourceItemConvert->convert($bunch);
         $this->sourceItemsDelete->execute($sourceItems);

--- a/app/code/Magento/InventoryImportExport/Model/Import/Serializer/Json.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Serializer/Json.php
@@ -36,7 +36,7 @@ class Json implements SerializerInterface
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function jsonEncode($valueToEncode)
+    public function jsonEncode($valueToEncode): string
     {
         return $this->serialize($valueToEncode);
     }
@@ -50,7 +50,7 @@ class Json implements SerializerInterface
      * @return mixed
      * @throws \InvalidArgumentException
      */
-    public function jsonDecode($encodedValue)
+    public function jsonDecode(string $encodedValue)
     {
         return $this->unserialize($encodedValue);
     }

--- a/app/code/Magento/InventoryImportExport/Model/Import/Sources.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Sources.php
@@ -26,10 +26,10 @@ class Sources extends AbstractEntity
     /**
      * Column names for import file
      */
-    const COL_SKU = SourceItemInterface::SKU;
-    const COL_SOURCE_CODE = SourceItemInterface::SOURCE_CODE;
-    const COL_QTY = SourceItemInterface::QUANTITY;
-    const COL_STATUS = SourceItemInterface::STATUS;
+    public const COL_SKU = SourceItemInterface::SKU;
+    public const COL_SOURCE_CODE = SourceItemInterface::SOURCE_CODE;
+    public const COL_QTY = SourceItemInterface::QUANTITY;
+    public const COL_STATUS = SourceItemInterface::STATUS;
 
     /**
      * @var Json
@@ -102,7 +102,7 @@ class Sources extends AbstractEntity
      * @return CommandInterface
      * @throws LocalizedException
      */
-    private function getCommandByBehavior($behavior)
+    private function getCommandByBehavior(string $behavior): CommandInterface
     {
         if (!isset($this->commands[$behavior])) {
             throw new LocalizedException(

--- a/app/code/Magento/InventoryImportExport/Model/Import/Validator/QtyValidator.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Validator/QtyValidator.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventoryImportExport\Model\Import\Validator;
 
-use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Validation\ValidationResult;
 use Magento\Framework\Validation\ValidationResultFactory;
 use Magento\InventoryImportExport\Model\Import\Sources;
 
@@ -23,7 +23,6 @@ class QtyValidator implements ValidatorInterface
 
     /**
      * @param ValidationResultFactory $validationResultFactory
-     * @throws LocalizedException
      */
     public function __construct(ValidationResultFactory $validationResultFactory)
     {
@@ -33,7 +32,7 @@ class QtyValidator implements ValidatorInterface
     /**
      * @inheritdoc
      */
-    public function validate(array $rowData, int $rowNumber)
+    public function validate(array $rowData, int $rowNumber): ValidationResult
     {
         $errors = [];
 

--- a/app/code/Magento/InventoryImportExport/Model/Import/Validator/SkuValidator.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Validator/SkuValidator.php
@@ -9,6 +9,7 @@ namespace Magento\InventoryImportExport\Model\Import\Validator;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\Validation\ValidationResult;
 use Magento\Framework\Validation\ValidationResultFactory;
 use Magento\InventoryImportExport\Model\Import\Sources;
 
@@ -42,7 +43,7 @@ class SkuValidator implements ValidatorInterface
     /**
      * @inheritdoc
      */
-    public function validate(array $rowData, int $rowNumber)
+    public function validate(array $rowData, int $rowNumber): ValidationResult
     {
         $errors = [];
 

--- a/app/code/Magento/InventoryImportExport/Model/Import/Validator/SourceValidator.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Validator/SourceValidator.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventoryImportExport\Model\Import\Validator;
 
+use Magento\Framework\Validation\ValidationResult;
 use Magento\Framework\Validation\ValidationResultFactory;
 use Magento\InventoryApi\Api\SourceRepositoryInterface;
 use Magento\InventoryImportExport\Model\Import\Sources;
@@ -47,7 +48,7 @@ class SourceValidator implements ValidatorInterface
     /**
      * @inheritdoc
      */
-    public function validate(array $rowData, int $rowNumber)
+    public function validate(array $rowData, int $rowNumber): ValidationResult
     {
         $errors = [];
 
@@ -66,7 +67,7 @@ class SourceValidator implements ValidatorInterface
      * @param string $sourceCode
      * @return bool
      */
-    private function isExistingSource($sourceCode): bool
+    private function isExistingSource(string $sourceCode): bool
     {
         return isset($this->sourceCodes[$sourceCode]);
     }
@@ -76,7 +77,7 @@ class SourceValidator implements ValidatorInterface
      *
      * @return void
      */
-    private function loadSourceCodes()
+    private function loadSourceCodes(): void
     {
         $sources = $this->sourceRepository->getList();
         foreach ($sources->getItems() as $source) {

--- a/app/code/Magento/InventoryImportExport/Model/Import/Validator/ValidatorChain.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Validator/ValidatorChain.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\InventoryImportExport\Model\Import\Validator;
 
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Validation\ValidationResult;
 use Magento\Framework\Validation\ValidationResultFactory;
 
 /**
@@ -49,7 +50,7 @@ class ValidatorChain implements ValidatorInterface
     /**
      * @inheritdoc
      */
-    public function validate(array $rowData, int $rowNumber)
+    public function validate(array $rowData, int $rowNumber): ValidationResult
     {
         /* the inner empty array covers cases when no loops were made */
         $errors = [[]];

--- a/app/code/Magento/InventoryImportExport/Model/Import/Validator/ValidatorInterface.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/Validator/ValidatorInterface.php
@@ -21,5 +21,5 @@ interface ValidatorInterface
      * @param int $rowNumber
      * @return ValidationResult
      */
-    public function validate(array $rowData, int $rowNumber);
+    public function validate(array $rowData, int $rowNumber): ValidationResult;
 }

--- a/app/code/Magento/InventoryImportExport/Plugin/Import/SourceItemImporter.php
+++ b/app/code/Magento/InventoryImportExport/Plugin/Import/SourceItemImporter.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 namespace Magento\InventoryImportExport\Plugin\Import;
 
 use Magento\CatalogImportExport\Model\StockItemImporterInterface;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Validation\ValidationException;
 use Magento\InventoryApi\Api\Data\SourceItemInterfaceFactory;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
 use Magento\InventoryApi\Api\SourceItemsSaveInterface;
@@ -59,9 +62,9 @@ class SourceItemImporter
      * @param StockItemImporterInterface $subject
      * @param null $result
      * @param array $stockData
-     * @throws \Magento\Framework\Exception\CouldNotSaveException
-     * @throws \Magento\Framework\Exception\InputException
-     * @throws \Magento\Framework\Validation\ValidationException
+     * @throws CouldNotSaveException
+     * @throws InputException
+     * @throws ValidationException
      * @return void
      * @see StockItemImporterInterface::import()
      *
@@ -71,7 +74,7 @@ class SourceItemImporter
         StockItemImporterInterface $subject,
         $result,
         array $stockData
-    ) {
+    ): void {
         $sourceItems = [];
         foreach ($stockData as $stockDatum) {
             if (!isset($stockDatum['sku'])) {
@@ -83,7 +86,7 @@ class SourceItemImporter
             $sourceItem = $this->sourceItemFactory->create();
             $sourceItem->setSku($stockDatum['sku']);
             $sourceItem->setSourceCode($this->defaultSource->getCode());
-            $sourceItem->setQuantity($qty);
+            $sourceItem->setQuantity((float)$qty);
             $sourceItem->setStatus($inStock);
             $sourceItems[] = $sourceItem;
         }

--- a/app/code/Magento/InventoryImportExport/Test/Integration/Model/StockItemImporterTest.php
+++ b/app/code/Magento/InventoryImportExport/Test/Integration/Model/StockItemImporterTest.php
@@ -93,9 +93,9 @@ class StockItemImporterTest extends TestCase
         $compareData = $this->buildDataArray($this->getSourceItemList()->getItems());
         $expectedData = [
             SourceItemInterface::SKU => 'SKU-1',
-            SourceItemInterface::QUANTITY => '1.0000',
+            SourceItemInterface::QUANTITY => 1.0,
             SourceItemInterface::SOURCE_CODE => (string)$this->defaultSourceProvider->getCode(),
-            SourceItemInterface::STATUS => (string)SourceItemInterface::STATUS_IN_STOCK,
+            SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
         ];
 
         $this->assertArrayHasKey('SKU-1', $compareData);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Module `InventoryImportExport`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#784: Apply PHP 7.1 syntax for all MSI interfaces