### PR TITLE
MSI-666: when duplicate a product set as disabled

### DIFF
--- a/app/code/Magento/InventoryCatalogAdminUi/Plugin/Catalog/CopySourceItemsPlugin.php
+++ b/app/code/Magento/InventoryCatalogAdminUi/Plugin/Catalog/CopySourceItemsPlugin.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\InventoryCatalogAdminUi\Plugin\Catalog;
 
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\Product\Copier;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SearchCriteriaBuilderFactory;
@@ -63,6 +64,8 @@ class CopySourceItemsPlugin
         Product $product
     ) {
         $this->copySourceItems($product->getSku(), $result->getSku());
+        $result->setStatus(Status::STATUS_DISABLED);
+
         return $result;
     }
 


### PR DESCRIPTION
### Description
If we duplicate a product from magento backend, we don't make the "old" behaviour from Magento and set the product out of stock.
We just copy 1:1 the stock item and put the product as disabled to avoid frontend error about quantity.

### Fixed Issues (if relevant)
Issue: #666 

### Manual testing scenarios
Duplicate a product from magento backend

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
