### PR TITLE
MSI-1438: Incompatibility with Sample Data

### DIFF
--- a/app/code/Magento/InventoryCatalog/Observer/CreateSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/CreateSourceItemsObserver.php
@@ -35,6 +35,7 @@ class CreateSourceItemsObserver implements ObserverInterface
      * @var IsSourceItemManagementAllowedForProductTypeInterface
      */
     private $isSourceItemAllowedForProductType;
+
     /**
      * @var ResourceConnection
      */
@@ -77,14 +78,16 @@ class CreateSourceItemsObserver implements ObserverInterface
                 $data[] = [
                     SourceItemInterface::SOURCE_CODE => $sourceCode,
                     SourceItemInterface::SKU => $product['sku'],
-                    SourceItemInterface::QUANTITY => $product['qty'] ?? null,
+                    SourceItemInterface::QUANTITY => $product['qty'] ?? 0,
                     SourceItemInterface::STATUS => $product['is_in_stock'] ?? 0,
                 ];
             }
         }
-        $this->resource->getConnection()->insertOnDuplicate(
-            $this->resource->getTableName(SourceItem::TABLE_NAME_SOURCE_ITEM),
-            $data
-        );
+        if ($data) {
+            $this->resource->getConnection()->insertOnDuplicate(
+                $this->resource->getTableName(SourceItem::TABLE_NAME_SOURCE_ITEM),
+                $data
+            );
+        }
     }
 }

--- a/app/code/Magento/InventoryCatalog/Observer/CreateSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/CreateSourceItemsObserver.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventoryCatalog\Observer;
 
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Inventory\Model\ResourceModel\SourceItem;
@@ -34,20 +35,27 @@ class CreateSourceItemsObserver implements ObserverInterface
      * @var IsSourceItemManagementAllowedForProductTypeInterface
      */
     private $isSourceItemAllowedForProductType;
+    /**
+     * @var ResourceConnection
+     */
+    private $resource;
 
     /**
      * @param IsSingleSourceModeInterface $isSingleSourceMode
      * @param DefaultSourceProviderInterface $defaultSourceProvider
      * @param IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemAllowedForProductType
+     * @param ResourceConnection $resource
      */
     public function __construct(
         IsSingleSourceModeInterface $isSingleSourceMode,
         DefaultSourceProviderInterface $defaultSourceProvider,
-        IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemAllowedForProductType
+        IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemAllowedForProductType,
+        ResourceConnection $resource
     ) {
         $this->isSingleSourceMode = $isSingleSourceMode;
         $this->defaultSourceProvider = $defaultSourceProvider;
         $this->isSourceItemAllowedForProductType = $isSourceItemAllowedForProductType;
+        $this->resource = $resource;
     }
 
     /**
@@ -74,8 +82,8 @@ class CreateSourceItemsObserver implements ObserverInterface
                 ];
             }
         }
-        $adapter->getConnection()->insertOnDuplicate(
-            $adapter->getConnection()->getTableName(SourceItem::TABLE_NAME_SOURCE_ITEM),
+        $this->resource->getConnection()->insertOnDuplicate(
+            $this->resource->getTableName(SourceItem::TABLE_NAME_SOURCE_ITEM),
             $data
         );
     }

--- a/app/code/Magento/InventoryCatalog/Observer/CreateSourceItemsObserver.php
+++ b/app/code/Magento/InventoryCatalog/Observer/CreateSourceItemsObserver.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Inventory\Model\ResourceModel\SourceItem;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryCatalogApi\Api\DefaultSourceProviderInterface;
+use Magento\InventoryCatalogApi\Model\IsSingleSourceModeInterface;
+use Magento\InventoryConfigurationApi\Model\IsSourceItemManagementAllowedForProductTypeInterface;
+
+/**
+ * Create source items during product import process for single source mode.
+ */
+class CreateSourceItemsObserver implements ObserverInterface
+{
+    /**
+     * @var IsSingleSourceModeInterface
+     */
+    private $isSingleSourceMode;
+
+    /**
+     * @var DefaultSourceProviderInterface
+     */
+    private $defaultSourceProvider;
+
+    /**
+     * @var IsSourceItemManagementAllowedForProductTypeInterface
+     */
+    private $isSourceItemAllowedForProductType;
+
+    /**
+     * @param IsSingleSourceModeInterface $isSingleSourceMode
+     * @param DefaultSourceProviderInterface $defaultSourceProvider
+     * @param IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemAllowedForProductType
+     */
+    public function __construct(
+        IsSingleSourceModeInterface $isSingleSourceMode,
+        DefaultSourceProviderInterface $defaultSourceProvider,
+        IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemAllowedForProductType
+    ) {
+        $this->isSingleSourceMode = $isSingleSourceMode;
+        $this->defaultSourceProvider = $defaultSourceProvider;
+        $this->isSourceItemAllowedForProductType = $isSourceItemAllowedForProductType;
+    }
+
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer): void
+    {
+        $adapter = $observer->getAdapter();
+        if (!$this->isSingleSourceMode->execute() || $adapter->getBehavior() === 'delete') {
+            return;
+        }
+
+        $data = [];
+        $products = $observer->getBunch();
+        $sourceCode = $this->defaultSourceProvider->getCode();
+        foreach ($products as $product) {
+            if ($this->isSourceItemAllowedForProductType->execute($product['product_type'])) {
+                $data[] = [
+                    SourceItemInterface::SOURCE_CODE => $sourceCode,
+                    SourceItemInterface::SKU => $product['sku'],
+                    SourceItemInterface::QUANTITY => $product['qty'] ?? null,
+                    SourceItemInterface::STATUS => $product['is_in_stock'] ?? 0,
+                ];
+            }
+        }
+        $adapter->getConnection()->insertOnDuplicate(
+            $adapter->getConnection()->getTableName(SourceItem::TABLE_NAME_SOURCE_ITEM),
+            $data
+        );
+    }
+}

--- a/app/code/Magento/InventoryCatalog/etc/events.xml
+++ b/app/code/Magento/InventoryCatalog/etc/events.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="catalog_product_import_bunch_save_after">
+        <observer name="create_source_items" instance="Magento\InventoryCatalog\Observer\CreateSourceItemsObserver"/>
+    </event>
+</config>


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento-engcom/msi#1438: Incompatibility with Sample Data

### Manual testing scenarios 1
1. Install Magento with MSI and [Sample Data](https://devdocs.magento.com/guides/v2.2/install-gde/install/sample-data-after-clone.html).
2. Check, installation proceeds without any errors.

### Manual testing scenarios 2
1. Install magento without MSI.
2. Navigate to admin area and create different types of products.
3. Export created products.
4. Install magento with MSI(single stock mode).
5. Import previously exported products.
6. Perform reindex, if needed.
7. Create order, invoice and shipment with imported products.
8. Check order, invoice and shipment created successfully.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
