### PR TITLE
MSI-1379: Multiple validation failures occurs while running api-functional tests for inventoryApiSourceRepositoryV1 (usage of "carrier_links")

### DIFF
--- a/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CarrierLinkManagementTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CarrierLinkManagementTest.php
@@ -28,6 +28,7 @@ class CarrierLinkManagementTest extends WebapiAbstract
      */
     public function testCarrierLinksManagement(array $carrierLinks)
     {
+        $this->markTestSkipped('Binding carriers to individual sources is not implemented in MSI MVP');
         $sourceCode = 'source-code-1';
         $expectedData = [
             SourceInterface::NAME => 'source-name-1',
@@ -146,9 +147,93 @@ class CarrierLinkManagementTest extends WebapiAbstract
     /**
      * @param array $carrierData
      * @param array $expectedErrorData
-     * @dataProvider failedValidationDataProvider
      */
-    public function testCarrierLinksValidation(array $carrierData, array $expectedErrorData)
+    public function testCarrierLinksValidationUseGlobalConfiguration()
+    {
+        $carrierData = [
+            SourceInterface::SOURCE_CODE => 'source-code-1',
+            SourceInterface::NAME => 'source-name-1',
+            SourceInterface::POSTCODE => 'source-postcode',
+            SourceInterface::COUNTRY_ID => 'US',
+            SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 1,
+            SourceInterface::CARRIER_LINKS => [
+                [
+                    SourceCarrierLinkInterface::CARRIER_CODE => 'ups',
+                    SourceCarrierLinkInterface::POSITION => 100,
+                ],
+                [
+                    SourceCarrierLinkInterface::CARRIER_CODE => 'usps',
+                    SourceCarrierLinkInterface::POSITION => 200,
+                ],
+            ],
+        ];
+        $expectedErrorData = [
+            'message' => 'Validation Failed',
+            'errors' => [
+                [
+                    'message' =>
+                        'You can\'t configure "%field" because you have chosen Global Shipping configuration.',
+                    'parameters' => [
+                        'field' => SourceInterface::CARRIER_LINKS,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->validate($carrierData, $expectedErrorData);
+    }
+
+    /**
+     * @param array $carrierData
+     * @param array $expectedErrorData
+     */
+    public function testCarrierLinksValidationWithNonExistedCarrierCode()
+    {
+        $this->markTestSkipped('Binding carriers to individual sources is not implemented in MSI MVP');
+        $carrierData = [
+            SourceInterface::SOURCE_CODE => 'source-code-1',
+            SourceInterface::NAME => 'source-name-1',
+            SourceInterface::POSTCODE => 'source-postcode',
+            SourceInterface::COUNTRY_ID => 'US',
+            SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 0,
+            SourceInterface::CARRIER_LINKS => [
+                [
+                    SourceCarrierLinkInterface::CARRIER_CODE => 'no_exists_1',
+                    SourceCarrierLinkInterface::POSITION => 100,
+                ],
+                [
+                    SourceCarrierLinkInterface::CARRIER_CODE => 'no_exists_2',
+                    SourceCarrierLinkInterface::POSITION => 200,
+                ],
+            ],
+        ];
+        $expectedErrorData = [
+            'message' => 'Validation Failed',
+            'errors' => [
+                [
+                    'message' => 'Carrier with code: "%carrier" don\'t exists.',
+                    'parameters' => [
+                        'carrier' => 'no_exists_1',
+                    ],
+                ],
+                [
+                    'message' => 'Carrier with code: "%carrier" don\'t exists.',
+                    'parameters' => [
+                        'carrier' => 'no_exists_2',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->validate($carrierData, $expectedErrorData);
+    }
+
+    /**
+     * @param array $carrierData
+     * @param array $expectedErrorData
+     * @return void
+     */
+    private function validate(array $carrierData, array $expectedErrorData): void
     {
         $serviceInfo = [
             'rest' => [
@@ -189,81 +274,5 @@ class CarrierLinkManagementTest extends WebapiAbstract
                 throw $e;
             }
         }
-    }
-
-    /**
-     * @return array
-     */
-    public function failedValidationDataProvider(): array
-    {
-        return [
-            'use_global_configuration_chosen' => [
-                [
-                    SourceInterface::SOURCE_CODE => 'source-code-1',
-                    SourceInterface::NAME => 'source-name-1',
-                    SourceInterface::POSTCODE => 'source-postcode',
-                    SourceInterface::COUNTRY_ID => 'US',
-                    SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 1,
-                    SourceInterface::CARRIER_LINKS => [
-                        [
-                            SourceCarrierLinkInterface::CARRIER_CODE => 'ups',
-                            SourceCarrierLinkInterface::POSITION => 100,
-                        ],
-                        [
-                            SourceCarrierLinkInterface::CARRIER_CODE => 'usps',
-                            SourceCarrierLinkInterface::POSITION => 200,
-                        ],
-                    ],
-                ],
-                [
-                    'message' => 'Validation Failed',
-                    'errors' => [
-                        [
-                            'message' =>
-                                'You can\'t configure "%field" because you have chosen Global Shipping configuration.',
-                            'parameters' => [
-                                'field' => SourceInterface::CARRIER_LINKS,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            'carrier_codes_not_exits' => [
-                [
-                    SourceInterface::SOURCE_CODE => 'source-code-1',
-                    SourceInterface::NAME => 'source-name-1',
-                    SourceInterface::POSTCODE => 'source-postcode',
-                    SourceInterface::COUNTRY_ID => 'US',
-                    SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 0,
-                    SourceInterface::CARRIER_LINKS => [
-                        [
-                            SourceCarrierLinkInterface::CARRIER_CODE => 'no_exists_1',
-                            SourceCarrierLinkInterface::POSITION => 100,
-                        ],
-                        [
-                            SourceCarrierLinkInterface::CARRIER_CODE => 'no_exists_2',
-                            SourceCarrierLinkInterface::POSITION => 200,
-                        ],
-                    ],
-                ],
-                [
-                    'message' => 'Validation Failed',
-                    'errors' => [
-                        [
-                            'message' => 'Carrier with code: "%carrier" don\'t exists.',
-                            'parameters' => [
-                                'carrier' => 'no_exists_1'
-                            ],
-                        ],
-                        [
-                            'message' => 'Carrier with code: "%carrier" don\'t exists.',
-                            'parameters' => [
-                                'carrier' => 'no_exists_2'
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
     }
 }

--- a/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CreateTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceRepository/CreateTest.php
@@ -9,7 +9,6 @@ namespace Magento\InventoryApi\Test\Api\SourceRepository;
 
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Webapi\Rest\Request;
-use Magento\InventoryApi\Api\Data\SourceCarrierLinkInterface;
 use Magento\InventoryApi\Api\Data\SourceInterface;
 use Magento\TestFramework\Assert\AssertArrayContains;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -43,17 +42,8 @@ class CreateTest extends WebapiAbstract
             SourceInterface::POSTCODE => 'source-postcode',
             SourceInterface::PHONE => 'source-phone',
             SourceInterface::FAX => 'source-fax',
-            SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 0,
-            SourceInterface::CARRIER_LINKS => [
-                [
-                    SourceCarrierLinkInterface::CARRIER_CODE => 'ups',
-                    SourceCarrierLinkInterface::POSITION => 100,
-                ],
-                [
-                    SourceCarrierLinkInterface::CARRIER_CODE => 'usps',
-                    SourceCarrierLinkInterface::POSITION => 200,
-                ],
-            ],
+            SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 1,
+            SourceInterface::CARRIER_LINKS => [],
         ];
         $serviceInfo = [
             'rest' => [

--- a/app/code/Magento/InventoryApi/Test/Api/SourceRepository/UpdateTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceRepository/UpdateTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Magento\InventoryApi\Test\Api\SourceRepository;
 
 use Magento\Framework\Webapi\Rest\Request;
-use Magento\InventoryApi\Api\Data\SourceCarrierLinkInterface;
 use Magento\InventoryApi\Api\Data\SourceInterface;
 use Magento\TestFramework\Assert\AssertArrayContains;
 use Magento\TestFramework\TestCase\WebapiAbstract;
@@ -43,17 +42,8 @@ class UpdateTest extends WebapiAbstract
             SourceInterface::POSTCODE => 'source-postcode-updated',
             SourceInterface::PHONE => 'source-phone-updated',
             SourceInterface::FAX => 'source-fax-updated',
-            SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 0,
-            SourceInterface::CARRIER_LINKS => [
-                [
-                    SourceCarrierLinkInterface::CARRIER_CODE => 'dhl',
-                    SourceCarrierLinkInterface::POSITION => 2000,
-                ],
-                [
-                    SourceCarrierLinkInterface::CARRIER_CODE => 'fedex',
-                    SourceCarrierLinkInterface::POSITION => 3000,
-                ],
-            ],
+            SourceInterface::USE_DEFAULT_CARRIER_CONFIG => 1,
+            SourceInterface::CARRIER_LINKS => [],
         ];
         $serviceInfo = [
             'rest' => [

--- a/app/code/Magento/InventoryApi/Test/Api/SourceRepository/ValidationTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/SourceRepository/ValidationTest.php
@@ -134,7 +134,7 @@ class ValidationTest extends WebapiAbstract
      * @param string $field
      * @param string|null $value
      * @param array $expectedErrorData
-     * @dataProvider failedValidationDataProvider
+     * @dataProvider failedValidationUpdateDataProvider
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source.php
      */
     public function testFailedValidationOnUpdate(string $field, $value, array $expectedErrorData)
@@ -225,6 +225,153 @@ class ValidationTest extends WebapiAbstract
                     ],
                 ],
             ],
+            'null_' . SourceInterface::NAME => [
+                SourceInterface::NAME,
+                null,
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::NAME,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'empty_' . SourceInterface::NAME => [
+                SourceInterface::NAME,
+                '',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::NAME,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'whitespaces_' . SourceInterface::NAME => [
+                SourceInterface::NAME,
+                ' ',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::NAME,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'empty_' . SourceInterface::POSTCODE => [
+                SourceInterface::POSTCODE,
+                '',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::POSTCODE,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'whitespaces_' . SourceInterface::POSTCODE => [
+                SourceInterface::POSTCODE,
+                ' ',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::POSTCODE,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'null_' . SourceInterface::POSTCODE => [
+                SourceInterface::POSTCODE,
+                null,
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::POSTCODE,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'empty_' . SourceInterface::COUNTRY_ID => [
+                SourceInterface::COUNTRY_ID,
+                '',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::COUNTRY_ID,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'whitespaces_' . SourceInterface::COUNTRY_ID => [
+                SourceInterface::COUNTRY_ID,
+                ' ',
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::COUNTRY_ID,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'null_' . SourceInterface::COUNTRY_ID => [
+                SourceInterface::COUNTRY_ID,
+                null,
+                [
+                    'message' => 'Validation Failed',
+                    'errors' => [
+                        [
+                            'message' => '"%field" can not be empty.',
+                            'parameters' => [
+                                'field' => SourceInterface::COUNTRY_ID,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * SuppressWarnings was added due to a tests on different fail types and big size of data provider.
+     *
+     * @return array
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function failedValidationUpdateDataProvider(): array
+    {
+        return [
             'null_' . SourceInterface::NAME => [
                 SourceInterface::NAME,
                 null,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
API-Functional test rework for new validation.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#1379: Multiple validation failures occurs while running api-functional tests for inventoryApiSourceRepositoryV1 (usage of "carrier_links")
