### PR TITLE
Fix Fluent interfaces

### DIFF
--- a/app/code/Magento/InventoryApi/Api/Data/SourceItemInterface.php
+++ b/app/code/Magento/InventoryApi/Api/Data/SourceItemInterface.php
@@ -91,7 +91,7 @@ interface SourceItemInterface extends ExtensibleDataInterface
      * Set source item status (One of self::STATUS_*)
      *
      * @param int|null $status
-     * @return int
+     * @return void
      */
     public function setStatus($status);
 

--- a/app/code/Magento/InventoryApi/Api/Data/StockExtension.php
+++ b/app/code/Magento/InventoryApi/Api/Data/StockExtension.php
@@ -14,20 +14,18 @@ namespace Magento\InventoryApi\Api\Data;
 class StockExtension extends \Magento\Framework\Api\AbstractSimpleObject implements StockExtensionInterface
 {
     /**
-     * @return \Magento\InventorySalesApi\Api\Data\SalesChannelInterface[]|null
+     * @inheritdoc
      */
-    public function getSalesChannels()
+    public function getSalesChannels(): ?array
     {
         return $this->_get('sales_channels');
     }
 
     /**
-     * @param \Magento\InventorySalesApi\Api\Data\SalesChannelInterface[] $salesChannels
-     * @return $this
+     * @inheritdoc
      */
-    public function setSalesChannels($salesChannels)
+    public function setSalesChannels(array $salesChannels): void
     {
         $this->setData('sales_channels', $salesChannels);
-        return $this;
     }
 }

--- a/app/code/Magento/InventoryApi/Api/Data/StockExtensionInterface.php
+++ b/app/code/Magento/InventoryApi/Api/Data/StockExtensionInterface.php
@@ -16,11 +16,11 @@ interface StockExtensionInterface extends \Magento\Framework\Api\ExtensionAttrib
     /**
      * @return \Magento\InventorySalesApi\Api\Data\SalesChannelInterface[]|null
      */
-    public function getSalesChannels();
+    public function getSalesChannels(): ?array;
 
     /**
      * @param \Magento\InventorySalesApi\Api\Data\SalesChannelInterface[] $salesChannels
-     * @return $this
+     * @return void
      */
-    public function setSalesChannels($salesChannels);
+    public function setSalesChannels(array $salesChannels): void;
 }

--- a/app/code/Magento/InventoryConfiguration/Model/StockItemConfiguration.php
+++ b/app/code/Magento/InventoryConfiguration/Model/StockItemConfiguration.php
@@ -42,7 +42,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setIsQtyDecimal(bool $isQtyDecimal): void
     {
-        $this->stockItem = $this->stockItem->setIsQtyDecimal($isQtyDecimal);
+        $this->stockItem->setIsQtyDecimal($isQtyDecimal);
     }
 
     /**
@@ -82,7 +82,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setMinQty(float $minQty): void
     {
-        $this->stockItem = $this->stockItem->setMinQty($minQty);
+        $this->stockItem->setMinQty($minQty);
     }
 
     /**
@@ -98,7 +98,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setUseConfigMinSaleQty(bool $useConfigMinSaleQty): void
     {
-        $this->stockItem = $this->stockItem->setUseConfigMinSaleQty($useConfigMinSaleQty);
+        $this->stockItem->setUseConfigMinSaleQty($useConfigMinSaleQty);
     }
 
     /**
@@ -114,7 +114,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setMinSaleQty(float $minSaleQty): void
     {
-        $this->stockItem = $this->stockItem->setMinSaleQty($minSaleQty);
+        $this->stockItem->setMinSaleQty($minSaleQty);
     }
 
     /**
@@ -130,7 +130,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setUseConfigMaxSaleQty(bool $useConfigMaxSaleQty): void
     {
-        $this->stockItem = $this->stockItem->setUseConfigMaxSaleQty($useConfigMaxSaleQty);
+        $this->stockItem->setUseConfigMaxSaleQty($useConfigMaxSaleQty);
     }
 
     /**
@@ -146,7 +146,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setMaxSaleQty(float $maxSaleQty): void
     {
-        $this->stockItem = $this->stockItem->setMaxSaleQty($maxSaleQty);
+        $this->stockItem->setMaxSaleQty($maxSaleQty);
     }
 
     /**
@@ -162,7 +162,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setUseConfigBackorders(bool $useConfigBackorders): void
     {
-        $this->stockItem = $this->stockItem->setUseConfigBackorders($useConfigBackorders);
+        $this->stockItem->setUseConfigBackorders($useConfigBackorders);
     }
 
     /**
@@ -178,7 +178,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setBackorders(int $backOrders): void
     {
-        $this->stockItem = $this->stockItem->setBackorders($backOrders);
+        $this->stockItem->setBackorders($backOrders);
     }
 
     /**
@@ -194,7 +194,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setUseConfigNotifyStockQty(bool $useConfigNotifyStockQty): void
     {
-        $this->stockItem = $this->stockItem->setUseConfigNotifyStockQty($useConfigNotifyStockQty);
+        $this->stockItem->setUseConfigNotifyStockQty($useConfigNotifyStockQty);
     }
 
     /**
@@ -210,7 +210,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setNotifyStockQty(float $notifyStockQty): void
     {
-        $this->stockItem = $this->stockItem->setNotifyStockQty($notifyStockQty);
+        $this->stockItem->setNotifyStockQty($notifyStockQty);
     }
 
     /**
@@ -226,7 +226,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setUseConfigQtyIncrements(bool $useConfigQtyIncrements): void
     {
-        $this->stockItem = $this->stockItem->setUseConfigQtyIncrements($useConfigQtyIncrements);
+        $this->stockItem->setUseConfigQtyIncrements($useConfigQtyIncrements);
     }
 
     /**
@@ -246,7 +246,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setQtyIncrements(float $qtyIncrements): void
     {
-        $this->stockItem = $this->stockItem->setQtyIncrements($qtyIncrements);
+        $this->stockItem->setQtyIncrements($qtyIncrements);
     }
 
     /**
@@ -262,7 +262,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setUseConfigEnableQtyInc(bool $useConfigEnableQtyInc): void
     {
-        $this->stockItem = $this->stockItem->setUseConfigEnableQtyInc($useConfigEnableQtyInc);
+        $this->stockItem->setUseConfigEnableQtyInc($useConfigEnableQtyInc);
     }
 
     /**
@@ -278,7 +278,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setEnableQtyIncrements(bool $enableQtyIncrements): void
     {
-        $this->stockItem = $this->stockItem->setEnableQtyIncrements($enableQtyIncrements);
+        $this->stockItem->setEnableQtyIncrements($enableQtyIncrements);
     }
 
     /**
@@ -294,7 +294,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setUseConfigManageStock(bool $useConfigManageStock): void
     {
-        $this->stockItem = $this->stockItem->setUseConfigManageStock($useConfigManageStock);
+        $this->stockItem->setUseConfigManageStock($useConfigManageStock);
     }
 
     /**
@@ -310,7 +310,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setManageStock(bool $manageStock): void
     {
-        $this->stockItem = $this->stockItem->setManageStock($manageStock);
+        $this->stockItem->setManageStock($manageStock);
     }
 
     /**
@@ -327,7 +327,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setLowStockDate(string $lowStockDate): void
     {
-        $this->stockItem = $this->stockItem->setLowStockDate($lowStockDate);
+        $this->stockItem->setLowStockDate($lowStockDate);
     }
 
     /**
@@ -343,7 +343,7 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setIsDecimalDivided(bool $isDecimalDivided): void
     {
-        $this->stockItem = $this->stockItem->setIsDecimalDivided($isDecimalDivided);
+        $this->stockItem->setIsDecimalDivided($isDecimalDivided);
     }
 
     /**
@@ -359,6 +359,6 @@ class StockItemConfiguration implements StockItemConfigurationInterface
      */
     public function setStockStatusChangedAuto(int $stockStatusChangedAuto): void
     {
-        $this->stockItem = $this->stockItem->setStockStatusChangedAuto($stockStatusChangedAuto);
+        $this->stockItem->setStockStatusChangedAuto($stockStatusChangedAuto);
     }
 }

--- a/app/code/Magento/InventoryConfiguration/Model/StockItemConfiguration.php
+++ b/app/code/Magento/InventoryConfiguration/Model/StockItemConfiguration.php
@@ -40,10 +40,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setIsQtyDecimal(bool $isQtyDecimal): StockItemConfigurationInterface
+    public function setIsQtyDecimal(bool $isQtyDecimal): void
     {
         $this->stockItem = $this->stockItem->setIsQtyDecimal($isQtyDecimal);
-        return $this;
     }
 
     /**
@@ -65,10 +64,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setUseConfigMinQty(bool $useConfigMinQty): StockItemConfigurationInterface
+    public function setUseConfigMinQty(bool $useConfigMinQty): void
     {
         $this->stockItem = $this->stockItem->setUseConfigMinQty($useConfigMinQty);
-        return $this;
     }
 
     /**
@@ -82,10 +80,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setMinQty(float $minQty): StockItemConfigurationInterface
+    public function setMinQty(float $minQty): void
     {
         $this->stockItem = $this->stockItem->setMinQty($minQty);
-        return $this;
     }
 
     /**
@@ -99,10 +96,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setUseConfigMinSaleQty(bool $useConfigMinSaleQty): StockItemConfigurationInterface
+    public function setUseConfigMinSaleQty(bool $useConfigMinSaleQty): void
     {
         $this->stockItem = $this->stockItem->setUseConfigMinSaleQty($useConfigMinSaleQty);
-        return $this;
     }
 
     /**
@@ -116,10 +112,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setMinSaleQty(float $minSaleQty): StockItemConfigurationInterface
+    public function setMinSaleQty(float $minSaleQty): void
     {
         $this->stockItem = $this->stockItem->setMinSaleQty($minSaleQty);
-        return $this;
     }
 
     /**
@@ -133,10 +128,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setUseConfigMaxSaleQty(bool $useConfigMaxSaleQty): StockItemConfigurationInterface
+    public function setUseConfigMaxSaleQty(bool $useConfigMaxSaleQty): void
     {
         $this->stockItem = $this->stockItem->setUseConfigMaxSaleQty($useConfigMaxSaleQty);
-        return $this;
     }
 
     /**
@@ -150,10 +144,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setMaxSaleQty(float $maxSaleQty): StockItemConfigurationInterface
+    public function setMaxSaleQty(float $maxSaleQty): void
     {
         $this->stockItem = $this->stockItem->setMaxSaleQty($maxSaleQty);
-        return $this;
     }
 
     /**
@@ -167,10 +160,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setUseConfigBackorders(bool $useConfigBackorders): StockItemConfigurationInterface
+    public function setUseConfigBackorders(bool $useConfigBackorders): void
     {
         $this->stockItem = $this->stockItem->setUseConfigBackorders($useConfigBackorders);
-        return $this;
     }
 
     /**
@@ -184,10 +176,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setBackorders(int $backOrders): StockItemConfigurationInterface
+    public function setBackorders(int $backOrders): void
     {
         $this->stockItem = $this->stockItem->setBackorders($backOrders);
-        return $this;
     }
 
     /**
@@ -201,10 +192,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setUseConfigNotifyStockQty(bool $useConfigNotifyStockQty): StockItemConfigurationInterface
+    public function setUseConfigNotifyStockQty(bool $useConfigNotifyStockQty): void
     {
         $this->stockItem = $this->stockItem->setUseConfigNotifyStockQty($useConfigNotifyStockQty);
-        return $this;
     }
 
     /**
@@ -218,10 +208,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setNotifyStockQty(float $notifyStockQty): StockItemConfigurationInterface
+    public function setNotifyStockQty(float $notifyStockQty): void
     {
         $this->stockItem = $this->stockItem->setNotifyStockQty($notifyStockQty);
-        return $this;
     }
 
     /**
@@ -235,10 +224,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setUseConfigQtyIncrements(bool $useConfigQtyIncrements): StockItemConfigurationInterface
+    public function setUseConfigQtyIncrements(bool $useConfigQtyIncrements): void
     {
         $this->stockItem = $this->stockItem->setUseConfigQtyIncrements($useConfigQtyIncrements);
-        return $this;
     }
 
     /**
@@ -256,10 +244,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setQtyIncrements(float $qtyIncrements): StockItemConfigurationInterface
+    public function setQtyIncrements(float $qtyIncrements): void
     {
         $this->stockItem = $this->stockItem->setQtyIncrements($qtyIncrements);
-        return $this;
     }
 
     /**
@@ -273,10 +260,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setUseConfigEnableQtyInc(bool $useConfigEnableQtyInc): StockItemConfigurationInterface
+    public function setUseConfigEnableQtyInc(bool $useConfigEnableQtyInc): void
     {
         $this->stockItem = $this->stockItem->setUseConfigEnableQtyInc($useConfigEnableQtyInc);
-        return $this;
     }
 
     /**
@@ -290,10 +276,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setEnableQtyIncrements(bool $enableQtyIncrements): StockItemConfigurationInterface
+    public function setEnableQtyIncrements(bool $enableQtyIncrements): void
     {
         $this->stockItem = $this->stockItem->setEnableQtyIncrements($enableQtyIncrements);
-        return $this;
     }
 
     /**
@@ -307,10 +292,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setUseConfigManageStock(bool $useConfigManageStock): StockItemConfigurationInterface
+    public function setUseConfigManageStock(bool $useConfigManageStock): void
     {
         $this->stockItem = $this->stockItem->setUseConfigManageStock($useConfigManageStock);
-        return $this;
     }
 
     /**
@@ -324,10 +308,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setManageStock(bool $manageStock): StockItemConfigurationInterface
+    public function setManageStock(bool $manageStock): void
     {
         $this->stockItem = $this->stockItem->setManageStock($manageStock);
-        return $this;
     }
 
     /**
@@ -336,16 +319,15 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     public function getLowStockDate(): string
     {
         $lowStockDate = $this->stockItem->getLowStockDate();
-        return null === $lowStockDate ? '': $lowStockDate;
+        return null === $lowStockDate ? '' : $lowStockDate;
     }
 
     /**
      * @inheritdoc
      */
-    public function setLowStockDate(string $lowStockDate): StockItemConfigurationInterface
+    public function setLowStockDate(string $lowStockDate): void
     {
         $this->stockItem = $this->stockItem->setLowStockDate($lowStockDate);
-        return $this;
     }
 
     /**
@@ -359,10 +341,9 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setIsDecimalDivided(bool $isDecimalDivided): StockItemConfigurationInterface
+    public function setIsDecimalDivided(bool $isDecimalDivided): void
     {
         $this->stockItem = $this->stockItem->setIsDecimalDivided($isDecimalDivided);
-        return $this;
     }
 
     /**
@@ -376,9 +357,8 @@ class StockItemConfiguration implements StockItemConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function setStockStatusChangedAuto(int $stockStatusChangedAuto): StockItemConfigurationInterface
+    public function setStockStatusChangedAuto(int $stockStatusChangedAuto): void
     {
         $this->stockItem = $this->stockItem->setStockStatusChangedAuto($stockStatusChangedAuto);
-        return $this;
     }
 }

--- a/app/code/Magento/InventoryConfigurationApi/Api/Data/StockItemConfigurationInterface.php
+++ b/app/code/Magento/InventoryConfigurationApi/Api/Data/StockItemConfigurationInterface.php
@@ -55,9 +55,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $isQtyDecimal
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setIsQtyDecimal(bool $isQtyDecimal): StockItemConfigurationInterface;
+    public function setIsQtyDecimal(bool $isQtyDecimal): void;
 
     /**
      * @return bool
@@ -71,9 +71,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $useConfigMinQty
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setUseConfigMinQty(bool $useConfigMinQty): StockItemConfigurationInterface;
+    public function setUseConfigMinQty(bool $useConfigMinQty): void;
 
     /**
      * @return float
@@ -82,9 +82,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param float $minQty
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setMinQty(float $minQty): StockItemConfigurationInterface;
+    public function setMinQty(float $minQty): void;
 
     /**
      * @return bool
@@ -93,9 +93,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $useConfigMinSaleQty
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setUseConfigMinSaleQty(bool $useConfigMinSaleQty): StockItemConfigurationInterface;
+    public function setUseConfigMinSaleQty(bool $useConfigMinSaleQty): void;
 
     /**
      * @return float
@@ -104,9 +104,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param float $minSaleQty
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setMinSaleQty(float $minSaleQty): StockItemConfigurationInterface;
+    public function setMinSaleQty(float $minSaleQty): void;
 
     /**
      * @return bool
@@ -115,9 +115,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $useConfigMaxSaleQty
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setUseConfigMaxSaleQty(bool $useConfigMaxSaleQty): StockItemConfigurationInterface;
+    public function setUseConfigMaxSaleQty(bool $useConfigMaxSaleQty): void;
 
     /**
      * @return float
@@ -126,9 +126,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param float $maxSaleQty
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setMaxSaleQty(float $maxSaleQty): StockItemConfigurationInterface;
+    public function setMaxSaleQty(float $maxSaleQty): void;
 
     /**
      * @return bool
@@ -137,9 +137,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $useConfigBackorders
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setUseConfigBackorders(bool $useConfigBackorders): StockItemConfigurationInterface;
+    public function setUseConfigBackorders(bool $useConfigBackorders): void;
 
     /**
      * Retrieve backorders status
@@ -150,9 +150,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param int $backOrders
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setBackorders(int $backOrders): StockItemConfigurationInterface;
+    public function setBackorders(int $backOrders): void;
 
     /**
      * @return bool
@@ -161,9 +161,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $useConfigNotifyStockQty
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setUseConfigNotifyStockQty(bool $useConfigNotifyStockQty): StockItemConfigurationInterface;
+    public function setUseConfigNotifyStockQty(bool $useConfigNotifyStockQty): void;
 
     /**
      * @return float
@@ -172,9 +172,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param float $notifyStockQty
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setNotifyStockQty(float $notifyStockQty): StockItemConfigurationInterface;
+    public function setNotifyStockQty(float $notifyStockQty): void;
 
     /**
      * @return bool
@@ -183,9 +183,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $useConfigQtyIncrements
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setUseConfigQtyIncrements(bool $useConfigQtyIncrements): StockItemConfigurationInterface;
+    public function setUseConfigQtyIncrements(bool $useConfigQtyIncrements): void;
 
     /**
      * Retrieve Quantity Increments data wrapper
@@ -196,9 +196,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param float $qtyIncrements
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setQtyIncrements(float $qtyIncrements): StockItemConfigurationInterface;
+    public function setQtyIncrements(float $qtyIncrements): void;
 
     /**
      * @return bool
@@ -207,9 +207,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $useConfigEnableQtyInc
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setUseConfigEnableQtyInc(bool $useConfigEnableQtyInc): StockItemConfigurationInterface;
+    public function setUseConfigEnableQtyInc(bool $useConfigEnableQtyInc): void;
 
     /**
      * @return bool
@@ -218,9 +218,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param $enableQtyIncrements
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setEnableQtyIncrements(bool $enableQtyIncrements): StockItemConfigurationInterface;
+    public function setEnableQtyIncrements(bool $enableQtyIncrements): void;
 
     /**
      * @return bool
@@ -229,9 +229,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $useConfigManageStock
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setUseConfigManageStock(bool $useConfigManageStock): StockItemConfigurationInterface;
+    public function setUseConfigManageStock(bool $useConfigManageStock): void;
 
     /**
      * @return bool
@@ -240,9 +240,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $manageStock
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setManageStock(bool $manageStock): StockItemConfigurationInterface;
+    public function setManageStock(bool $manageStock): void;
 
     /**
      * @return string
@@ -251,9 +251,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param string $lowStockDate
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setLowStockDate(string $lowStockDate): StockItemConfigurationInterface;
+    public function setLowStockDate(string $lowStockDate): void;
 
     /**
      * @return bool
@@ -262,9 +262,9 @@ interface StockItemConfigurationInterface
 
     /**
      * @param bool $isDecimalDivided
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setIsDecimalDivided(bool $isDecimalDivided): StockItemConfigurationInterface;
+    public function setIsDecimalDivided(bool $isDecimalDivided): void;
 
     /**
      * @return int
@@ -273,7 +273,7 @@ interface StockItemConfigurationInterface
 
     /**
      * @param int $stockStatusChangedAuto
-     * @return StockItemConfigurationInterface
+     * @return void
      */
-    public function setStockStatusChangedAuto(int $stockStatusChangedAuto): StockItemConfigurationInterface;
+    public function setStockStatusChangedAuto(int $stockStatusChangedAuto): void;
 }


### PR DESCRIPTION
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#1167: Fluent interfaces are forbidden in Magento, StockItemConfigurationInterface need to be refactored