### PR TITLE
Fix 'Change Default state of "Notify Quantity Use default" checkbox on "checked" the first time user assigns sources to a product'

### DIFF
--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/web/js/components/use-config-settings.js
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/web/js/components/use-config-settings.js
@@ -14,6 +14,17 @@ define([
             linkedValue: ''
         },
 
+        /** @inheritdoc */
+        initialize: function () {
+            this._super();
+
+            if (this.linkedValue() === '') {
+                this.checked(true);
+            }
+
+            return this;
+        },
+
         /**
          * @returns {Element}
          */
@@ -32,17 +43,6 @@ define([
             }
 
             this._super(newChecked);
-        },
-
-        /** @inheritdoc */
-        initialize: function () {
-            this._super();
-
-            if (this.linkedValue() === "") {
-                this.checked(true);
-            }
-
-            return this;
-        },
+        }
     });
 });

--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/web/js/components/use-config-settings.js
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/web/js/components/use-config-settings.js
@@ -32,6 +32,17 @@ define([
             }
 
             this._super(newChecked);
-        }
+        },
+
+        /** @inheritdoc */
+        initialize: function () {
+            this._super();
+
+            if (this.linkedValue() === "") {
+                this.checked(true);
+            }
+
+            return this;
+        },
     });
 });


### PR DESCRIPTION
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#1282: Change Default state of "Notify Quantity Use default" checkbox on "checked" the first time user assigns sources to a product

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
