### PR TITLE
MSI-1383: Fix exception message: Request does not match any route in InventoryApi tests

### DIFF
--- a/app/code/Magento/InventoryApi/Test/Api/SourceItemsSave/SaveTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceItemsSave/SaveTest.php
@@ -50,8 +50,8 @@ class SaveTest extends WebapiAbstract
                 'httpMethod' => Request::HTTP_METHOD_POST,
             ],
             'soap' => [
-                'service' => self::SERVICE_NAME_SAVE,
-                'operation' => self::SERVICE_NAME_SAVE . 'Execute',
+                'service' => self::SERVICE_NAME_DELETE,
+                'operation' => self::SERVICE_NAME_DELETE . 'Execute',
             ],
         ];
         $this->_webApiCall($serviceInfo, ['sourceItems' => $sourceItems]);

--- a/app/code/Magento/InventoryApi/Test/Api/SourceItemsSave/SaveTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceItemsSave/SaveTest.php
@@ -68,21 +68,25 @@ class SaveTest extends WebapiAbstract
             [
                 SourceItemInterface::SOURCE_CODE => 'eu-1',
                 SourceItemInterface::SKU => 'SKU-1',
+                SourceItemInterface::QUANTITY => 5.5,
+                SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
             ],
             [
                 SourceItemInterface::SOURCE_CODE => 'eu-2',
                 SourceItemInterface::SKU => 'SKU-1',
+                SourceItemInterface::QUANTITY => 3,
+                SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
             ],
         ];
         $serviceInfo = [
             'rest' => [
                 'resourcePath' => self::RESOURCE_PATH . '?'
                     . http_build_query(['sourceItems' => $sourceItems]),
-                'httpMethod' => Request::HTTP_METHOD_DELETE,
+                'httpMethod' => Request::HTTP_METHOD_POST,
             ],
             'soap' => [
-                'service' => self::SERVICE_NAME_DELETE,
-                'operation' => self::SERVICE_NAME_DELETE . 'Execute',
+                'service' => self::SERVICE_NAME_SAVE,
+                'operation' => self::SERVICE_NAME_SAVE . 'Execute',
             ],
         ];
         (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST)

--- a/app/code/Magento/InventoryApi/Test/Api/SourceItemsSave/SaveTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceItemsSave/SaveTest.php
@@ -50,8 +50,8 @@ class SaveTest extends WebapiAbstract
                 'httpMethod' => Request::HTTP_METHOD_POST,
             ],
             'soap' => [
-                'service' => self::SERVICE_NAME_DELETE,
-                'operation' => self::SERVICE_NAME_DELETE . 'Execute',
+                'service' => self::SERVICE_NAME_SAVE,
+                'operation' => self::SERVICE_NAME_SAVE . 'Execute',
             ],
         ];
         $this->_webApiCall($serviceInfo, ['sourceItems' => $sourceItems]);
@@ -85,8 +85,8 @@ class SaveTest extends WebapiAbstract
                 'httpMethod' => Request::HTTP_METHOD_POST,
             ],
             'soap' => [
-                'service' => self::SERVICE_NAME_SAVE,
-                'operation' => self::SERVICE_NAME_SAVE . 'Execute',
+                'service' => self::SERVICE_NAME_DELETE,
+                'operation' => self::SERVICE_NAME_DELETE . 'Execute',
             ],
         ];
         (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST)
@@ -102,7 +102,17 @@ class SaveTest extends WebapiAbstract
     {
         $requestData = [
             'searchCriteria' => [
-                SearchCriteria::FILTER_GROUPS => [],
+                SearchCriteria::FILTER_GROUPS => [
+                    [
+                        'filters' => [
+                            [
+                                'field' => SourceItemInterface::SKU,
+                                'value' => 'SKU-1',
+                                'condition_type' => 'eq',
+                            ],
+                        ],
+                    ],
+                ],
                 SearchCriteria::PAGE_SIZE => 10
             ],
         ];

--- a/app/code/Magento/InventoryApi/Test/Api/StockSourceLink/StockSourceLinksSaveTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/StockSourceLink/StockSourceLinksSaveTest.php
@@ -67,10 +67,12 @@ class StockSourceLinksSaveTest extends WebapiAbstract
             [
                 StockSourceLinkInterface::SOURCE_CODE => 'eu-1',
                 StockSourceLinkInterface::STOCK_ID => 10,
+                StockSourceLinkInterface::PRIORITY => 1,
             ],
             [
                 StockSourceLinkInterface::SOURCE_CODE => 'eu-2',
                 StockSourceLinkInterface::STOCK_ID => 10,
+                StockSourceLinkInterface::PRIORITY => 2,
             ],
         ];
 
@@ -78,11 +80,11 @@ class StockSourceLinksSaveTest extends WebapiAbstract
             'rest' => [
                 'resourcePath' => self::RESOURCE_PATH . '?'
                     . http_build_query(['links' => $links]),
-                'httpMethod' => Request::HTTP_METHOD_DELETE,
+                'httpMethod' => Request::HTTP_METHOD_POST,
             ],
             'soap' => [
-                'service' => self::SERVICE_NAME_DELETE,
-                'operation' => self::SERVICE_NAME_DELETE . 'Execute',
+                'service' => self::SERVICE_NAME_SAVE,
+                'operation' => self::SERVICE_NAME_SAVE . 'Execute',
             ],
         ];
 

--- a/app/code/Magento/InventoryApi/Test/Api/StockSourceLink/StockSourceLinksSaveTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/StockSourceLink/StockSourceLinksSaveTest.php
@@ -83,8 +83,8 @@ class StockSourceLinksSaveTest extends WebapiAbstract
                 'httpMethod' => Request::HTTP_METHOD_POST,
             ],
             'soap' => [
-                'service' => self::SERVICE_NAME_SAVE,
-                'operation' => self::SERVICE_NAME_SAVE . 'Execute',
+                'service' => self::SERVICE_NAME_DELETE,
+                'operation' => self::SERVICE_NAME_DELETE . 'Execute',
             ],
         ];
 


### PR DESCRIPTION
### Description
DELETE action verb for Web API is no longer available for removing Stock Source Links. Now we use `POST /V1/inventory/stock-source-links-delete`

DELETE action verb for Web API is no longer available for removing Source Items. Now we use `POST /V1/inventory/stock-source-links-delete`

Tests were failing during teardown. Additionally was changed tests data to satisfy the validation.

### Fixed Issues (if relevant)
1. magento-engcom/msi#1383: Exception: {"message":"Request does not match any route."} in InventoryApi tests

### Manual testing scenarios
1. Run api-functional tests

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
