### PR TITLE
Apply PHP 7.1 syntax for all MSI interfaces - Module InventorySalesAdminUi

### DIFF
--- a/app/code/Magento/InventorySalesAdminUi/Model/GetSalableQuantityDataBySku.php
+++ b/app/code/Magento/InventorySalesAdminUi/Model/GetSalableQuantityDataBySku.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventorySalesAdminUi\Model;
 
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventorySalesAdminUi\Model\ResourceModel\GetAssignedStockIdsBySku;
 use Magento\InventoryApi\Api\StockRepositoryInterface;
 use Magento\InventorySalesApi\Api\GetProductSalableQtyInterface;
@@ -49,6 +50,7 @@ class GetSalableQuantityDataBySku
     /**
      * @param string $sku
      * @return array
+     * @throws NoSuchEntityException
      */
     public function execute(string $sku): array
     {

--- a/app/code/Magento/InventorySalesAdminUi/Model/OptionSource/WebsiteSource.php
+++ b/app/code/Magento/InventorySalesAdminUi/Model/OptionSource/WebsiteSource.php
@@ -33,7 +33,7 @@ class WebsiteSource implements OptionSourceInterface
     /**
      * @inheritdoc
      */
-    public function toOptionArray(): array
+    public function toOptionArray()
     {
         $websites = [];
         foreach ($this->websiteRepository->getList() as $website) {

--- a/app/code/Magento/InventorySalesAdminUi/Ui/Component/Listing/Column/SalableQuantity.php
+++ b/app/code/Magento/InventorySalesAdminUi/Ui/Component/Listing/Column/SalableQuantity.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventorySalesAdminUi\Ui\Component\Listing\Column;
 
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\InventorySalesAdminUi\Model\GetSalableQuantityDataBySku;
@@ -60,6 +61,7 @@ class SalableQuantity extends Column
 
     /**
      * @inheritdoc
+     * @throws NoSuchEntityException
      */
     public function prepareDataSource(array $dataSource)
     {

--- a/app/code/Magento/InventorySalesAdminUi/Ui/Component/Listing/Column/SalesChannels.php
+++ b/app/code/Magento/InventorySalesAdminUi/Ui/Component/Listing/Column/SalesChannels.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventorySalesAdminUi\Ui\Component\Listing\Column;
 
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventorySalesAdminUi\Ui\SalesChannelNameResolverInterface;
 use Magento\Ui\Component\Listing\Columns\Column;
 use Magento\Framework\View\Element\UiComponentFactory;
@@ -45,8 +46,9 @@ class SalesChannels extends Column
      *
      * @param array $dataSource
      * @return array
+     * @throws NoSuchEntityException
      */
-    public function prepareDataSource(array $dataSource)
+    public function prepareDataSource(array $dataSource): array
     {
         if ($dataSource['data']['totalRecords'] > 0) {
             foreach ($dataSource['data']['items'] as &$row) {
@@ -64,6 +66,7 @@ class SalesChannels extends Column
      *
      * @param array $salesChannelData
      * @return array
+     * @throws NoSuchEntityException
      */
     private function prepareSalesChannelData(array $salesChannelData): array
     {

--- a/app/code/Magento/InventorySalesAdminUi/Ui/DataProvider/Product/Form/Modifier/SalableQuantity.php
+++ b/app/code/Magento/InventorySalesAdminUi/Ui/DataProvider/Product/Form/Modifier/SalableQuantity.php
@@ -9,6 +9,7 @@ namespace Magento\InventorySalesAdminUi\Ui\DataProvider\Product\Form\Modifier;
 
 use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Catalog\Model\Locator\LocatorInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventorySalesAdminUi\Model\GetSalableQuantityDataBySku;
 use Magento\InventoryCatalogApi\Model\IsSingleSourceModeInterface;
 use Magento\InventoryConfigurationApi\Model\IsSourceItemManagementAllowedForProductTypeInterface;
@@ -58,6 +59,7 @@ class SalableQuantity extends AbstractModifier
 
     /**
      * @inheritdoc
+     * @throws NoSuchEntityException
      */
     public function modifyData(array $data)
     {

--- a/app/code/Magento/InventorySalesAdminUi/Ui/SalesChannelNameResolverInterface.php
+++ b/app/code/Magento/InventorySalesAdminUi/Ui/SalesChannelNameResolverInterface.php
@@ -18,6 +18,7 @@ interface SalesChannelNameResolverInterface
      * @param string $type
      * @param string $code
      * @return string
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function resolve(string $type, string $code): string;
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Module `InventorySalesAdminUi`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#784: Apply PHP 7.1 syntax for all MSI interfaces
