### PR TITLE
Issue 1291 webapi broken validation

### DIFF
--- a/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CarrierLinkManagementTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CarrierLinkManagementTest.php
@@ -129,7 +129,9 @@ class CarrierLinkManagementTest extends WebapiAbstract
      * @param string $sourceCode
      * @return array
      */
-    private function getSourceDataByCode(string $sourceCode): array
+    // TODO: Test for carriers link implementation not yet available in MSI MVP.
+    // TODO: Reactivate them when custom linked carriers are available
+    /*private function getSourceDataByCode(string $sourceCode): array
     {
         $serviceInfo = [
             'rest' => [
@@ -146,12 +148,13 @@ class CarrierLinkManagementTest extends WebapiAbstract
             : $this->_webApiCall($serviceInfo, ['sourceCode' => $sourceCode]);
         self::assertArrayHasKey(SourceInterface::SOURCE_CODE, $response);
         return $response;
-    }
+    }*/
 
     /**
      * @param array $carrierData
      * @param array $expectedErrorData
      * @dataProvider failedValidationDataProvider
+     * @throws \Exception
      */
     public function testCarrierLinksValidation(array $carrierData, array $expectedErrorData)
     {
@@ -175,10 +178,10 @@ class CarrierLinkManagementTest extends WebapiAbstract
                 self::assertEquals(\Magento\Framework\Webapi\Exception::HTTP_BAD_REQUEST, $e->getCode());
             } elseif (TESTS_WEB_API_ADAPTER === self::ADAPTER_SOAP) {
                 $this->assertInstanceOf('SoapFault', $e);
-                $expectedWrappedErrors = [];
+                $expWrappedErrors = [];
                 foreach ($expectedErrorData['errors'] as $error) {
                     // @see \Magento\TestFramework\TestCase\WebapiAbstract::getActualWrappedErrors()
-                    $expectedWrappedErrors[] = [
+                    $expWrappedErrors[] = [
                         'message' => $error['message'],
                         'params' => $error['parameters'],
                     ];
@@ -188,7 +191,7 @@ class CarrierLinkManagementTest extends WebapiAbstract
                     $expectedErrorData['message'],
                     'env:Sender',
                     [],
-                    $expectedWrappedErrors
+                    $expWrappedErrors
                 );
             } else {
                 throw $e;

--- a/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CarrierLinkManagementTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CarrierLinkManagementTest.php
@@ -26,11 +26,12 @@ class CarrierLinkManagementTest extends WebapiAbstract
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source.php
      * @dataProvider dataProviderCarrierLinks
      */
-    public function testCarrierLinksManagement(array $carrierLinks)
+    // TODO: Test for carriers link implementation not yet available in MSI MVP.
+    // TODO: Reactivate them when custom linked carriers are available
+    /*public function testCarrierLinksManagement(array $carrierLinks)
     {
-        // TODO: Test for carriers link implementation not yet available in MSI MVP.
-        // TODO: Reactivate them when custom linked carriers are available
-        /*$sourceCode = 'source-code-1';
+
+        $sourceCode = 'source-code-1';
         $expectedData = [
             SourceInterface::NAME => 'source-name-1',
             SourceInterface::POSTCODE => 'source-postcode',
@@ -49,8 +50,8 @@ class CarrierLinkManagementTest extends WebapiAbstract
         );
 
         self::assertArrayHasKey(SourceInterface::CARRIER_LINKS, $sourceData);
-        self::assertEquals($expectedData[SourceInterface::CARRIER_LINKS], $sourceData[SourceInterface::CARRIER_LINKS]);*/
-    }
+        self::assertEquals($expectedData[SourceInterface::CARRIER_LINKS], $sourceData[SourceInterface::CARRIER_LINKS]);
+    }*/
 
     /**
      * @return array
@@ -101,7 +102,9 @@ class CarrierLinkManagementTest extends WebapiAbstract
      * @param array $data
      * @return void
      */
-    private function saveSource(string $sourceCode, array $data)
+    // TODO: Test for carriers link implementation not yet available in MSI MVP.
+    // TODO: Reactivate them when custom linked carriers are available
+    /*private function saveSource(string $sourceCode, array $data)
     {
         $serviceInfo = [
             'rest' => [
@@ -120,7 +123,7 @@ class CarrierLinkManagementTest extends WebapiAbstract
             $requestData['sourceCode'] = $sourceCode;
             $this->_webApiCall($serviceInfo, ['source' => $requestData]);
         }
-    }
+    }*/
 
     /**
      * @param string $sourceCode

--- a/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CarrierLinkManagementTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CarrierLinkManagementTest.php
@@ -28,7 +28,9 @@ class CarrierLinkManagementTest extends WebapiAbstract
      */
     public function testCarrierLinksManagement(array $carrierLinks)
     {
-        $sourceCode = 'source-code-1';
+        // TODO: Test for carriers link implementation not yet available in MSI MVP.
+        // TODO: Reactivate them when custom linked carriers are available
+        /*$sourceCode = 'source-code-1';
         $expectedData = [
             SourceInterface::NAME => 'source-name-1',
             SourceInterface::POSTCODE => 'source-postcode',
@@ -47,7 +49,7 @@ class CarrierLinkManagementTest extends WebapiAbstract
         );
 
         self::assertArrayHasKey(SourceInterface::CARRIER_LINKS, $sourceData);
-        self::assertEquals($expectedData[SourceInterface::CARRIER_LINKS], $sourceData[SourceInterface::CARRIER_LINKS]);
+        self::assertEquals($expectedData[SourceInterface::CARRIER_LINKS], $sourceData[SourceInterface::CARRIER_LINKS]);*/
     }
 
     /**
@@ -228,7 +230,9 @@ class CarrierLinkManagementTest extends WebapiAbstract
                     ],
                 ],
             ],
-            'carrier_codes_not_exits' => [
+            // TODO: Test for carriers link implementation not yet available in MSI MVP.
+            // TODO: Reactivate them when custom linked carriers are available
+            /*'carrier_codes_not_exits' => [
                 [
                     SourceInterface::SOURCE_CODE => 'source-code-1',
                     SourceInterface::NAME => 'source-name-1',
@@ -263,7 +267,7 @@ class CarrierLinkManagementTest extends WebapiAbstract
                         ],
                     ],
                 ],
-            ],
+            ],*/
         ];
     }
 }

--- a/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CreateTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CreateTest.php
@@ -43,16 +43,19 @@ class CreateTest extends WebapiAbstract
             SourceInterface::POSTCODE => 'source-postcode',
             SourceInterface::PHONE => 'source-phone',
             SourceInterface::FAX => 'source-fax',
-            SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 0,
+            // TODO: Test for carriers link implementation not yet available in MSI MVP.
+            // TODO: Reactivate them when custom linked carriers are available
+            SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 1,
+            //SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 0,
             SourceInterface::CARRIER_LINKS => [
-                [
+                /*[
                     SourceCarrierLinkInterface::CARRIER_CODE => 'ups',
                     SourceCarrierLinkInterface::POSITION => 100,
                 ],
                 [
                     SourceCarrierLinkInterface::CARRIER_CODE => 'usps',
                     SourceCarrierLinkInterface::POSITION => 200,
-                ],
+                ],*/
             ],
         ];
         $serviceInfo = [

--- a/app/code/Magento/InventoryApi/Test/Api/SourceRepository/UpdateTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceRepository/UpdateTest.php
@@ -43,8 +43,11 @@ class UpdateTest extends WebapiAbstract
             SourceInterface::POSTCODE => 'source-postcode-updated',
             SourceInterface::PHONE => 'source-phone-updated',
             SourceInterface::FAX => 'source-fax-updated',
-            SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 0,
-            SourceInterface::CARRIER_LINKS => [
+            // TODO: Test for carriers link implementation not yet available in MSI MVP.
+            // TODO: Reactivate them when custom linked carriers are available
+            //SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 0,
+            SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 1,
+            /*SourceInterface::CARRIER_LINKS => [
                 [
                     SourceCarrierLinkInterface::CARRIER_CODE => 'dhl',
                     SourceCarrierLinkInterface::POSITION => 2000,
@@ -53,7 +56,7 @@ class UpdateTest extends WebapiAbstract
                     SourceCarrierLinkInterface::CARRIER_CODE => 'fedex',
                     SourceCarrierLinkInterface::POSITION => 3000,
                 ],
-            ],
+            ],*/
         ];
         $serviceInfo = [
             'rest' => [

--- a/app/code/Magento/InventoryApi/Test/Api/SourceRepository/ValidationTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceRepository/ValidationTest.php
@@ -134,7 +134,7 @@ class ValidationTest extends WebapiAbstract
      * @param string $field
      * @param string|null $value
      * @param array $expectedErrorData
-     * @dataProvider failedValidationDataProvider
+     * @dataProvider failedValidationUpdateDataProvider
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source.php
      */
     public function testFailedValidationOnUpdate(string $field, $value, array $expectedErrorData)
@@ -164,7 +164,7 @@ class ValidationTest extends WebapiAbstract
      */
     public function failedValidationDataProvider(): array
     {
-        return [
+        return array_merge($this->failedValidationUpdateDataProvider(), [
             'null_' . SourceInterface::SOURCE_CODE => [
                 SourceInterface::SOURCE_CODE,
                 null,
@@ -225,6 +225,153 @@ class ValidationTest extends WebapiAbstract
                     ],
                 ],
             ],
+            'null_' . SourceInterface::NAME => [
+                SourceInterface::NAME,
+                null,
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::NAME,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'empty_' . SourceInterface::NAME => [
+                SourceInterface::NAME,
+                '',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::NAME,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'whitespaces_' . SourceInterface::NAME => [
+                SourceInterface::NAME,
+                ' ',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::NAME,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'empty_' . SourceInterface::POSTCODE => [
+                SourceInterface::POSTCODE,
+                '',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::POSTCODE,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'whitespaces_' . SourceInterface::POSTCODE => [
+                SourceInterface::POSTCODE,
+                ' ',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::POSTCODE,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'null_' . SourceInterface::POSTCODE => [
+                SourceInterface::POSTCODE,
+                null,
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::POSTCODE,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'empty_' . SourceInterface::COUNTRY_ID => [
+                SourceInterface::COUNTRY_ID,
+                '',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::COUNTRY_ID,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'whitespaces_' . SourceInterface::COUNTRY_ID => [
+                SourceInterface::COUNTRY_ID,
+                ' ',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::COUNTRY_ID,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'null_' . SourceInterface::COUNTRY_ID => [
+                SourceInterface::COUNTRY_ID,
+                null,
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::COUNTRY_ID,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * SuppressWarnings was added due to a tests on different fail types and big size of data provider
+     *
+     * @return array
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function failedValidationUpdateDataProvider(): array
+    {
+        return [
             'null_' . SourceInterface::NAME => [
                 SourceInterface::NAME,
                 null,


### PR DESCRIPTION
### Description
FIX for API functional tests.

- Fixed validation for dropped CarrierLinks logic
- Fixed wrong PUT requests during validation

### Fixed Issues (if relevant)
1. magento-engcom/msi#1291: Fix Web API tests which got broken on Validation of Shipping CarrierLinks after this logic was dropped

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
