### PR TITLE
Apply PHP 7.1 syntax for all MSI interfaces - Module InventoryIndexer

### DIFF
--- a/app/code/Magento/InventoryIndexer/Indexer/IndexHandler.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/IndexHandler.php
@@ -59,7 +59,7 @@ class IndexHandler implements IndexHandlerInterface
     /**
      * @inheritdoc
      */
-    public function saveIndex(IndexName $indexName, \Traversable $documents, string $connectionName)
+    public function saveIndex(IndexName $indexName, \Traversable $documents, string $connectionName): void
     {
         $connection = $this->resourceConnection->getConnection($connectionName);
         $tableName = $this->indexNameResolver->resolveName($indexName);
@@ -73,7 +73,7 @@ class IndexHandler implements IndexHandlerInterface
     /**
      * @inheritdoc
      */
-    public function cleanIndex(IndexName $indexName, \Traversable $documents, string $connectionName)
+    public function cleanIndex(IndexName $indexName, \Traversable $documents, string $connectionName): void
     {
         $connection = $this->resourceConnection->getConnection($connectionName);
         $tableName = $this->indexNameResolver->resolveName($indexName);

--- a/app/code/Magento/InventoryIndexer/Indexer/IndexStructure.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/IndexStructure.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\InventoryIndexer\Indexer;
 
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Ddl\Table;
 use Magento\Framework\Exception\StateException;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\IndexName;
@@ -22,9 +23,9 @@ class IndexStructure implements IndexStructureInterface
     /**
      * Constants for represent fields in index table
      */
-    const SKU = 'sku';
-    const QUANTITY = 'quantity';
-    const IS_SALABLE = 'is_salable';
+    public const SKU = 'sku';
+    public const QUANTITY = 'quantity';
+    public const IS_SALABLE = 'is_salable';
     /**#@-*/
 
     /**
@@ -62,7 +63,7 @@ class IndexStructure implements IndexStructureInterface
     /**
      * @inheritdoc
      */
-    public function create(IndexName $indexName, string $connectionName)
+    public function create(IndexName $indexName, string $connectionName): void
     {
         $connection = $this->resourceConnection->getConnection($connectionName);
         $tableName = $this->indexNameResolver->resolveName($indexName);
@@ -76,11 +77,13 @@ class IndexStructure implements IndexStructureInterface
 
     /**
      * Create the index table
-     * @param \Magento\Framework\DB\Adapter\AdapterInterface $connection
+     *
+     * @param AdapterInterface $connection
      * @param string $tableName
      * @return void
+     * @throws \Zend_Db_Exception
      */
-    private function createTable(\Magento\Framework\DB\Adapter\AdapterInterface $connection, string $tableName)
+    private function createTable(AdapterInterface $connection, string $tableName): void
     {
         $table = $connection->newTable(
             $this->resourceConnection->getTableName($tableName)
@@ -122,7 +125,7 @@ class IndexStructure implements IndexStructureInterface
     /**
      * @inheritdoc
      */
-    public function delete(IndexName $indexName, string $connectionName)
+    public function delete(IndexName $indexName, string $connectionName): void
     {
         $connection = $this->resourceConnection->getConnection($connectionName);
         $tableName = $this->indexNameResolver->resolveName($indexName);

--- a/app/code/Magento/InventoryIndexer/Indexer/InventoryIndexer.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/InventoryIndexer.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventoryIndexer\Indexer;
 
+use Magento\Framework\Exception\StateException;
 use Magento\Framework\Indexer\ActionInterface;
 use Magento\InventoryIndexer\Indexer\SourceItem\SourceItemIndexer;
 
@@ -20,7 +21,7 @@ class InventoryIndexer implements ActionInterface
     /**
      * Indexer ID in configuration
      */
-    const INDEXER_ID = 'inventory';
+    public const INDEXER_ID = 'inventory';
 
     /**
      * @var SourceItemIndexer
@@ -38,6 +39,7 @@ class InventoryIndexer implements ActionInterface
 
     /**
      * @inheritdoc
+     * @throws StateException
      */
     public function executeFull()
     {
@@ -46,6 +48,7 @@ class InventoryIndexer implements ActionInterface
 
     /**
      * @inheritdoc
+     * @throws StateException
      */
     public function executeRow($sourceItemId)
     {
@@ -54,6 +57,7 @@ class InventoryIndexer implements ActionInterface
 
     /**
      * @inheritdoc
+     * @throws StateException
      */
     public function executeList(array $sourceItemIds)
     {

--- a/app/code/Magento/InventoryIndexer/Indexer/Mview/Action.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/Mview/Action.php
@@ -35,10 +35,7 @@ class Action implements ActionInterface
     }
 
     /**
-     * Execute materialization on ids entities
-     *
-     * @param int[] $ids
-     * @return void
+     * {@inheritdoc}
      */
     public function execute($ids)
     {

--- a/app/code/Magento/InventoryIndexer/Indexer/SelectBuilder.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/SelectBuilder.php
@@ -111,7 +111,6 @@ class SelectBuilder
             ->where('stock_source_link.' . StockSourceLink::STOCK_ID . ' = ?', $stockId)
             ->where(SourceInterface::ENABLED . ' = ?', 1);
 
-        $sourceCodes = $connection->fetchCol($select);
-        return $sourceCodes;
+        return $connection->fetchCol($select);
     }
 }

--- a/app/code/Magento/InventoryIndexer/Indexer/Source/GetAssignedStockIds.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/Source/GetAssignedStockIds.php
@@ -48,7 +48,6 @@ class GetAssignedStockIds
             ->group(StockSourceLink::STOCK_ID);
 
         $stockIds = $connection->fetchCol($select);
-        $stockIds = array_map('intval', $stockIds);
-        return $stockIds;
+        return array_map('intval', $stockIds);
     }
 }

--- a/app/code/Magento/InventoryIndexer/Indexer/Source/SourceIndexer.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/Source/SourceIndexer.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventoryIndexer\Indexer\Source;
 
+use Magento\Framework\Exception\StateException;
 use Magento\InventoryIndexer\Indexer\Stock\StockIndexer;
 
 /**
@@ -40,8 +41,9 @@ class SourceIndexer
 
     /**
      * @return void
+     * @throws StateException
      */
-    public function executeFull()
+    public function executeFull(): void
     {
         $this->stockIndexer->executeFull();
     }
@@ -49,16 +51,19 @@ class SourceIndexer
     /**
      * @param string $sourceCode
      * @return void
+     * @throws StateException
      */
-    public function executeRow(string $sourceCode)
+    public function executeRow(string $sourceCode): void
     {
         $this->executeList([$sourceCode]);
     }
 
     /**
      * @param array $sourceCodes
+     * @return void
+     * @throws StateException
      */
-    public function executeList(array $sourceCodes)
+    public function executeList(array $sourceCodes): void
     {
         $stockIds = $this->getAssignedStockIds->execute($sourceCodes);
         $this->stockIndexer->executeList($stockIds);

--- a/app/code/Magento/InventoryIndexer/Indexer/SourceItem/SkuListInStock.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/SourceItem/SkuListInStock.php
@@ -34,7 +34,7 @@ class SkuListInStock
      * @param int $stockId
      * @return void
      */
-    public function setStockId(int $stockId)
+    public function setStockId(int $stockId): void
     {
         $this->stockId = $stockId;
     }
@@ -51,7 +51,7 @@ class SkuListInStock
      * @param array $skuList
      * @return void
      */
-    public function setSkuList(array $skuList)
+    public function setSkuList(array $skuList): void
     {
         $this->skuList = $skuList;
     }

--- a/app/code/Magento/InventoryIndexer/Indexer/SourceItem/SourceItemIndexer.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/SourceItem/SourceItemIndexer.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\InventoryIndexer\Indexer\SourceItem;
 
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\StateException;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\Alias;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\IndexHandlerInterface;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\IndexNameBuilder;
@@ -20,6 +21,7 @@ use Magento\InventoryIndexer\Indexer\Stock\StockIndexer;
  * Source Item indexer
  *
  * @api
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class SourceItemIndexer
 {
@@ -89,8 +91,9 @@ class SourceItemIndexer
 
     /**
      * @return void
+     * @throws StateException
      */
-    public function executeFull()
+    public function executeFull(): void
     {
         $this->stockIndexer->executeFull();
     }
@@ -98,8 +101,9 @@ class SourceItemIndexer
     /**
      * @param int $sourceItemId
      * @return void
+     * @throws StateException
      */
-    public function executeRow(int $sourceItemId)
+    public function executeRow(int $sourceItemId): void
     {
         $this->executeList([$sourceItemId]);
     }
@@ -107,8 +111,9 @@ class SourceItemIndexer
     /**
      * @param array $sourceItemIds
      * @return void
+     * @throws StateException
      */
-    public function executeList(array $sourceItemIds)
+    public function executeList(array $sourceItemIds): void
     {
         $skuListInStockList = $this->getSkuListInStock->execute($sourceItemIds);
 

--- a/app/code/Magento/InventoryIndexer/Indexer/Stock/GetAllStockIds.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/Stock/GetAllStockIds.php
@@ -40,8 +40,6 @@ class GetAllStockIds
         $select = $connection->select()->from($stockTable, StockSourceLink::STOCK_ID);
 
         $stockIds = $connection->fetchCol($select);
-        $stockIds = array_map('intval', $stockIds);
-
-        return $stockIds;
+        return array_map('intval', $stockIds);
     }
 }

--- a/app/code/Magento/InventoryIndexer/Indexer/Stock/StockIndexer.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/Stock/StockIndexer.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\InventoryIndexer\Indexer\Stock;
 
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\StateException;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\Alias;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\IndexHandlerInterface;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\IndexNameBuilder;
@@ -21,6 +22,7 @@ use Magento\InventoryIndexer\Indexer\InventoryIndexer;
  * Extension point for indexation
  *
  * @api
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class StockIndexer
 {
@@ -90,8 +92,9 @@ class StockIndexer
 
     /**
      * @return void
+     * @throws StateException
      */
-    public function executeFull()
+    public function executeFull(): void
     {
         $stockIds = $this->getAllStockIds->execute();
         $this->executeList($stockIds);
@@ -100,8 +103,9 @@ class StockIndexer
     /**
      * @param int $stockId
      * @return void
+     * @throws StateException
      */
-    public function executeRow(int $stockId)
+    public function executeRow(int $stockId): void
     {
         $this->executeList([$stockId]);
     }
@@ -109,8 +113,9 @@ class StockIndexer
     /**
      * @param array $stockIds
      * @return void
+     * @throws StateException
      */
-    public function executeList(array $stockIds)
+    public function executeList(array $stockIds): void
     {
         foreach ($stockIds as $stockId) {
             if ($this->defaultStockProvider->getId() === (int)$stockId) {

--- a/app/code/Magento/InventoryIndexer/Model/ResourceModel/GetStockItemData.php
+++ b/app/code/Magento/InventoryIndexer/Model/ResourceModel/GetStockItemData.php
@@ -43,7 +43,7 @@ class GetStockItemData implements GetStockItemDataInterface
     /**
      * @inheritdoc
      */
-    public function execute(string $sku, int $stockId)
+    public function execute(string $sku, int $stockId): ?array
     {
         $stockItemTableName = $this->stockIndexTableNameResolver->execute($stockId);
 

--- a/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/InvalidateAfterEnablingOrDisablingSourcePlugin.php
+++ b/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/InvalidateAfterEnablingOrDisablingSourcePlugin.php
@@ -53,7 +53,7 @@ class InvalidateAfterEnablingOrDisablingSourcePlugin
         SourceRepositoryInterface $subject,
         callable $proceed,
         SourceInterface $source
-    ) {
+    ): void {
         $invalidationRequired = false;
         if ($source->getSourceCode()) {
             $invalidationRequired = $this->isInvalidationRequiredForSource->execute(

--- a/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/InvalidateAfterStockSourceLinksDeletePlugin.php
+++ b/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/InvalidateAfterStockSourceLinksDeletePlugin.php
@@ -39,7 +39,7 @@ class InvalidateAfterStockSourceLinksDeletePlugin
     public function afterExecute(
         StockSourceLinksDeleteInterface $subject,
         $result
-    ) {
+    ): void {
         $indexer = $this->indexerRegistry->get(InventoryIndexer::INDEXER_ID);
         if ($indexer->isValid()) {
             $indexer->invalidate();

--- a/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/InvalidateAfterStockSourceLinksSavePlugin.php
+++ b/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/InvalidateAfterStockSourceLinksSavePlugin.php
@@ -33,12 +33,13 @@ class InvalidateAfterStockSourceLinksSavePlugin
     /**
      * @param StockSourceLinksSaveInterface $subject
      * @param void $result
+     * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterExecute(
         StockSourceLinksSaveInterface $subject,
         $result
-    ) {
+    ): void {
         $indexer = $this->indexerRegistry->get(InventoryIndexer::INDEXER_ID);
         if ($indexer->isValid()) {
             $indexer->invalidate();

--- a/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsDeletePlugin.php
+++ b/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsDeletePlugin.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventoryIndexer\Plugin\InventoryApi;
 
+use Magento\Framework\Exception\StateException;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
 use Magento\InventoryApi\Api\SourceItemsDeleteInterface;
 use Magento\InventoryIndexer\Indexer\Source\SourceIndexer;
@@ -34,13 +35,14 @@ class ReindexAfterSourceItemsDeletePlugin
      * @param callable $proceed
      * @param SourceItemInterface[] $sourceItems
      * @return void
+     * @throws StateException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function aroundExecute(
         SourceItemsDeleteInterface $subject,
         callable $proceed,
         array $sourceItems
-    ) {
+    ): void {
         $sourceCodes = [];
         foreach ($sourceItems as $sourceItem) {
             $sourceCodes[] = $sourceItem->getSourceCode();

--- a/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsSavePlugin.php
+++ b/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsSavePlugin.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventoryIndexer\Plugin\InventoryApi;
 
+use Magento\Framework\Exception\StateException;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
 use Magento\InventoryApi\Api\SourceItemsSaveInterface;
 use Magento\InventoryIndexer\Indexer\SourceItem\GetSourceItemIds;
@@ -39,16 +40,17 @@ class ReindexAfterSourceItemsSavePlugin
 
     /**
      * @param SourceItemsSaveInterface $subject
-     * @param void $result
+     * @param null $result
      * @param SourceItemInterface[] $sourceItems
      * @return void
+     * @throws StateException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterExecute(
         SourceItemsSaveInterface $subject,
         $result,
         array $sourceItems
-    ) {
+    ): void {
         $sourceItemIds = $this->getSourceItemIds->execute($sourceItems);
         if (count($sourceItemIds)) {
             $this->sourceItemIndexer->executeList($sourceItemIds);

--- a/app/code/Magento/InventoryMultiDimensionalIndexerApi/Model/IndexHandlerInterface.php
+++ b/app/code/Magento/InventoryMultiDimensionalIndexerApi/Model/IndexHandlerInterface.php
@@ -22,7 +22,7 @@ interface IndexHandlerInterface
      * @param string $connectionName
      * @return void
      */
-    public function saveIndex(IndexName $indexName, \Traversable $documents, string $connectionName);
+    public function saveIndex(IndexName $indexName, \Traversable $documents, string $connectionName): void;
 
     /**
      * Remove given documents from Index
@@ -32,5 +32,5 @@ interface IndexHandlerInterface
      * @param string $connectionName
      * @return void
      */
-    public function cleanIndex(IndexName $indexName, \Traversable $documents, string $connectionName);
+    public function cleanIndex(IndexName $indexName, \Traversable $documents, string $connectionName): void;
 }

--- a/app/code/Magento/InventoryMultiDimensionalIndexerApi/Model/IndexStructureInterface.php
+++ b/app/code/Magento/InventoryMultiDimensionalIndexerApi/Model/IndexStructureInterface.php
@@ -19,10 +19,11 @@ interface IndexStructureInterface
      *
      * @param IndexName $indexName
      * @param string $connectionName
-     * @throws \Magento\Framework\Exception\StateException
      * @return void
+     * @throws \Zend_Db_Exception
+     * @throws \Magento\Framework\Exception\StateException
      */
-    public function create(IndexName $indexName, string $connectionName);
+    public function create(IndexName $indexName, string $connectionName): void;
 
     /**
      * Delete the given Index
@@ -31,7 +32,7 @@ interface IndexStructureInterface
      * @param string $connectionName
      * @return void
      */
-    public function delete(IndexName $indexName, string $connectionName);
+    public function delete(IndexName $indexName, string $connectionName): void;
 
     /**
      * Checks whether the Index exits

--- a/app/code/Magento/InventorySalesApi/Model/GetStockItemDataInterface.php
+++ b/app/code/Magento/InventorySalesApi/Model/GetStockItemDataInterface.php
@@ -19,9 +19,9 @@ interface GetStockItemDataInterface
     /**
      * Constants for represent fields in result array
      */
-    const SKU = 'sku';
-    const QUANTITY = 'quantity';
-    const IS_SALABLE = 'is_salable';
+    public const SKU = 'sku';
+    public const QUANTITY = 'quantity';
+    public const IS_SALABLE = 'is_salable';
     /**#@-*/
 
     /**
@@ -32,5 +32,5 @@ interface GetStockItemDataInterface
      * @return array|null
      * @throws LocalizedException
      */
-    public function execute(string $sku, int $stockId);
+    public function execute(string $sku, int $stockId): ?array;
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Module `InventoryIndexer`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#784: Apply PHP 7.1 syntax for all MSI interfaces