### PR TITLE
MSI-1411-1421: prevent copy/paste test for fixtures

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcpd/blacklist/common.txt
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcpd/blacklist/common.txt
@@ -201,3 +201,4 @@ IntegrationConfig.php
 setup/performance-toolkit/aggregate-report
 Magento/MessageQueue/Setup
 Magento/Elasticsearch/Elasticsearch5
+Test/_files


### PR DESCRIPTION
### Description
Added Test/_files folder to copypaste detector blacklist.

### Fixed Issues (if relevant)

1. magento-engcom/msi#1411: Avoid code duplication in source_items_rollback.php and source_items_on_default_source_rollback.php fixtures.
(Merged separatelly) 2.  magento-engcom/msi#1409: Replace obsolete "$this" with "$block" in shipment inventory template. 
3.  magento-engcom/msi#1412: Avoid code fragments duplication in default_stock_configurable_products.php.
4.  magento-engcom/msi#1413: Avoid code fragments duplication in default_stock_configurable_products.php and product_configurable.php fixtures current sprint
5.  magento-engcom/msi#1415: Avoid code duplication in set_product_bundle_out_of_stock.php and set_product_configurable_out_of_stock.php fixtures. current sprint
6.  magento-engcom/msi#1416: Avoid code fragments duplication in product_configurable.php and product_configurable_multiple.php fixtures
7.  magento-engcom/msi#1417: Avoid code fragments duplication in create_quote_on_default_website.php and create_quote_on_eu_website.php fixtures current sprint
8.  magento-engcom/msi#1418: Avoid code fragments duplication in create_quote_on_default_website_rollback.php and create_quote_on_eu_website_rollback.php fixtures 
9.  magento-engcom/msi#1420: Avoid code fragments duplication in products_rollback.php and products_bundle_rollback.php fixtures 
10.  magento-engcom/msi#1421: Avoid code fragments duplication in products_rollback.php and products_virtual_rollback.php fixtures