### PR TITLE
Change format of Reservation metadata to JSON

### DIFF
--- a/app/code/Magento/InventorySales/Model/PlaceReservationsForSalesEvent.php
+++ b/app/code/Magento/InventorySales/Model/PlaceReservationsForSalesEvent.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventorySales\Model;
 
+use Magento\Framework\Serialize\SerializerInterface;
 use Magento\InventoryReservationsApi\Model\AppendReservationsInterface;
 use Magento\InventoryReservationsApi\Model\ReservationBuilderInterface;
 use Magento\InventorySalesApi\Api\Data\ItemToSellInterface;
@@ -48,6 +49,11 @@ class PlaceReservationsForSalesEvent implements PlaceReservationsForSalesEventIn
     private $isSourceItemManagementAllowedForProductType;
 
     /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
      * @param ReservationBuilderInterface $reservationBuilder
      * @param AppendReservationsInterface $appendReservations
      * @param StockResolverInterface $stockResolver
@@ -59,13 +65,15 @@ class PlaceReservationsForSalesEvent implements PlaceReservationsForSalesEventIn
         AppendReservationsInterface $appendReservations,
         StockResolverInterface $stockResolver,
         GetProductTypesBySkusInterface $getProductTypesBySkus,
-        IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemManagementAllowedForProductType
+        IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemManagementAllowedForProductType,
+        SerializerInterface $serializer
     ) {
         $this->reservationBuilder = $reservationBuilder;
         $this->appendReservations = $appendReservations;
         $this->stockResolver = $stockResolver;
         $this->getProductTypesBySkus = $getProductTypesBySkus;
         $this->isSourceItemManagementAllowedForProductType = $isSourceItemManagementAllowedForProductType;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -97,12 +105,7 @@ class PlaceReservationsForSalesEvent implements PlaceReservationsForSalesEventIn
                     ->setSku($item->getSku())
                     ->setQuantity((float)$item->getQuantity())
                     ->setStockId($stockId)
-                    ->setMetadata(sprintf(
-                        '%s:%s:%s',
-                        $salesEvent->getType(),
-                        $salesEvent->getObjectType(),
-                        $salesEvent->getObjectId()
-                    ))
+                    ->setMetadata($this->serializer->serialize($salesEvent->toArray()))
                     ->build();
             }
         }

--- a/app/code/Magento/InventorySales/Model/SalesEvent.php
+++ b/app/code/Magento/InventorySales/Model/SalesEvent.php
@@ -64,4 +64,16 @@ class SalesEvent implements SalesEventInterface
     {
         return $this->objectId;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray(): array
+    {
+        return [
+            'event_type' => $this->getType(),
+            'object_type' => $this->getObjectType(),
+            'object_id' => $this->getObjectId(),
+        ];
+    }
 }

--- a/app/code/Magento/InventorySales/Test/Integration/StockManagement/ReservationPlacingDuringRegisterProductsSaleTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/StockManagement/ReservationPlacingDuringRegisterProductsSaleTest.php
@@ -176,12 +176,7 @@ class ReservationPlacingDuringRegisterProductsSaleTest extends TestCase
         self::assertEquals(5, $this->getProductSalableQty->execute('SKU-1', 10));
         self::assertEquals(-3.5, $this->getReservationsQuantity->execute('SKU-1', 10));
         self::assertEquals(
-            sprintf(
-                '%s:%s:%d',
-                SalesEventInterface::EVENT_ORDER_PLACED,
-                SalesEventInterface::OBJECT_TYPE_ORDER,
-                $orderId
-            ),
+            '{"event_type":"order_placed","object_type":"order","object_id":"' . $orderId . '"}',
             $this->getReservationMetadata()
         );
 

--- a/app/code/Magento/InventorySalesApi/Api/Data/SalesEventInterface.php
+++ b/app/code/Magento/InventorySalesApi/Api/Data/SalesEventInterface.php
@@ -35,4 +35,10 @@ interface SalesEventInterface
     public function getObjectType(): string;
 
     public function getObjectId(): string;
+
+    /**
+     * Convert this object to an associative array whose keys represent object properties.
+     * This method is used to facilitate object serialization.
+     */
+    public function toArray(): array;
 }


### PR DESCRIPTION
This PR is intended to address Issue #1071: change format of Reservation metadata to JSON

- Inject and use serializer into `PlaceReservationsForSalesEvent` service to serialize reservation metadata
- Add `toArray()` method to `SalesEventInterface` and implement it to facilitate object serialization
- Update `ReservationPlacingDuringRegisterProductsSaleTest` integration test