### PR TITLE
More robust fix to https://github.com/magento-engcom/msi/issues/1524

### DIFF
--- a/app/code/Magento/InventorySourceSelection/Model/Request/InventoryRequest.php
+++ b/app/code/Magento/InventorySourceSelection/Model/Request/InventoryRequest.php
@@ -9,7 +9,6 @@ namespace Magento\InventorySourceSelection\Model\Request;
 
 use Magento\InventorySourceSelectionApi\Api\Data\InventoryRequestInterface;
 use Magento\InventorySourceSelectionApi\Api\Data\ItemRequestInterface;
-use Magento\InventorySourceSelectionApi\Api\Data\ItemRequestInterfaceFactory;
 
 /**
  * @inheritdoc
@@ -27,34 +26,13 @@ class InventoryRequest implements InventoryRequestInterface
     private $items;
 
     /**
-     * @var ItemRequestInterfaceFactory
-     */
-    private $itemRequestFactory;
-
-    /**
-     * @param ItemRequestInterfaceFactory $itemRequestFactory
      * @param int $stockId
      * @param ItemRequestInterface[] $items
      */
-    public function __construct(
-        ItemRequestInterfaceFactory $itemRequestFactory,
-        int $stockId,
-        array $items
-    ) {
+    public function __construct(int $stockId = null, array $items = null)
+    {
         $this->stockId = $stockId;
-        $this->itemRequestFactory = $itemRequestFactory;
-
-        //TODO: Temporary fix for resolving issue with webApi (https://github.com/magento-engcom/msi/issues/1524)
-        foreach ($items as $item) {
-            if (false === $item instanceof ItemRequestInterface) {
-                $this->items[] = $this->itemRequestFactory->create([
-                    'sku' => $item['sku'],
-                    'qty' => $item['qty']
-                ]);
-            } else {
-                $this->items[] = $item;
-            }
-        }
+        $this->items = $items;
     }
 
     /**
@@ -76,7 +54,7 @@ class InventoryRequest implements InventoryRequestInterface
     /**
      * @inheritdoc
      */
-    public function setStockId(int $stockId): void
+    public function setStockId($stockId)
     {
         $this->stockId = $stockId;
     }
@@ -84,7 +62,7 @@ class InventoryRequest implements InventoryRequestInterface
     /**
      * @inheritdoc
      */
-    public function setItems(array $items): void
+    public function setItems($items)
     {
         $this->items = $items;
     }

--- a/app/code/Magento/InventorySourceSelection/Model/Request/ItemRequest.php
+++ b/app/code/Magento/InventorySourceSelection/Model/Request/ItemRequest.php
@@ -53,7 +53,7 @@ class ItemRequest implements ItemRequestInterface
     /**
      * @inheritdoc
      */
-    public function setSku(string $sku): void
+    public function setSku($sku)
     {
         $this->sku = $sku;
     }
@@ -61,7 +61,7 @@ class ItemRequest implements ItemRequestInterface
     /**
      * @inheritdoc
      */
-    public function setQty(float $qty): void
+    public function setQty($qty)
     {
         $this->qty = $qty;
     }

--- a/app/code/Magento/InventorySourceSelection/Model/SourceSelectionService.php
+++ b/app/code/Magento/InventorySourceSelection/Model/SourceSelectionService.php
@@ -38,7 +38,9 @@ class SourceSelectionService implements SourceSelectionServiceInterface
     }
 
     /**
-     * @inheritdoc
+     * @param InventoryRequestInterface $inventoryRequest
+     * @param string $algorithmCode
+     * @return SourceSelectionResultInterface
      */
     public function execute(
         InventoryRequestInterface $inventoryRequest,

--- a/app/code/Magento/InventorySourceSelectionApi/Api/Data/InventoryRequestInterface.php
+++ b/app/code/Magento/InventorySourceSelectionApi/Api/Data/InventoryRequestInterface.php
@@ -34,7 +34,7 @@ interface InventoryRequestInterface
      * @param int $stockId
      * @return void
      */
-    public function setStockId(int $stockId): void;
+    public function setStockId($stockId);
 
     /**
      * Set Items
@@ -42,5 +42,5 @@ interface InventoryRequestInterface
      * @param \Magento\InventorySourceSelectionApi\Api\Data\ItemRequestInterface[] $items
      * @return void
      */
-    public function setItems(array $items): void;
+    public function setItems($items);
 }

--- a/app/code/Magento/InventorySourceSelectionApi/Api/Data/ItemRequestInterface.php
+++ b/app/code/Magento/InventorySourceSelectionApi/Api/Data/ItemRequestInterface.php
@@ -31,16 +31,16 @@ interface ItemRequestInterface
     /**
      * Set SKU
      *
-     * @param string $sku
+     * @param $sku
      * @return void
      */
-    public function setSku(string $sku): void;
+    public function setSku($sku);
 
     /**
      * Set Quantity
      *
-     * @param float $qty
+     * @param $qty
      * @return void
      */
-    public function setQty(float $qty): void;
+    public function setQty($qty);
 }

--- a/app/code/Magento/InventorySourceSelectionApi/Api/SourceSelectionServiceInterface.php
+++ b/app/code/Magento/InventorySourceSelectionApi/Api/SourceSelectionServiceInterface.php
@@ -18,7 +18,7 @@ use Magento\InventorySourceSelectionApi\Api\Data\SourceSelectionResultInterface;
 interface SourceSelectionServiceInterface
 {
     /**
-     * @param \Magento\InventorySourceSelectionApi\Api\Data\InventoryRequestInterface $inventoryRequest
+     * @param InventoryRequestInterface $inventoryRequest
      * @param string $algorithmCode
      * @return \Magento\InventorySourceSelectionApi\Api\Data\SourceSelectionResultInterface
      */

--- a/lib/internal/Magento/Framework/Reflection/Test/Unit/TypeProcessorTest.php
+++ b/lib/internal/Magento/Framework/Reflection/Test/Unit/TypeProcessorTest.php
@@ -8,6 +8,7 @@ namespace Magento\Framework\Reflection\Test\Unit;
 
 use Magento\Framework\Exception\SerializationException;
 use Magento\Framework\Reflection\Test\Unit\Fixture\TSample;
+use Magento\Framework\Reflection\Test\Unit\Fixture\TSampleInterface;
 use Magento\Framework\Reflection\TypeProcessor;
 use Zend\Code\Reflection\ClassReflection;
 
@@ -278,7 +279,7 @@ class TypeProcessorTest extends \PHPUnit\Framework\TestCase
     {
         return [
             ['method name' => 'addData', 'type' => 'array[]'],
-            ['method name' => 'addObjectList', 'type' => 'TSampleInterface[]']
+            ['method name' => 'addObjectList', 'type' => TSampleInterface::class . '[]']
         ];
     }
 

--- a/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
@@ -175,7 +175,7 @@ class ServiceInputProcessor implements ServicePayloadConverterInterface
         $preferenceClass = $this->config->getPreference($className);
         $class = new ClassReflection($preferenceClass ?: $className);
 
-        $constructor = $class->getConstructor();
+        $constructor = $class->getMethod('__construct');
         if ($constructor === null) {
             return [];
         }
@@ -184,7 +184,15 @@ class ServiceInputProcessor implements ServicePayloadConverterInterface
         $parameters = $constructor->getParameters();
         foreach ($parameters as $parameter) {
             if (isset($data[$parameter->getName()])) {
-                $res[$parameter->getName()] = $data[$parameter->getName()];
+                $parameterType = $this->typeProcessor->getParamType($parameter);
+
+                try {
+                    $res[$parameter->getName()] = $this->convertValue($data[$parameter->getName()], $parameterType);
+                } catch (\ReflectionException $e) {
+                    // Parameter was not correclty declared or the class is uknown.
+                    // By not returing the contructor value, we will automatically fall back to the "setters" way.
+                    continue;
+                }
             }
         }
 


### PR DESCRIPTION
This is a more robust fix for issue https://github.com/magento-engcom/msi/issues/1524 .
Also see: https://github.com/magento-engcom/msi/issues/1537 .

### Description
Other than fixing https://github.com/magento-engcom/msi/issues/1524 and https://github.com/magento-engcom/msi/issues/1537 , this commit also provides a Magento2 support for **non-FQN classes** in interfaces.

Before this commit you were not able to import class names in interfaces used for web-API.

For example, the following interface was not working with the non-FQN name `MyClass` imported through the `use` alias definition.
```
namespace ...;

use My\Module\MyClass;

interface SomeInterface
{
...
/**
 * @param MyClass $param
 * ...
 */
 public function getMyMethod()
 ...
...
}
```


### Fixed Issues (if relevant)
1. magento-engcom/msi#1537: Provide robust fix for nested object instantiation via Web API
2. magento-engcom/msi#1524: POST V1/inventory/source-selection-algorithm-result throws exception

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
