### PR TITLE
Usage of isProductSalable for grouped associated products instead of isSalable

### DIFF
--- a/app/code/Magento/InventoryCatalog/Plugin/Catalog/ProductPlugin.php
+++ b/app/code/Magento/InventoryCatalog/Plugin/Catalog/ProductPlugin.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Company: Ping24/7 GmbH
+ * Developer: Stepan Furman (s.furman@ping247.de)
+ * Date: 22.06.18
+ * Time: 14:23
+ */
+
+namespace Magento\InventoryCatalog\Plugin\Catalog;
+
+use Magento\Catalog\Model\Product;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\IsProductSalableInterface;
+use Magento\InventorySalesApi\Api\StockResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class ProductPlugin
+{
+    /**
+     * @var IsProductSalableInterface
+     */
+    private $isProductSalable;
+    /**
+     * @var StockResolverInterface
+     */
+    private $stockResolver;
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @param IsProductSalableInterface $isProductSalable
+     * @param StockResolverInterface $stockResolver
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        IsProductSalableInterface $isProductSalable,
+        StockResolverInterface $stockResolver,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->isProductSalable = $isProductSalable;
+        $this->stockResolver = $stockResolver;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @param Product $subject
+     * @param callable $proceed
+     * @return boolean
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function aroundIsSalable(Product $subject, callable $proceed)
+    {
+        $website = $this->storeManager->getWebsite();
+        $stock = $this->stockResolver->get(SalesChannelInterface::TYPE_WEBSITE, $website->getCode());
+
+        return $this->isProductSalable->execute($subject->getSku(), $stock->getStockId());
+    }
+}

--- a/app/code/Magento/InventoryCatalog/Plugin/Catalog/ProductPlugin.php
+++ b/app/code/Magento/InventoryCatalog/Plugin/Catalog/ProductPlugin.php
@@ -1,11 +1,8 @@
 <?php
 /**
- * Company: Ping24/7 GmbH
- * Developer: Stepan Furman (s.furman@ping247.de)
- * Date: 22.06.18
- * Time: 14:23
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
  */
-
 namespace Magento\InventoryCatalog\Plugin\Catalog;
 
 use Magento\Catalog\Model\Product;

--- a/app/code/Magento/InventoryCatalog/etc/di.xml
+++ b/app/code/Magento/InventoryCatalog/etc/di.xml
@@ -16,6 +16,10 @@
         <plugin name="prevent_default_stock_deleting"
                 type="Magento\InventoryCatalog\Plugin\InventoryApi\StockRepository\PreventDeleting\DefaultStockPlugin"/>
     </type>
+    <type name="Magento\Catalog\Model\Product">
+        <plugin name="replace_issalable_with_isProductSalable"
+                type="\Magento\InventoryCatalog\Plugin\Catalog\ProductPlugin"/>
+    </type>
     <type name="Magento\InventoryApi\Api\SourceItemsSaveInterface">
         <plugin name="set_data_to_legacy_catalog_inventory_at_source_items_save"
                 type="Magento\InventoryCatalog\Plugin\InventoryApi\SetDataToLegacyCatalogInventoryAtSourceItemsSavePlugin"/>


### PR DESCRIPTION
Using Is product salable for grouped associated products instead of isSalable

### Description
Associated products were displayed at grouped product page even if they were out of stock until shipment for previous orders with this product wasn't created.
Replaced checking isSalable products  with isProductSalable

### Fixed Issue
magento/msi#1112: 
Grouped product doesn't take care of his Linked Products when SalableQuantity < ProductLink.ExtensionAttributes.Qty after Source Deduction

### Manual testing scenarios
Described in issue
