### PR TITLE
MSI-1504: added check if website exist when saving the stock

### DIFF
--- a/app/code/Magento/InventoryApi/Test/Api/StockRepository/ValidationTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/StockRepository/ValidationTest.php
@@ -10,6 +10,7 @@ namespace Magento\InventoryApi\Test\Api\StockRepository;
 use Magento\Framework\Webapi\Exception;
 use Magento\Framework\Webapi\Rest\Request;
 use Magento\InventoryApi\Api\Data\StockInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
 use Magento\TestFramework\TestCase\WebapiAbstract;
 
 class ValidationTest extends WebapiAbstract
@@ -85,6 +86,44 @@ class ValidationTest extends WebapiAbstract
     {
         $data = $this->validData;
         $data[$field] = $value;
+
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH,
+                'httpMethod' => Request::HTTP_METHOD_POST,
+            ],
+            'soap' => [
+                'service' => self::SERVICE_NAME,
+                'operation' => self::SERVICE_NAME . 'Save',
+            ],
+        ];
+        $this->webApiCall($serviceInfo, $data, $expectedErrorData);
+    }
+
+    public function testFailedValidationWhenCreateOnNotExistingWebsite()
+    {
+        $notExistingWebsiteCode = 'NotExistingWebsite';
+        $data = $validData = [
+            StockInterface::NAME => 'stock-name',
+            StockInterface::EXTENSION_ATTRIBUTES_KEY => [
+                'sales_channels' => [[
+                    'type' => SalesChannelInterface::TYPE_WEBSITE,
+                    'code' => $notExistingWebsiteCode
+                ]]
+            ]
+        ];
+
+        $expectedErrorData = [
+            'message' => 'Validation Failed',
+            'errors' => [
+                [
+                    'message' => 'The website with code "%code" does not exist.',
+                    'parameters' => [
+                        'code' => $notExistingWebsiteCode,
+                    ],
+                ],
+            ],
+        ];
 
         $serviceInfo = [
             'rest' => [

--- a/app/code/Magento/InventoryApi/Test/Api/StockRepository/ValidationTest.php
+++ b/app/code/Magento/InventoryApi/Test/Api/StockRepository/ValidationTest.php
@@ -103,7 +103,7 @@ class ValidationTest extends WebapiAbstract
     public function testFailedValidationWhenCreateOnNotExistingWebsite()
     {
         $notExistingWebsiteCode = 'NotExistingWebsite';
-        $data = $validData = [
+        $data = [
             StockInterface::NAME => 'stock-name',
             StockInterface::EXTENSION_ATTRIBUTES_KEY => [
                 'sales_channels' => [[


### PR DESCRIPTION
### Description
Has been added check is website exist on stock save.

### Fixed Issues (if relevant)
1. magento-engcom/msi#1504: Stock grid disappears after assigning a sales channel to a stock via REST
2. magento-engcom/msi#1513: Cannot add products to cart with REST call

The issue reason was in StockRepositoryInterface, we were able to save the stock on the not existing website as a sale channel, and further WebsiteNameResolver could not resolve the name of the website.
In order to fix it, I've added the additional check to the validator.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
