### PR TITLE
1409: removed $this usage from template

### DIFF
--- a/app/code/Magento/InventoryShippingAdminUi/view/adminhtml/templates/shipment/inventory.phtml
+++ b/app/code/Magento/InventoryShippingAdminUi/view/adminhtml/templates/shipment/inventory.phtml
@@ -18,7 +18,7 @@ $sourceCode = $block->getSourceCode();
     </div>
     <div class="admin__page-section-content">
         <?= $block->escapeHtml(__('Source:')) ?>
-        <?= $block->escapeHtml($this->getSourceName($sourceCode)) ?>
+        <?= $block->escapeHtml($block->getSourceName($sourceCode)) ?>
     </div>
 </section>
 <input name="sourceCode" type="hidden" value="<?= /* @escapeNotVerified */ $sourceCode ?>">


### PR DESCRIPTION

### Description
Removed $this usage from template.

### Fixed Issues (if relevant)
1. magento-engcom/msi#1409: Replace obsolete "$this" with "$block" in shipment inventory template. 
