### PR TITLE
FIX for issue#1341: Preventing assigning product to default source

### DIFF
--- a/app/code/Magento/InventoryApi/Test/_files/products.php
+++ b/app/code/Magento/InventoryApi/Test/_files/products.php
@@ -42,16 +42,22 @@ $stockData = [
     ],
     'SKU-4' => [
         'use_config_manage_stock' => false
-    ]
+    ],
+    'SKU-5' => [
+        'qty' => 0,
+        'is_in_stock' => false,
+        'manage_stock' => true
+    ],
 ];
 $productsData = [
     1 => 'Orange',
     2 => 'Blue',
     3 => 'White',
-    4 => 'Purple'
+    4 => 'Purple',
+    5 => 'Black'
 ];
 
-for ($i = 1; $i <= 4; $i++) {
+for ($i = 1; $i <= 5; $i++) {
     $product = $productFactory->create();
     $product->setTypeId(Type::TYPE_SIMPLE)
         ->setAttributeSetId(4)
@@ -78,7 +84,7 @@ if ($moduleManager->isEnabled('Magento_InventoryCatalog')) {
 
     // Unassign created product from default Source
     $searchCriteria = $searchCriteriaBuilder
-        ->addFilter(SourceItemInterface::SKU, ['SKU-1', 'SKU-2', 'SKU-3', 'SKU-4'], 'in')
+        ->addFilter(SourceItemInterface::SKU, ['SKU-1', 'SKU-2', 'SKU-3', 'SKU-4', 'SKU-5'], 'in')
         ->addFilter(SourceItemInterface::SOURCE_CODE, $defaultSourceProvider->getCode())
         ->create();
     $sourceItems = $sourceItemRepository->getList($searchCriteria)->getItems();

--- a/app/code/Magento/InventoryCatalog/Model/GetDefaultSourceItemBySku.php
+++ b/app/code/Magento/InventoryCatalog/Model/GetDefaultSourceItemBySku.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Model;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\SourceItemRepositoryInterface;
+use Magento\InventoryCatalogApi\Api\DefaultSourceProviderInterface;
+
+/**
+ * Get the default source item by product sku or return null if not existing
+ */
+class GetDefaultSourceItemBySku
+{
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var DefaultSourceProviderInterface
+     */
+    private $defaultSourceProvider;
+
+    /**
+     * @var SourceItemRepositoryInterface
+     */
+    private $sourceItemRepository;
+
+    /**
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param DefaultSourceProviderInterface $defaultSourceProvider
+     * @param SourceItemRepositoryInterface $sourceItemRepository
+     */
+    public function __construct(
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        DefaultSourceProviderInterface $defaultSourceProvider,
+        SourceItemRepositoryInterface $sourceItemRepository
+    ) {
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->defaultSourceProvider = $defaultSourceProvider;
+        $this->sourceItemRepository = $sourceItemRepository;
+    }
+
+    /**
+     * @param string $productSku
+     * @return SourceItemInterface|null
+     */
+    public function execute(string $productSku): ?SourceItemInterface
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter(SourceItemInterface::SKU, $productSku)
+            ->addFilter(SourceItemInterface::SOURCE_CODE, $this->defaultSourceProvider->getCode())
+            ->create();
+
+        $sourceItems = $this->sourceItemRepository->getList($searchCriteria)->getItems();
+        return count($sourceItems) ? reset($sourceItems) : null;
+    }
+}

--- a/app/code/Magento/InventoryCatalog/Plugin/CatalogInventory/UpdateSourceItemAtLegacyStockItemSavePlugin.php
+++ b/app/code/Magento/InventoryCatalog/Plugin/CatalogInventory/UpdateSourceItemAtLegacyStockItemSavePlugin.php
@@ -11,6 +11,7 @@ use Magento\CatalogInventory\Model\ResourceModel\Stock\Item as ItemResourceModel
 use Magento\CatalogInventory\Model\Stock\Item;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Model\AbstractModel;
+use Magento\InventoryCatalog\Model\GetDefaultSourceItemBySku;
 use Magento\InventoryCatalogApi\Model\GetProductTypesBySkusInterface;
 use Magento\InventoryCatalogApi\Model\GetSkusByProductIdsInterface;
 use Magento\InventoryCatalog\Model\UpdateSourceItemBasedOnLegacyStockItem;
@@ -48,24 +49,32 @@ class UpdateSourceItemAtLegacyStockItemSavePlugin
     private $getSkusByProductIds;
 
     /**
+     * @var GetDefaultSourceItemBySku
+     */
+    private $getDefaultSourceItemBySku;
+
+    /**
      * @param UpdateSourceItemBasedOnLegacyStockItem $updateSourceItemBasedOnLegacyStockItem
      * @param ResourceConnection $resourceConnection
      * @param IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemManagementAllowedForProductType
      * @param GetProductTypesBySkusInterface $getProductTypeBySku
      * @param GetSkusByProductIdsInterface $getSkusByProductIds
+     * @param GetDefaultSourceItemBySku $getDefaultSourceItemBySku
      */
     public function __construct(
         UpdateSourceItemBasedOnLegacyStockItem $updateSourceItemBasedOnLegacyStockItem,
         ResourceConnection $resourceConnection,
         IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemManagementAllowedForProductType,
         GetProductTypesBySkusInterface $getProductTypeBySku,
-        GetSkusByProductIdsInterface $getSkusByProductIds
+        GetSkusByProductIdsInterface $getSkusByProductIds,
+        GetDefaultSourceItemBySku $getDefaultSourceItemBySku
     ) {
         $this->updateSourceItemBasedOnLegacyStockItem = $updateSourceItemBasedOnLegacyStockItem;
         $this->resourceConnection = $resourceConnection;
         $this->isSourceItemManagementAllowedForProductType = $isSourceItemManagementAllowedForProductType;
         $this->getProductTypeBySku = $getProductTypeBySku;
         $this->getSkusByProductIds = $getSkusByProductIds;
+        $this->getDefaultSourceItemBySku = $getDefaultSourceItemBySku;
     }
 
     /**
@@ -87,7 +96,9 @@ class UpdateSourceItemAtLegacyStockItemSavePlugin
 
             $typeId = $this->getTypeId($legacyStockItem);
             if ($this->isSourceItemManagementAllowedForProductType->execute($typeId)) {
-                $this->updateSourceItemBasedOnLegacyStockItem->execute($legacyStockItem);
+                if ($this->shouldAlignDefaultSourceWithLegacy($legacyStockItem)) {
+                    $this->updateSourceItemBasedOnLegacyStockItem->execute($legacyStockItem);
+                }
             }
 
             $connection->commit();
@@ -100,8 +111,26 @@ class UpdateSourceItemAtLegacyStockItemSavePlugin
     }
 
     /**
+     * Return true if legacy stock item should update default source (if existing)
+     * @param Item $legacyStockItem
+     * @return bool
+     * @throws \Magento\Framework\Exception\InputException
+     */
+    private function shouldAlignDefaultSourceWithLegacy(Item $legacyStockItem): bool
+    {
+        $productSku = $this->getSkusByProductIds
+            ->execute([$legacyStockItem->getProductId()])[$legacyStockItem->getProductId()];
+
+        return
+            $legacyStockItem->getIsInStock() ||
+            ($legacyStockItem->getQty() !== (float) 0) ||
+            ($this->getDefaultSourceItemBySku->execute($productSku) !== null);
+    }
+
+    /**
      * @param Item $legacyStockItem
      * @return string
+     * @throws \Magento\Framework\Exception\InputException
      */
     private function getTypeId(Item $legacyStockItem): string
     {

--- a/app/code/Magento/InventoryCatalog/Plugin/CatalogInventory/UpdateSourceItemAtLegacyStockItemSavePlugin.php
+++ b/app/code/Magento/InventoryCatalog/Plugin/CatalogInventory/UpdateSourceItemAtLegacyStockItemSavePlugin.php
@@ -121,10 +121,11 @@ class UpdateSourceItemAtLegacyStockItemSavePlugin
         $productSku = $this->getSkusByProductIds
             ->execute([$legacyStockItem->getProductId()])[$legacyStockItem->getProductId()];
 
-        return
-            $legacyStockItem->getIsInStock() ||
+        $result = $legacyStockItem->getIsInStock() ||
             ((float) $legacyStockItem->getQty() !== (float) 0) ||
             ($this->getDefaultSourceItemBySku->execute($productSku) !== null);
+
+        return $result;
     }
 
     /**

--- a/app/code/Magento/InventoryCatalog/Plugin/CatalogInventory/UpdateSourceItemAtLegacyStockItemSavePlugin.php
+++ b/app/code/Magento/InventoryCatalog/Plugin/CatalogInventory/UpdateSourceItemAtLegacyStockItemSavePlugin.php
@@ -123,7 +123,7 @@ class UpdateSourceItemAtLegacyStockItemSavePlugin
 
         return
             $legacyStockItem->getIsInStock() ||
-            ($legacyStockItem->getQty() !== (float) 0) ||
+            ((float) $legacyStockItem->getQty() !== (float) 0) ||
             ($this->getDefaultSourceItemBySku->execute($productSku) !== null);
     }
 

--- a/app/code/Magento/InventoryCatalog/Test/Integration/CatalogInventory/Model/ResourceModel/Stock/Status/AddStockDataToCollectionOnDefaultStockTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/CatalogInventory/Model/ResourceModel/Stock/Status/AddStockDataToCollectionOnDefaultStockTest.php
@@ -54,7 +54,7 @@ class AddStockDataToCollectionOnDefaultStockTest extends TestCase
     {
         return [
             [3, true],
-            [4, false],
+            [5, false],
         ];
     }
 }

--- a/app/code/Magento/InventoryCatalog/Test/Integration/CatalogInventory/Model/ResourceModel/Stock/Status/AddStockStatusToSelectOnDefaultStockTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/CatalogInventory/Model/ResourceModel/Stock/Status/AddStockStatusToSelectOnDefaultStockTest.php
@@ -47,7 +47,7 @@ class AddStockStatusToSelectOnDefaultStockTest extends TestCase
     {
         $actualIsSalableCount = $actualNotSalableCount = 0;
         $expectedIsSalableCount = 3;
-        $expectedNotSalableCount = 1;
+        $expectedNotSalableCount = 2;
 
         /** @var Collection $collection */
         $collection = Bootstrap::getObjectManager()->create(Collection::class);

--- a/app/code/Magento/InventoryCatalog/Test/Integration/CatalogInventory/Model/ResourceModel/Stock/Status/AddStockStatusToSelectTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/CatalogInventory/Model/ResourceModel/Stock/Status/AddStockStatusToSelectTest.php
@@ -85,9 +85,9 @@ class AddStockStatusToSelectTest extends TestCase
     public function addStockStatusToSelectDataProvider(): array
     {
         return [
-            ['eu_website', 2, 2],
-            ['us_website', 1, 3],
-            ['global_website', 3, 1],
+            ['eu_website', 2, 3],
+            ['us_website', 1, 4],
+            ['global_website', 3, 2],
         ];
     }
 

--- a/app/code/Magento/InventoryCatalog/Test/Integration/GetDefaultSourceItemBySkuTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/GetDefaultSourceItemBySkuTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright :copyright: Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);

--- a/app/code/Magento/InventoryCatalog/Test/Integration/GetDefaultSourceItemBySkuTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/GetDefaultSourceItemBySkuTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright :copyright: Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Test\Integration;
+
+use Magento\InventoryCatalog\Model\GetDefaultSourceItemBySku;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class GetDefaultSourceItemBySkuTest extends TestCase
+{
+    /**
+     * @var GetDefaultSourceItemBySku
+     */
+    private $getDefaultSourceItemBySku;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->getDefaultSourceItemBySku = Bootstrap::getObjectManager()->get(GetDefaultSourceItemBySku::class);
+    }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryCatalog/Test/_files/source_items_on_mixed_sources.php
+     */
+    public function testExecute()
+    {
+        self::assertNotNull(
+            $this->getDefaultSourceItemBySku->execute('SKU-1'),
+            'Unable to find default source_item for a product assigned to Default source only'
+        );
+        self::assertNotNull(
+            $this->getDefaultSourceItemBySku->execute('SKU-2'),
+            'Unable to find default source_item for a product assigned to Default source and others'
+        );
+        self::assertNull(
+            $this->getDefaultSourceItemBySku->execute('SKU-3'),
+            'Returned a wrong default source_item for a product assigned elsewhere'
+        );
+    }
+}

--- a/app/code/Magento/InventoryCatalog/Test/Integration/GetProductIdsBySkusTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/GetProductIdsBySkusTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright :copyright: Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);

--- a/app/code/Magento/InventoryCatalog/Test/Integration/GetSkusByProductIdsTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/GetSkusByProductIdsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright :copyright: Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);

--- a/app/code/Magento/InventoryCatalog/Test/Integration/InvalidateIndexOnConfigChangeTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/InvalidateIndexOnConfigChangeTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright :copyright: Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);

--- a/app/code/Magento/InventoryCatalog/Test/Integration/UpdateDefaultSourceItemAtLegacyStockItemSaveTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/UpdateDefaultSourceItemAtLegacyStockItemSaveTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright :copyright: Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);

--- a/app/code/Magento/InventoryCatalog/Test/Integration/UpdateDefaultSourceItemAtLegacyStockItemSaveTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/UpdateDefaultSourceItemAtLegacyStockItemSaveTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright :copyright: Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Test\Integration;
+
+use Magento\CatalogInventory\Api\StockRegistryInterface;
+use Magento\InventoryCatalog\Model\GetDefaultSourceItemBySku;
+use PHPUnit\Framework\TestCase;
+use Magento\TestFramework\Helper\Bootstrap;
+
+class UpdateDefaultSourceItemAtLegacyStockItemSaveTest extends TestCase
+{
+    /**
+     * @var StockRegistryInterface
+     */
+    private $stockRegistry;
+
+    /**
+     * @var GetDefaultSourceItemBySku
+     */
+    private $getDefaultSourceItemBySku;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->stockRegistry = Bootstrap::getObjectManager()->create(StockRegistryInterface::class);
+        $this->getDefaultSourceItemBySku = Bootstrap::getObjectManager()->get(GetDefaultSourceItemBySku::class);
+    }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryCatalog/Test/_files/source_items_on_mixed_sources.php
+     * @magentoDbIsolation enabled
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function testSaveLegacyStockItemAssignedToDefaultSource()
+    {
+        $stockItem = $this->stockRegistry->getStockItemBySku('SKU-1');
+        $stockItem->setQty(10);
+        $this->stockRegistry->updateStockItemBySku('SKU-1', $stockItem);
+
+        $defaultSourceItem = $this->getDefaultSourceItemBySku->execute('SKU-1');
+        self::assertEquals(
+            10,
+            $defaultSourceItem->getQuantity(),
+            'Quantity is not updated in default source when legacy stock is updated and product was'
+                . 'previously assigned to default source'
+        );
+    }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryCatalog/Test/_files/source_items_on_mixed_sources.php
+     * @magentoDbIsolation enabled
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function testSaveLegacyStockItemNotAssignedToDefaultSource()
+    {
+        $stockItem = $this->stockRegistry->getStockItemBySku('SKU-2');
+        $stockItem->setQty(10);
+        $this->stockRegistry->updateStockItemBySku('SKU-2', $stockItem);
+
+        $defaultSourceItem = $this->getDefaultSourceItemBySku->execute('SKU-2');
+        self::assertEquals(
+            10,
+            $defaultSourceItem->getQuantity(),
+            'Quantity is not updated in default source when legacy stock is updated'
+        );
+
+        // SKU-3 is out of stock and not assigned to default source
+        $stockItem = $this->stockRegistry->getStockItemBySku('SKU-3');
+        $stockItem->setQty(10);
+        $this->stockRegistry->updateStockItemBySku('SKU-3', $stockItem);
+
+        $defaultSourceItem = $this->getDefaultSourceItemBySku->execute('SKU-3');
+        self::assertEquals(
+            10,
+            $defaultSourceItem->getQuantity(),
+            'Quantity is not updated in default source when legacy stock is updated and product was not '
+                . 'previously assigned to default source'
+        );
+    }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryCatalog/Test/_files/source_items_on_mixed_sources.php
+     * @magentoDbIsolation enabled
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function testSaveLegacyStockItemWithoutDefaultSourceAssignment()
+    {
+        // SKU-3 is out of stock and not assigned to default source
+        $stockItem = $this->stockRegistry->getStockItemBySku('SKU-3');
+        $stockItem->setQty(0);
+        $stockItem->setIsInStock(false);
+        $this->stockRegistry->updateStockItemBySku('SKU-3', $stockItem);
+
+        $defaultSourceItem = $this->getDefaultSourceItemBySku->execute('SKU-3');
+        self::assertNull(
+            $defaultSourceItem,
+            'Product is assigned to default source on legacy stock item save even if it should not be'
+        );
+
+        // SKU-5 is out of stock and not assigned to default source
+        $stockItem = $this->stockRegistry->getStockItemBySku('SKU-5');
+        $stockItem->setQty(1);
+        $stockItem->setIsInStock(true);
+        $this->stockRegistry->updateStockItemBySku('SKU-5', $stockItem);
+
+        $defaultSourceItem = $this->getDefaultSourceItemBySku->execute('SKU-5');
+        self::assertNotNull(
+            $defaultSourceItem,
+            'Product is not assigned to default source on legacy stock item save even if it should be'
+        );
+    }
+}

--- a/app/code/Magento/InventoryCatalog/Test/Integration/UpdateDefaultSourceItemAtProductSaveTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/UpdateDefaultSourceItemAtProductSaveTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright :copyright: Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);

--- a/app/code/Magento/InventoryCatalog/Test/Integration/UpdateDefaultSourceItemAtProductSaveTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Integration/UpdateDefaultSourceItemAtProductSaveTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright :copyright: Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Test\Integration;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\InventoryCatalog\Model\GetDefaultSourceItemBySku;
+use PHPUnit\Framework\TestCase;
+use Magento\TestFramework\Helper\Bootstrap;
+
+class UpdateDefaultSourceItemAtProductSaveTest extends TestCase
+{
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    /**
+     * @var GetDefaultSourceItemBySku
+     */
+    private $getDefaultSourceItemBySku;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->productRepository = Bootstrap::getObjectManager()->create(ProductRepositoryInterface::class);
+        $this->getDefaultSourceItemBySku = Bootstrap::getObjectManager()->get(GetDefaultSourceItemBySku::class);
+    }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryCatalog/Test/_files/source_items_on_mixed_sources.php
+     * @magentoDbIsolation enabled
+     */
+    public function testSaveOutOfStockProductNotAssignedToDefaultSource()
+    {
+        // SKU-3 is out of stock
+        $product = $this->productRepository->get('SKU-3');
+        $this->productRepository->save($product);
+
+        $defaultSourceItem = $this->getDefaultSourceItemBySku->execute('SKU-3');
+        self::assertNull(
+            $defaultSourceItem,
+            'Default source was accidentally created on a product not assigned while saving it'
+        );
+    }
+}

--- a/app/code/Magento/InventoryCatalog/Test/_files/source_items_on_mixed_sources.php
+++ b/app/code/Magento/InventoryCatalog/Test/_files/source_items_on_mixed_sources.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Framework\Api\DataObjectHelper;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\Data\SourceItemInterfaceFactory;
+use Magento\InventoryApi\Api\SourceItemsSaveInterface;
+use Magento\InventoryCatalogApi\Api\DefaultSourceProviderInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/** @var DataObjectHelper $dataObjectHelper */
+$dataObjectHelper = Bootstrap::getObjectManager()->get(DataObjectHelper::class);
+
+/** @var SourceItemInterfaceFactory $sourceItemFactory */
+$sourceItemFactory = Bootstrap::getObjectManager()->get(SourceItemInterfaceFactory::class);
+
+/** @var  SourceItemsSaveInterface $sourceItemsSave */
+$sourceItemsSave = Bootstrap::getObjectManager()->get(SourceItemsSaveInterface::class);
+
+/** @var DefaultSourceProviderInterface $defaultSourceProvider */
+$defaultSourceProvider = Bootstrap::getObjectManager()->get(DefaultSourceProviderInterface::class);
+
+$sourcesItemsData = [
+    [
+        SourceItemInterface::SOURCE_CODE => $defaultSourceProvider->getCode(),
+        SourceItemInterface::SKU => 'SKU-1',
+        SourceItemInterface::QUANTITY => 1,
+        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
+    ],
+    [
+        SourceItemInterface::SOURCE_CODE => $defaultSourceProvider->getCode(),
+        SourceItemInterface::SKU => 'SKU-2',
+        SourceItemInterface::QUANTITY => 1,
+        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
+    ],
+    [
+        SourceItemInterface::SOURCE_CODE => 'eu-1',
+        SourceItemInterface::SKU => 'SKU-2',
+        SourceItemInterface::QUANTITY => 1,
+        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
+    ],
+    [
+        SourceItemInterface::SOURCE_CODE => 'eu-1',
+        SourceItemInterface::SKU => 'SKU-3',
+        SourceItemInterface::QUANTITY => 1,
+        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
+    ],
+];
+
+$sourceItems = [];
+foreach ($sourcesItemsData as $sourceItemData) {
+    /** @var SourceItemInterface $source */
+    $sourceItem = $sourceItemFactory->create();
+    $dataObjectHelper->populateWithArray($sourceItem, $sourceItemData, SourceItemInterface::class);
+    $sourceItems[] = $sourceItem;
+}
+
+$sourceItemsSave->execute($sourceItems);

--- a/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Adapter/Mysql/Aggregation/DataProvider/ApplyStockConditionToSelectTest.php
+++ b/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Adapter/Mysql/Aggregation/DataProvider/ApplyStockConditionToSelectTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright :copyright: Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);

--- a/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Adapter/Mysql/Aggregation/DataProvider/ApplyStockConditionToSelectWithDefaultStockTest.php
+++ b/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Adapter/Mysql/Aggregation/DataProvider/ApplyStockConditionToSelectWithDefaultStockTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright :copyright: Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);


### PR DESCRIPTION
Products not assigned to default source should not be automatically assigned when the legacy stock update is called with
out of stock, zero quantity and not previously assigned default source

### Fixed Issues (if relevant)
1. magento-engcom/msi#1341: Prevent assigning Product to Default source

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
