### PR TITLE
MSI-1547: Inconsistent menu names in backoffice 

### DIFF
--- a/app/code/Magento/InventoryAdminUi/etc/adminhtml/menu.xml
+++ b/app/code/Magento/InventoryAdminUi/etc/adminhtml/menu.xml
@@ -13,7 +13,7 @@
              module="Magento_Backend"
              sortOrder="15"
              parent="Magento_Backend::stores"
-             resource="Magento_InventoryAdminUi::inventory"/>
+             resource="Magento_InventoryApi::inventory"/>
         <add id="Magento_InventoryAdminUi::source"
              title="Sources"
              translate="title"

--- a/app/code/Magento/InventoryAdminUi/etc/adminhtml/menu.xml
+++ b/app/code/Magento/InventoryAdminUi/etc/adminhtml/menu.xml
@@ -7,20 +7,27 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
+        <add id="Magento_InventoryAdminUi::inventory"
+             title="Inventory"
+             translate="title"
+             module="Magento_Backend"
+             sortOrder="15"
+             parent="Magento_Backend::stores"
+             resource="Magento_InventoryAdminUi::inventory"/>
         <add id="Magento_InventoryAdminUi::source"
-             title="Manage Sources"
+             title="Sources"
              translate="title"
              module="Magento_InventoryAdminUi"
-             sortOrder="60"
-             parent="Magento_Backend::stores_settings"
+             sortOrder="10"
+             parent="Magento_InventoryAdminUi::inventory"
              action="inventory/source/index"
              resource="Magento_InventoryApi::source"/>
         <add id="Magento_InventoryAdminUi::stock"
-             title="Manage Stocks"
+             title="Stocks"
              translate="title"
              module="Magento_InventoryAdminUi"
-             sortOrder="70"
-             parent="Magento_Backend::stores_settings"
+             sortOrder="20"
+             parent="Magento_InventoryAdminUi::inventory"
              action="inventory/stock/index"
              resource="Magento_InventoryApi::stock"/>
     </menu>

--- a/app/code/Magento/InventoryApi/etc/acl.xml
+++ b/app/code/Magento/InventoryApi/etc/acl.xml
@@ -9,13 +9,17 @@
     <acl>
         <resources>
             <resource id="Magento_Backend::admin">
-                <resource id="Magento_InventoryApi::source" title="Inventory Sources" translate="title" sortOrder="10">
-                    <resource id="Magento_InventoryApi::source_edit" title="Edit Inventory Sources" translate="title" sortOrder="10" />
-                </resource>
-                <resource id="Magento_InventoryApi::stock" title="Inventory Stocks" translate="title" sortOrder="20">
-                    <resource id="Magento_InventoryApi::stock_edit" title="Edit Inventory Stocks" translate="title" sortOrder="10" />
-                    <resource id="Magento_InventoryApi::stock_delete" title="Delete Inventory Stocks" translate="title" sortOrder="20" />
-                    <resource id="Magento_InventoryApi::source_stock_link" title="Source to Stock Assigning" translate="title" sortOrder="30" />
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_InventoryApi::inventory" title="Inventory" translate="title" sortOrder="10">
+                        <resource id="Magento_InventoryApi::source" title="Sources" translate="title" sortOrder="10">
+                            <resource id="Magento_InventoryApi::source_edit" title="Edit Sources" translate="title" sortOrder="10" />
+                        </resource>
+                        <resource id="Magento_InventoryApi::stock" title="Stocks" translate="title" sortOrder="20">
+                            <resource id="Magento_InventoryApi::stock_edit" title="Edit Stocks" translate="title" sortOrder="10" />
+                            <resource id="Magento_InventoryApi::stock_delete" title="Delete Stocks" translate="title" sortOrder="20" />
+                            <resource id="Magento_InventoryApi::source_stock_link" title="Source to Stock Assigning" translate="title" sortOrder="30" />
+                        </resource>
+                    </resource>
                 </resource>
             </resource>
         </resources>


### PR DESCRIPTION
### Description
- Changed menu names and location. They have their own section in the stores menu.
- Changed ACL so that they are also displayed under the store menu.

### Fixed Issues
1. magento-engcom/msi#1547: Inconsistent menu names in backoffice 

### Manual testing scenarios
1. Login in to the backoffice open the stores menu and check changed location and names of "Inventory" items
2. Go into the user roles section and open up the role resources tab. The inventory roles are under the stores.