### PR TITLE
Search by keyword in Manage Stock grid

### DIFF
--- a/app/code/Magento/Inventory/Model/Stock/SearchCriteria/CollectionProcessor/StockFilterProcessor/StockNameFilter.php
+++ b/app/code/Magento/Inventory/Model/Stock/SearchCriteria/CollectionProcessor/StockFilterProcessor/StockNameFilter.php
@@ -4,6 +4,8 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\Inventory\Model\Stock\SearchCriteria\CollectionProcessor\StockFilterProcessor;
 
 use Magento\Framework\Api\Filter;
@@ -18,10 +20,9 @@ class StockNameFilter implements CustomFilterInterface
      *
      * @param Filter $filter
      * @param AbstractDb $collection
-     * @return bool Whether the filter was applied
-     * @since 100.2.0
+     * @return bool
      */
-    public function apply(Filter $filter, AbstractDb $collection)
+    public function apply(Filter $filter, AbstractDb $collection): bool
     {
         $conditionType = $filter->getConditionType();
         $value = $filter->getValue();
@@ -30,9 +31,9 @@ class StockNameFilter implements CustomFilterInterface
             $conditionType = 'like';
             $value = '%' . $value . '%';
         }
-        $nameFilter = [$conditionType => [$value]];
+        $fieldFilter = [$conditionType => [$value]];
 
-        $collection->addFieldToFilter($filter->getField(), $nameFilter);
+        $collection->addFieldToFilter($filter->getField(), $fieldFilter);
 
         return true;
     }

--- a/app/code/Magento/Inventory/Model/Stock/SearchCriteria/CollectionProcessor/StockFilterProcessor/StockNameFilter.php
+++ b/app/code/Magento/Inventory/Model/Stock/SearchCriteria/CollectionProcessor/StockFilterProcessor/StockNameFilter.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Inventory\Model\Stock\SearchCriteria\CollectionProcessor\StockFilterProcessor;
+
+use Magento\Framework\Api\Filter;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessor\FilterProcessor\CustomFilterInterface;
+use Magento\Framework\Data\Collection\AbstractDb;
+
+class StockNameFilter implements CustomFilterInterface
+{
+
+    /**
+     * Apply Custom Filter to Collection
+     *
+     * @param Filter $filter
+     * @param AbstractDb $collection
+     * @return bool Whether the filter was applied
+     * @since 100.2.0
+     */
+    public function apply(Filter $filter, AbstractDb $collection)
+    {
+        $conditionType = $filter->getConditionType();
+        $value = $filter->getValue();
+
+        if ($conditionType === 'fulltext') {
+            $conditionType = 'like';
+            $value = '%' . $value . '%';
+        }
+        $nameFilter = [$conditionType => [$value]];
+
+        $collection->addFieldToFilter($filter->getField(), $nameFilter);
+
+        return true;
+    }
+}

--- a/app/code/Magento/Inventory/etc/di.xml
+++ b/app/code/Magento/Inventory/etc/di.xml
@@ -74,8 +74,6 @@
         <arguments>
             <argument name="processors" xsi:type="array">
                 <item name="filters" xsi:type="object">Magento\Inventory\Model\Stock\SearchCriteria\CollectionProcessor\StockFilterProcessor</item>
-                <item name="sorting" xsi:type="object">Magento\Framework\Api\SearchCriteria\CollectionProcessor\SortingProcessor</item>
-                <item name="pagination" xsi:type="object">Magento\Framework\Api\SearchCriteria\CollectionProcessor\PaginationProcessor</item>
             </argument>
         </arguments>
     </virtualType>

--- a/app/code/Magento/Inventory/etc/di.xml
+++ b/app/code/Magento/Inventory/etc/di.xml
@@ -69,6 +69,28 @@
             </argument>
         </arguments>
     </type>
+
+    <virtualType name="Magento\Inventory\Model\Stock\SearchCriteria\StockCollectionProcessor" type="Magento\Framework\Api\SearchCriteria\CollectionProcessor">
+        <arguments>
+            <argument name="processors" xsi:type="array">
+                <item name="filters" xsi:type="object">Magento\Inventory\Model\Stock\SearchCriteria\CollectionProcessor\StockFilterProcessor</item>
+                <item name="sorting" xsi:type="object">Magento\Framework\Api\SearchCriteria\CollectionProcessor\SortingProcessor</item>
+                <item name="pagination" xsi:type="object">Magento\Framework\Api\SearchCriteria\CollectionProcessor\PaginationProcessor</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Magento\Inventory\Model\Stock\SearchCriteria\CollectionProcessor\StockFilterProcessor" type="Magento\Framework\Api\SearchCriteria\CollectionProcessor\FilterProcessor">
+        <arguments>
+            <argument name="customFilters" xsi:type="array">
+                <item name="name" xsi:type="object">Magento\Inventory\Model\Stock\SearchCriteria\CollectionProcessor\StockFilterProcessor\StockNameFilter</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <type name="Magento\Inventory\Model\Stock\Command\GetList">
+        <arguments>
+            <argument name="collectionProcessor" xsi:type="object">Magento\Inventory\Model\Stock\SearchCriteria\StockCollectionProcessor</argument>
+        </arguments>
+    </type>
     <!-- StockSourceLink -->
     <preference for="Magento\InventoryApi\Api\Data\StockSourceLinkInterface" type="Magento\Inventory\Model\StockSourceLink"/>
     <preference for="Magento\InventoryApi\Api\Data\StockSourceLinkSearchResultsInterface" type="Magento\Inventory\Model\StockSourceLinkSearchResults"/>


### PR DESCRIPTION
fixes #1222

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When searching for a keyword in Manage Stock grid, the search filteron name is considered a fulltext search and then translated in a 'equal to' query for collection filtering.
I have added a StockCollectionProcessor virtual type that uses a StockFilterProcessor to apply a StockNameFilter, that eventually translates the fulltext filter to a like query.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#1222: Cannot search stocks in stock grid by keyword #1222 
2. magento-engcom/msi#325: Search by keyword by part of the name of Stock doesn't work in Manage Stocks grid #325

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. New Stock "Test Stock 1" created
2. Try to do "Search by keyword" with word "Test"
3. Test Stock 1 is returned
4. Try to add further filters to search, as ID
5. Correct results are returned

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
