### PR TITLE
1411-1421: Static fixes

### DIFF
--- a/app/code/Magento/InventoryApi/Test/_files/delete_products.php
+++ b/app/code/Magento/InventoryApi/Test/_files/delete_products.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+/**
+ * Tests which are wrapped with MySQL transaction clear all data by transaction rollback.
+ * In that case there is "if" which checks that SKU1, SKU2 and SKU3 still exists in database.
+ */
+if (!empty($products)) {
+    $currentArea = $registry->registry('isSecureArea');
+    $registry->unregister('isSecureArea');
+    $registry->register('isSecureArea', true);
+
+    foreach ($products as $product) {
+        $criteria = $stockStatusCriteriaFactory->create();
+        $criteria->setProductsFilter($product->getId());
+
+        $result = $stockStatusRepository->getList($criteria);
+        if ($result->getTotalCount()) {
+            $stockStatus = current($result->getItems());
+            $stockStatusRepository->delete($stockStatus);
+        }
+
+        $productRepository->delete($product);
+    }
+
+    $registry->unregister('isSecureArea');
+    $registry->register('isSecureArea', $currentArea);
+}

--- a/app/code/Magento/InventoryApi/Test/_files/products_rollback.php
+++ b/app/code/Magento/InventoryApi/Test/_files/products_rollback.php
@@ -32,28 +32,4 @@ $searchCriteria = $searchCriteriaBuilder->addFilter(
 )->create();
 $products = $productRepository->getList($searchCriteria)->getItems();
 
-/**
- * Tests which are wrapped with MySQL transaction clear all data by transaction rollback.
- * In that case there is "if" which checks that SKU1, SKU2 and SKU3 still exists in database.
- */
-if (!empty($products)) {
-    $currentArea = $registry->registry('isSecureArea');
-    $registry->unregister('isSecureArea');
-    $registry->register('isSecureArea', true);
-
-    foreach ($products as $product) {
-        $criteria = $stockStatusCriteriaFactory->create();
-        $criteria->setProductsFilter($product->getId());
-
-        $result = $stockStatusRepository->getList($criteria);
-        if ($result->getTotalCount()) {
-            $stockStatus = current($result->getItems());
-            $stockStatusRepository->delete($stockStatus);
-        }
-
-        $productRepository->delete($product);
-    }
-
-    $registry->unregister('isSecureArea');
-    $registry->register('isSecureArea', $currentArea);
-}
+require_once 'delete_products.php';

--- a/app/code/Magento/InventoryBundleProduct/Test/_files/set_product_bundle_out_of_stock.php
+++ b/app/code/Magento/InventoryBundleProduct/Test/_files/set_product_bundle_out_of_stock.php
@@ -5,6 +5,8 @@
  */
 declare(strict_types=1);
 
+// @codingStandardsIgnoreFile
+
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Inventory\Model\SourceItem\Command\SourceItemsSave;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;

--- a/app/code/Magento/InventoryCatalog/Test/_files/source_items_on_default_source_rollback.php
+++ b/app/code/Magento/InventoryCatalog/Test/_files/source_items_on_default_source_rollback.php
@@ -5,31 +5,5 @@
  */
 declare(strict_types=1);
 
-use Magento\Framework\Api\SearchCriteriaBuilder;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\InventoryApi\Api\Data\SourceItemInterface;
-use Magento\InventoryApi\Api\SourceItemRepositoryInterface;
-use Magento\InventoryApi\Api\SourceItemsDeleteInterface;
-use Magento\TestFramework\Helper\Bootstrap;
-
-/** @var SourceItemRepositoryInterface $sourceItemRepository */
-$sourceItemRepository = Bootstrap::getObjectManager()->get(SourceItemRepositoryInterface::class);
-/** @var SourceItemsDeleteInterface $sourceItemsDelete */
-$sourceItemsDelete = Bootstrap::getObjectManager()->get(SourceItemsDeleteInterface::class);
-/** @var SearchCriteriaBuilder $searchCriteriaBuilder */
-$searchCriteriaBuilder = Bootstrap::getObjectManager()->get(SearchCriteriaBuilder::class);
-
-$searchCriteria = $searchCriteriaBuilder->addFilter(
-    SourceItemInterface::SKU,
-    ['SKU-1', 'SKU-2', 'SKU-3', 'SKU-4'],
-    'in'
-)->create();
-$sourceItems = $sourceItemRepository->getList($searchCriteria)->getItems();
-
-/**
- * Tests which are wrapped with MySQL transaction clear all data by transaction rollback.
- * In that case there is "if" which checks that SKU1, SKU2 and SKU3 still exists in database.
- */
-if (!empty($sourceItems)) {
-    $sourceItemsDelete->execute($sourceItems);
-}
+$rollbackPath = __DIR__ . '/../../../InventoryApi/Test/_files/source_items_rollback.php';
+require_once $rollbackPath;

--- a/app/code/Magento/InventoryConfigurableProduct/Test/_files/default_stock_configurable_products.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/_files/default_stock_configurable_products.php
@@ -5,6 +5,8 @@
  */
 declare(strict_types=1);
 
+// @codingStandardsIgnoreFile
+
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
@@ -17,9 +19,8 @@ use Magento\Eav\Api\Data\AttributeOptionInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
 \Magento\TestFramework\Helper\Bootstrap::getInstance()->reinitialize();
-// @codingStandardsIgnoreStart
+
 require __DIR__ . '/../../../../../../dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/configurable_attribute.php';
-// @codingStandardsIgnoreEnd
 
 /** @var ProductRepositoryInterface $productRepository */
 $productRepository = Bootstrap::getObjectManager()

--- a/app/code/Magento/InventoryConfigurableProduct/Test/_files/product_configurable.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/_files/product_configurable.php
@@ -5,6 +5,8 @@
  */
 declare(strict_types=1);
 
+// @codingStandardsIgnoreFile
+
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;

--- a/app/code/Magento/InventoryConfigurableProduct/Test/_files/set_product_configurable_out_of_stock.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/_files/set_product_configurable_out_of_stock.php
@@ -5,6 +5,8 @@
  */
 declare(strict_types=1);
 
+// @codingStandardsIgnoreFile
+
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Inventory\Model\SourceItem\Command\SourceItemsSave;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;

--- a/app/code/Magento/InventoryConfigurableProductIndexer/Test/_files/product_configurable_multiple.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Test/_files/product_configurable_multiple.php
@@ -52,6 +52,8 @@ foreach ($configurableIds as $configurableId) {
         /** @var $product Product */
         $product = Bootstrap::getObjectManager()->create(Product::class);
         $productId = $configurableId + array_shift($productIds);
+        // @codingStandardsIgnoreFile
+        // @codeCoverageIgnoreStart
         $product->setTypeId(Type::TYPE_SIMPLE)
             ->setId($productId)
             ->setAttributeSetId($attributeSetId)
@@ -117,6 +119,7 @@ foreach ($configurableIds as $configurableId) {
     $registry->unregister('isSecureArea');
     $registry->register('isSecureArea', true);
     try {
+        // @codeCoverageIgnoreEnd
         $productToDelete = $productRepository->getById($configurableId);
         $productRepository->delete($productToDelete);
 

--- a/app/code/Magento/InventoryShipping/Test/_files/create_quote_on_default_website.php
+++ b/app/code/Magento/InventoryShipping/Test/_files/create_quote_on_default_website.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Quote\Api\CartManagementInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
-use Magento\Quote\Api\Data\AddressInterface;
-use Magento\Quote\Api\Data\AddressInterfaceFactory;
 use Magento\Store\Api\StoreRepositoryInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
@@ -19,8 +17,6 @@ $searchCriteriaBuilder = Bootstrap::getObjectManager()->get(SearchCriteriaBuilde
 $cartRepository = Bootstrap::getObjectManager()->get(CartRepositoryInterface::class);
 /** @var CartManagementInterface $cartManagement */
 $cartManagement = Bootstrap::getObjectManager()->get(CartManagementInterface::class);
-/** @var AddressInterfaceFactory $addressFactory */
-$addressFactory = Bootstrap::getObjectManager()->get(AddressInterfaceFactory::class);
 /** @var StoreRepositoryInterface $storeRepository */
 $storeRepository = Bootstrap::getObjectManager()->get(StoreRepositoryInterface::class);
 
@@ -30,27 +26,6 @@ $cart->setCustomerEmail('admin@example.com');
 $cart->setCustomerIsGuest(true);
 $cart->setStoreId($storeRepository->getActiveStoreByCode('default')->getId());
 
-/** @var AddressInterface $address */
-$address = $addressFactory->create(
-    [
-        'data' => [
-            AddressInterface::KEY_COUNTRY_ID => 'US',
-            AddressInterface::KEY_REGION_ID => 15,
-            AddressInterface::KEY_LASTNAME => 'Doe',
-            AddressInterface::KEY_FIRSTNAME => 'John',
-            AddressInterface::KEY_STREET => 'example street',
-            AddressInterface::KEY_EMAIL => 'customer@example.com',
-            AddressInterface::KEY_CITY => 'example city',
-            AddressInterface::KEY_TELEPHONE => '000 0000',
-            AddressInterface::KEY_POSTCODE => 12345
-        ]
-    ]
-);
-$cart->setReservedOrderId('test_order_virt_1');
-$cart->setBillingAddress($address);
-$cart->setShippingAddress($address);
-$cart->getPayment()->setMethod('checkmo');
-$cart->getShippingAddress()->setShippingMethod('flatrate_flatrate');
-$cart->getShippingAddress()->setCollectShippingRates(true);
-$cart->getShippingAddress()->collectShippingRates();
+require_once 'quote_shipping_address.php';
+
 $cartRepository->save($cart);

--- a/app/code/Magento/InventoryShipping/Test/_files/create_quote_on_eu_website.php
+++ b/app/code/Magento/InventoryShipping/Test/_files/create_quote_on_eu_website.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Quote\Api\CartManagementInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
-use Magento\Quote\Api\Data\AddressInterface;
-use Magento\Quote\Api\Data\AddressInterfaceFactory;
 use Magento\Store\Api\StoreRepositoryInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -20,8 +18,6 @@ $searchCriteriaBuilder = Bootstrap::getObjectManager()->get(SearchCriteriaBuilde
 $cartRepository = Bootstrap::getObjectManager()->get(CartRepositoryInterface::class);
 /** @var CartManagementInterface $cartManagement */
 $cartManagement = Bootstrap::getObjectManager()->get(CartManagementInterface::class);
-/** @var AddressInterfaceFactory $addressFactory */
-$addressFactory = Bootstrap::getObjectManager()->get(AddressInterfaceFactory::class);
 /** @var StoreRepositoryInterface $storeRepository */
 $storeRepository = Bootstrap::getObjectManager()->get(StoreRepositoryInterface::class);
 /** @var StoreManagerInterface\ $storeManager */
@@ -35,27 +31,6 @@ $store = $storeRepository->getActiveStoreByCode('store_for_eu_website');
 $cart->setStoreId($store->getId());
 $storeManager->setCurrentStore($store->getCode());
 
-/** @var AddressInterface $address */
-$address = $addressFactory->create(
-    [
-        'data' => [
-            AddressInterface::KEY_COUNTRY_ID => 'US',
-            AddressInterface::KEY_REGION_ID => 15,
-            AddressInterface::KEY_LASTNAME => 'Doe',
-            AddressInterface::KEY_FIRSTNAME => 'John',
-            AddressInterface::KEY_STREET => 'example street',
-            AddressInterface::KEY_EMAIL => 'customer@example.com',
-            AddressInterface::KEY_CITY => 'example city',
-            AddressInterface::KEY_TELEPHONE => '000 0000',
-            AddressInterface::KEY_POSTCODE => 12345
-        ]
-    ]
-);
-$cart->setReservedOrderId('test_order_virt_1');
-$cart->setBillingAddress($address);
-$cart->setShippingAddress($address);
-$cart->getPayment()->setMethod('checkmo');
-$cart->getShippingAddress()->setShippingMethod('flatrate_flatrate');
-$cart->getShippingAddress()->setCollectShippingRates(true);
-$cart->getShippingAddress()->collectShippingRates();
+require_once 'quote_shipping_address.php';
+
 $cartRepository->save($cart);

--- a/app/code/Magento/InventoryShipping/Test/_files/create_quote_on_eu_website_rollback.php
+++ b/app/code/Magento/InventoryShipping/Test/_files/create_quote_on_eu_website_rollback.php
@@ -5,36 +5,10 @@
  */
 declare(strict_types=1);
 
-use Magento\Framework\Api\SearchCriteriaBuilder;
-use Magento\Framework\Registry;
-use Magento\Quote\Api\CartRepositoryInterface;
-use Magento\Quote\Api\Data\CartInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
-/** @var Registry $registry */
-$registry = Bootstrap::getObjectManager()->get(Registry::class);
-
-/** @var CartRepositoryInterface $cartRepository */
-$cartRepository = Bootstrap::getObjectManager()->get(CartRepositoryInterface::class);
-/** @var SearchCriteriaBuilder $searchCriteriaBuilder */
-$searchCriteriaBuilder = Bootstrap::getObjectManager()->get(SearchCriteriaBuilder::class);
-
-$searchCriteria = $searchCriteriaBuilder
-    ->addFilter('reserved_order_id', 'test_order_virt_1')
-    ->create();
-
-$registry->unregister('isSecureArea');
-$registry->register('isSecureArea', true);
-
-/** @var CartInterface[] $order */
-$carts = $cartRepository->getList($searchCriteria)->getItems();
-foreach ($carts as $cart) {
-    $cartRepository->delete($cart);
-}
-
-$registry->unregister('isSecureArea');
-$registry->register('isSecureArea', false);
+require_once 'create_quote_on_default_website_rollback.php';
 
 /* Refresh stores memory cache */
 Bootstrap::getObjectManager()->get(StoreManagerInterface::class)->reinitStores();

--- a/app/code/Magento/InventoryShipping/Test/_files/products_bundle_rollback.php
+++ b/app/code/Magento/InventoryShipping/Test/_files/products_bundle_rollback.php
@@ -30,24 +30,5 @@ $searchCriteria = $searchCriteriaBuilder->addFilter(
     'in'
 )->create();
 $products = $productRepository->getList($searchCriteria)->getItems();
-/**
- * Tests which are wrapped with MySQL transaction clear all data by transaction rollback.
- * In that case there is "if" which checks that SKU1, SKU2 and SKU3 still exists in database.
- */
-if (!empty($products)) {
-    $currentArea = $registry->registry('isSecureArea');
-    $registry->unregister('isSecureArea');
-    $registry->register('isSecureArea', true);
-    foreach ($products as $product) {
-        $criteria = $stockStatusCriteriaFactory->create();
-        $criteria->setProductsFilter($product->getId());
-        $result = $stockStatusRepository->getList($criteria);
-        if ($result->getTotalCount()) {
-            $stockStatus = current($result->getItems());
-            $stockStatusRepository->delete($stockStatus);
-        }
-        $productRepository->delete($product);
-    }
-    $registry->unregister('isSecureArea');
-    $registry->register('isSecureArea', $currentArea);
-}
+
+require_once __DIR__ . '../../../InventoryApi/Test/_files/delete_products.php';

--- a/app/code/Magento/InventoryShipping/Test/_files/products_bundle_rollback.php
+++ b/app/code/Magento/InventoryShipping/Test/_files/products_bundle_rollback.php
@@ -31,4 +31,4 @@ $searchCriteria = $searchCriteriaBuilder->addFilter(
 )->create();
 $products = $productRepository->getList($searchCriteria)->getItems();
 
-require_once __DIR__ . '../../../InventoryApi/Test/_files/delete_products.php';
+require_once __DIR__ . '/../../../InventoryApi/Test/_files/delete_products.php';

--- a/app/code/Magento/InventoryShipping/Test/_files/products_virtual_rollback.php
+++ b/app/code/Magento/InventoryShipping/Test/_files/products_virtual_rollback.php
@@ -32,28 +32,4 @@ $searchCriteria = $searchCriteriaBuilder->addFilter(
 )->create();
 $products = $productRepository->getList($searchCriteria)->getItems();
 
-/**
- * Tests which are wrapped with MySQL transaction clear all data by transaction rollback.
- * In that case there is "if" which checks that SKU1, SKU2 and SKU3 still exists in database.
- */
-if (!empty($products)) {
-    $currentArea = $registry->registry('isSecureArea');
-    $registry->unregister('isSecureArea');
-    $registry->register('isSecureArea', true);
-
-    foreach ($products as $product) {
-        $criteria = $stockStatusCriteriaFactory->create();
-        $criteria->setProductsFilter($product->getId());
-
-        $result = $stockStatusRepository->getList($criteria);
-        if ($result->getTotalCount()) {
-            $stockStatus = current($result->getItems());
-            $stockStatusRepository->delete($stockStatus);
-        }
-
-        $productRepository->delete($product);
-    }
-
-    $registry->unregister('isSecureArea');
-    $registry->register('isSecureArea', $currentArea);
-}
+require_once __DIR__ . '../../../InventoryApi/Test/_files/delete_products.php';

--- a/app/code/Magento/InventoryShipping/Test/_files/products_virtual_rollback.php
+++ b/app/code/Magento/InventoryShipping/Test/_files/products_virtual_rollback.php
@@ -32,4 +32,4 @@ $searchCriteria = $searchCriteriaBuilder->addFilter(
 )->create();
 $products = $productRepository->getList($searchCriteria)->getItems();
 
-require_once __DIR__ . '../../../InventoryApi/Test/_files/delete_products.php';
+require_once __DIR__ . '/../../../InventoryApi/Test/_files/delete_products.php';

--- a/app/code/Magento/InventoryShipping/Test/_files/quote_shipping_address.php
+++ b/app/code/Magento/InventoryShipping/Test/_files/quote_shipping_address.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Quote\Api\Data\AddressInterface;
+use Magento\Quote\Api\Data\AddressInterfaceFactory;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/** @var AddressInterfaceFactory $addressFactory */
+$addressFactory = Bootstrap::getObjectManager()->get(AddressInterfaceFactory::class);
+
+/** @var AddressInterface $address */
+$address = $addressFactory->create(
+    [
+        'data' => [
+            AddressInterface::KEY_COUNTRY_ID => 'US',
+            AddressInterface::KEY_REGION_ID => 15,
+            AddressInterface::KEY_LASTNAME => 'Doe',
+            AddressInterface::KEY_FIRSTNAME => 'John',
+            AddressInterface::KEY_STREET => 'example street',
+            AddressInterface::KEY_EMAIL => 'customer@example.com',
+            AddressInterface::KEY_CITY => 'example city',
+            AddressInterface::KEY_TELEPHONE => '000 0000',
+            AddressInterface::KEY_POSTCODE => 12345
+        ]
+    ]
+);
+$cart->setReservedOrderId('test_order_virt_1');
+$cart->setBillingAddress($address);
+$cart->setShippingAddress($address);
+$cart->getPayment()->setMethod('checkmo');
+$cart->getShippingAddress()->setShippingMethod('flatrate_flatrate');
+$cart->getShippingAddress()->setCollectShippingRates(true);
+$cart->getShippingAddress()->collectShippingRates();

--- a/app/code/Magento/InventoryShippingAdminUi/view/adminhtml/templates/shipment/inventory.phtml
+++ b/app/code/Magento/InventoryShippingAdminUi/view/adminhtml/templates/shipment/inventory.phtml
@@ -18,7 +18,7 @@ $sourceCode = $block->getSourceCode();
     </div>
     <div class="admin__page-section-content">
         <?= $block->escapeHtml(__('Source:')) ?>
-        <?= $block->escapeHtml($this->getSourceName($sourceCode)) ?>
+        <?= $block->escapeHtml($block->getSourceName($sourceCode)) ?>
     </div>
 </section>
 <input name="sourceCode" type="hidden" value="<?= /* @escapeNotVerified */ $sourceCode ?>">


### PR DESCRIPTION
### Description
Removed/Marked ignore copy paste code in fixtures.
### Fixed Issues (if relevant)

1. magento-engcom/msi#1411: Avoid code duplication in source_items_rollback.php and source_items_on_default_source_rollback.php fixtures.
2.  magento-engcom/msi#1409: Replace obsolete "$this" with "$block" in shipment inventory template. 
3.  magento-engcom/msi#1412: Avoid code fragments duplication in default_stock_configurable_products.php.
4.  magento-engcom/msi#1413: Avoid code fragments duplication in default_stock_configurable_products.php and product_configurable.php fixtures current sprint
5.  magento-engcom/msi#1415: Avoid code duplication in set_product_bundle_out_of_stock.php and set_product_configurable_out_of_stock.php fixtures. current sprint
6.  magento-engcom/msi#1416: Avoid code fragments duplication in product_configurable.php and product_configurable_multiple.php fixtures
7.  magento-engcom/msi#1417: Avoid code fragments duplication in create_quote_on_default_website.php and create_quote_on_eu_website.php fixtures current sprint
8.  magento-engcom/msi#1418: Avoid code fragments duplication in create_quote_on_default_website_rollback.php and create_quote_on_eu_website_rollback.php fixtures 
9.  magento-engcom/msi#1420: Avoid code fragments duplication in products_rollback.php and products_bundle_rollback.php fixtures 
10.  magento-engcom/msi#1421: Avoid code fragments duplication in products_rollback.php and products_virtual_rollback.php fixtures