### PR TITLE
#1282 notify qty use default check box

### DIFF
--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/Ui/DataProvider/Product/Form/Modifier/SourceItemConfiguration.php
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/Ui/DataProvider/Product/Form/Modifier/SourceItemConfiguration.php
@@ -96,6 +96,7 @@ class SourceItemConfiguration extends AbstractModifier
 
             $source[SourceItemConfigurationInterface::INVENTORY_NOTIFY_QTY] =
                 $sourceConfiguration[SourceItemConfigurationInterface::INVENTORY_NOTIFY_QTY];
+            $source['notify_stock_qty_use_default'] = "0";
 
             if ($source[SourceItemConfigurationInterface::INVENTORY_NOTIFY_QTY] === null) {
                 $source[SourceItemConfigurationInterface::INVENTORY_NOTIFY_QTY] = $this->getNotifyQtyConfigValue();

--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/ui_component/product_form.xml
@@ -33,6 +33,7 @@
                         <item name="config" xsi:type="array">
                             <item name="valueFromConfig" xsi:type="object">Magento\CatalogInventory\Model\Source\StockConfiguration</item>
                             <item name="keyInConfiguration" xsi:type="string">notify_stock_qty</item>
+                            <item name="default" xsi:type="number">1</item>
                         </item>
                     </argument>
                     <settings>

--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/web/js/components/use-config-settings.js
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/web/js/components/use-config-settings.js
@@ -15,7 +15,7 @@ define([
         },
 
         /**
-         * @returns {Element}
+         * @inheritdoc
          */
         initObservable: function () {
             return this
@@ -34,12 +34,17 @@ define([
             this._super(newChecked);
         },
 
+        /**
+         * @returns {String}
+         */
         getInitialValue: function () {
             var values = [this.value(), this.default],
                 value;
 
             values.some(function (v) {
-                return v ? value = v : !!v
+                value = v || !!v;
+
+                return value;
             });
 
             return this.normalizeData(value);

--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/web/js/components/use-config-settings.js
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/web/js/components/use-config-settings.js
@@ -38,7 +38,7 @@ define([
             var values = [this.value(), this.default],
                 value;
 
-            values.some(function(v){
+            values.some(function (v) {
                 return v ? value = v : !!v
             });
 

--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/web/js/components/use-config-settings.js
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/web/js/components/use-config-settings.js
@@ -32,6 +32,17 @@ define([
             }
 
             this._super(newChecked);
+        },
+
+        getInitialValue: function () {
+            var values = [this.value(), this.default],
+                value;
+
+            values.some(function(v){
+                return v ? value = v : !!v
+            });
+
+            return this.normalizeData(value);
         }
     });
 });


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento-engcom/msi#1282: Change Default state of "Notify Quantity Use default" checkbox on "checked" the first time user assigns sources to a product

### Manual testing scenarios
1  Create custom stock.
2. Create two custom sources and assign them to created stock.
3. Go to "Add new product" page.
4. Assign created sources.
5. After assignment "Notify Quantity Use default" checkbox should be checked by default.
6. Fill necessary product data (name, sku, price).
7. Save product.
8. Check, "Notify Quantity Use default" is checked on both sources.
9. Uncheck "Notify Quantity Use default" on lower source and set some custom value for "Notify Quantity"
10. Save product.
11. Check, "Notify Quantity Use default" is checked on upper source and unchecked on lower one. Check   value for "Notify Quantity" are correct for both sources.