### PR TITLE
MSI-1250:  Prevent Disabling Default Source by Disabling 'Is Enabled' Switcher

### DIFF
--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_source_form.xml
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_source_form.xml
@@ -81,6 +81,9 @@
             <settings>
                 <dataType>boolean</dataType>
                 <label translate="true">Is Enabled</label>
+                <imports>
+                    <link name="disabled">${ $.provider }:data.general.switcher_disabled</link>
+                </imports>
             </settings>
             <formElements>
                 <checkbox>

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_source_form.xml
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_source_form.xml
@@ -81,9 +81,6 @@
             <settings>
                 <dataType>boolean</dataType>
                 <label translate="true">Is Enabled</label>
-                <imports>
-                    <link name="disabled">${ $.provider }:data.general.switcher_disabled</link>
-                </imports>
             </settings>
             <formElements>
                 <checkbox>

--- a/app/code/Magento/InventoryCatalog/Plugin/InventoryAdminUi/Ui/DataProvider/PreventDisablingDefaultSourcePlugin.php
+++ b/app/code/Magento/InventoryCatalog/Plugin/InventoryAdminUi/Ui/DataProvider/PreventDisablingDefaultSourcePlugin.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Plugin\InventoryAdminUi\Ui\DataProvider;
+
+use Magento\InventoryCatalogApi\Api\DefaultSourceProviderInterface;
+use Magento\InventoryAdminUi\Ui\DataProvider\SourceDataProvider;
+
+class PreventDisablingDefaultSourcePlugin
+{
+    /**
+     * @var DefaultSourceProviderInterface
+     */
+    private $defaultSourceProvider;
+
+    /**
+     * @param DefaultSourceProviderInterface $defaultSourceProvider
+     */
+    public function __construct(
+        DefaultSourceProviderInterface $defaultSourceProvider
+    ) {
+        $this->defaultSourceProvider = $defaultSourceProvider;
+    }
+
+    /**
+     * @param SourceDataProvider $subject
+     * @param $result
+     * @return array
+     */
+    public function afterGetData(
+        SourceDataProvider $subject,
+        $result
+    ): array {
+        $defaultSourceCode = $this->defaultSourceProvider->getCode();
+        if (array_key_exists($defaultSourceCode, $result)) {
+            $result[$defaultSourceCode]['general']['switcher_disabled'] = true;
+        }
+        return $result;
+    }
+}

--- a/app/code/Magento/InventoryCatalog/Plugin/InventoryAdminUi/Ui/DataProvider/PreventDisablingDefaultSourcePlugin.php
+++ b/app/code/Magento/InventoryCatalog/Plugin/InventoryAdminUi/Ui/DataProvider/PreventDisablingDefaultSourcePlugin.php
@@ -28,17 +28,32 @@ class PreventDisablingDefaultSourcePlugin
 
     /**
      * @param SourceDataProvider $subject
-     * @param $result
+     * @param $meta
      * @return array
      */
-    public function afterGetData(
+    public function afterGetMeta(
         SourceDataProvider $subject,
-        $result
+        $meta
     ): array {
+        $data = $subject->getData();
         $defaultSourceCode = $this->defaultSourceProvider->getCode();
-        if (array_key_exists($defaultSourceCode, $result)) {
-            $result[$defaultSourceCode]['general']['switcher_disabled'] = true;
+        if (array_key_exists($defaultSourceCode, $data)) {
+            //$result[$defaultSourceCode]['general']['switcher_disabled'] = true;
+            $meta['general'] = [
+                'children' => [
+                    'enabled' => [
+                        'arguments' => [
+                            'data' => [
+                                'config' => [
+                                    'disabled' => true,
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ];
         }
-        return $result;
+
+        return $meta;
     }
 }

--- a/app/code/Magento/InventoryCatalog/etc/adminhtml/di.xml
+++ b/app/code/Magento/InventoryCatalog/etc/adminhtml/di.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\InventoryAdminUi\Ui\DataProvider\SourceDataProvider">
+        <plugin name="preventDisablingDefaultSourcePlugin" type="Magento\InventoryCatalog\Plugin\InventoryAdminUi\Ui\DataProvider\PreventDisablingDefaultSourcePlugin"/>
+    </type>
+</config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added Plugin to add new param `switcher_disabled` to disable 'Is Enabled' Switcher for default Source.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi[#1250](https://github.com/magento-engcom/msi/issues/1250): Prevent Disabling Default Source by Disabling 'Is Enabled' Switcher