### PR TITLE
Simplify method

### DIFF
--- a/app/code/Magento/InventoryConfiguration/Model/IsSourceItemManagementAllowedForProductType.php
+++ b/app/code/Magento/InventoryConfiguration/Model/IsSourceItemManagementAllowedForProductType.php
@@ -33,6 +33,6 @@ class IsSourceItemManagementAllowedForProductType implements IsSourceItemManagem
      */
     public function execute(string $productType): bool
     {
-        return in_array($productType, array_keys(array_filter($this->stockConfiguration->getIsQtyTypeIds())), true);
+        return array_key_exists($productType, array_filter($this->stockConfiguration->getIsQtyTypeIds()));
     }
 }

--- a/app/code/Magento/InventoryConfiguration/Test/Unit/Model/IsSourceItemManagementAllowedForProductTypeTest.php
+++ b/app/code/Magento/InventoryConfiguration/Test/Unit/Model/IsSourceItemManagementAllowedForProductTypeTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryConfiguration\Test\Unit\Model;
+
+use Magento\CatalogInventory\Api\StockConfigurationInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\InventoryConfiguration\Model\IsSourceItemManagementAllowedForProductType;
+use PHPUnit\Framework\TestCase;
+
+class IsSourceItemManagementAllowedForProductTypeTest extends TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $stockConfiguration;
+
+    /**
+     * @var IsSourceItemManagementAllowedForProductType
+     */
+    private $isSourceItemManagementAllowedForProductType;
+
+    protected function setUp()
+    {
+        $this->stockConfiguration = $this->getMockBuilder(StockConfigurationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->isSourceItemManagementAllowedForProductType = (new ObjectManager($this))->getObject(
+            IsSourceItemManagementAllowedForProductType::class,
+            [
+                'stockConfiguration' => $this->stockConfiguration,
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider executeDataProvider
+     */
+    public function testExecute($productType, $expectedResult)
+    {
+        $configData = [
+            'simple' => true,
+            'virtual' => true,
+            'bundle' => false,
+            'downloadable' => true,
+            'configurable' => false,
+            'grouped' => false,
+        ];
+
+        $this->stockConfiguration->expects($this->once())
+            ->method('getIsQtyTypeIds')
+            ->willReturn($configData);
+
+        $this->assertEquals($expectedResult, $this->isSourceItemManagementAllowedForProductType->execute($productType));
+    }
+
+    public function executeDataProvider()
+    {
+        return [
+            ['simple', true],
+            ['virtual', true],
+            ['bundle', false],
+            ['downloadable', true],
+            ['configurable', false],
+            ['grouped', false],
+        ];
+    }
+}


### PR DESCRIPTION
This small PR simplifies `\Magento\InventoryConfiguration\Model\IsSourceItemManagementAllowedForProductType::execute()` method leaving the semantic as is.