### PR TITLE
MSI-1552: MFTF Backorders enabled on Configuration page and applied from Homepage to Simple product on Single Stock mode

### DIFF
--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/BackordersEnabledOnConfigurationPageAndAppliedToSimpleProductOnSingleStockModeTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/BackordersEnabledOnConfigurationPageAndAppliedToSimpleProductOnSingleStockModeTest.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <test name="BackordersEnabledOnConfigurationPageAndAppliedToSimpleProductOnSingleStockModeTest">
+        <annotations>
+            <features value="Catalog"/>
+            <stories value="CatalogInventory stock option"/>
+            <title value="Backorders enabled on Configuration page and applied from Homepage to Simple product on Single Stock mode"/>
+            <description value="In single stock mode you should be able to create order with simple product and enabled backorders config"/>
+            <testCaseId value="1552"/>
+            <severity value="CRITICAL"/>
+            <group value="msi"/>
+            <group value="single_mode"/>
+        </annotations>
+        <before>
+            <comment userInput="Fill config 'Backorders'." stepKey="fillConfigComment"/>
+            <magentoCLI command="config:set cataloginventory/item_options/backorders 1" stepKey="fillConfigValue"/>
+
+            <comment userInput="Perform reindex and cache flush after fill 'Backorders' configuration config." stepKey="reindexCacheFlushAfterFillBackordersConfigComment"/>
+            <magentoCLI command="indexer:reindex" stepKey="performReindexAfterFillBackordersConfig"/>
+            <magentoCLI command="cache:flush" stepKey="cleanCacheAfterFillBackordersConfig"/>
+
+            <createData entity="SimpleSubCategory" stepKey="createCategory"/>
+            <createData entity="SimpleProduct" stepKey="createProduct">
+                <field key="price">10.00</field>
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+            <createData entity="Msi_US_Customer" stepKey="createCustomer"/>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginToAdminArea"/>
+            <waitForPageLoad stepKey="waitForDashboardLoad"/>
+
+            <comment userInput="Assign main website to default stock" stepKey="assignChannelToStockComment"/>
+            <amOnPage url="{{AdminManageStockPage.url}}" stepKey="navigateToStockListPageToAssignMainWebsiteToDefaultStock"/>
+            <waitForPageLoad time="30" stepKey="waitForStockListPageLoad"/>
+            <actionGroup ref="searchAdminDataGridByKeyword" stepKey="searchDefaultStockByNameForAssignMainWebsiteChannel">
+                <argument name="keyword" value="_defaultStock.name"/>
+            </actionGroup>
+            <click selector="{{AdminGridRow.editByValue(_defaultStock.name)}}" stepKey="clickEditDefaultStock"/>
+            <waitForPageLoad time="30" stepKey="waitForDefaultStockPageLoaded"/>
+            <selectOption selector="{{AdminEditStockSalesChannelsSection.websites}}" userInput="Main Website" stepKey="selectDefaultWebsiteAsSalesChannelForDefaultStock"/>
+            <click selector="{{AdminGridMainControls.saveAndContinue}}" stepKey="saveDefaultStock"/>
+        </before>
+        <after>
+            <comment userInput="Revert config 'Backorders' changes." stepKey="revertConfigChangesComment"/>
+            <magentoCLI command="config:set cataloginventory/item_options/backorders 0" stepKey="revertConfigValue"/>
+
+            <comment userInput="Perform reindex and cache flush after revert 'Backorders' configuration config." stepKey="reindexCacheFlushAfterFillBackordersConfigComment"/>
+            <magentoCLI command="indexer:reindex" stepKey="performReindexAfterRevertBackordersConfig"/>
+            <magentoCLI command="cache:flush" stepKey="cleanCacheAfterRevertBackordersConfig"/>
+
+            <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
+        </after>
+        <comment userInput="Customer login to storefront." stepKey="customerLoginToStorefrontComment"/>
+        <actionGroup ref="LoginToStorefrontActionGroup" stepKey="loginToStorefront">
+            <argument name="Customer" value="$$createCustomer$$"/>
+        </actionGroup>
+
+        <comment userInput="Add product to cart." stepKey="addProductToCartComment"/>
+        <amOnPage url="{{StorefrontCategoryPage.url($$createCategory.name$$)}}" stepKey="navigateToCategory"/>
+        <waitForPageLoad time="30" stepKey="waitForCategoryPageLoad"/>
+        <click selector="{{StorefrontCategoryMainSection.specifiedProductItemInfo($$createProduct.product[name]$$)}}" stepKey="openProductPage"/>
+        <waitForAjaxLoad stepKey="waitForImageLoader"/>
+        <fillField selector="{{StorefrontProductPageSection.qtyInput}}" userInput="1001" stepKey="fillCorrectQuantity"/>
+        <click selector="{{StorefrontProductPageSection.addToCartBtn}}" stepKey="addProductToCart"/>
+        <waitForElementVisible selector="{{StorefrontProductPageSection.successMsg}}" time="30" stepKey="waitForProductAdded"/>
+        <conditionalClick selector="{{StorefrontMinicartSection.showCart}}" dependentSelector="{{StorefrontMinicartSection.miniCartOpened}}" visible="false" stepKey="openMiniCart"/>
+        <waitForElementVisible selector="{{StorefrontMinicartSection.viewAndEditCart}}" stepKey="waitForViewAndEditCartVisible"/>
+        <click selector="{{StorefrontMinicartSection.goToCheckout}}" stepKey="goToCheckout"/>
+        <waitForElementVisible selector="{{CheckoutShippingMethodsSection.firstShippingMethod}}" stepKey="waitForShippingMethodsLoad"/>
+        <click selector="{{CheckoutShippingMethodsSection.firstShippingMethod}}" stepKey="selectShippingMethod"/>
+        <waitForElement selector="{{CheckoutShippingMethodsSection.next}}" time="30" stepKey="waitForNextButtonVisible"/>
+        <click selector="{{CheckoutShippingMethodsSection.next}}" stepKey="navigateToSecondCheckoutStep"/>
+        <waitForPageLoad stepKey="waitFroPaymentSelectionPageLoad"/>
+        <actionGroup ref="CheckoutSelectCheckMoneyOrderPaymentActionGroup" stepKey="selectCheckMoneyOrderPayment"/>
+        <waitForElement selector="{{CheckoutPaymentSection.placeOrder}}" time="30" stepKey="waitForPlaceOrderButtonVisible"/>
+        <see selector="{{CheckoutPaymentSection.billingAddress}}" userInput="{{US_Address_TX.street[0]}}" stepKey="chooseBillingAddress"/>
+        <click selector="{{CheckoutPaymentSection.placeOrder}}" stepKey="placeOrder"/>
+        <waitForPageLoad stepKey="waitUntilOrderPlaced"/>
+        <grabTextFrom selector="{{CheckoutSuccessMainSection.orderNumber22}}" stepKey="grabOrderNumber"/>
+        <see selector="{{CheckoutSuccessMainSection.success}}" userInput="Your order number is:" stepKey="checkOrderPlaceSuccessMessage"/>
+
+        <comment userInput="Go to order in admin panel for verify data." stepKey="searchAndVerifyOrderDataComment"/>
+        <amOnPage url="{{AdminOrdersPage.url}}" stepKey="goToOrderPage"/>
+        <waitForPageLoad time="30" stepKey="waitForOrdersPageLoad"/>
+        <fillField selector="{{AdminOrdersGridSection.search}}" userInput="{$grabOrderNumber}" stepKey="searchOrderByNumber"/>
+        <click selector="{{AdminOrdersGridSection.submitSearch}}" stepKey="submitSearch"/>
+        <waitForPageLoad time="30" stepKey="waitForSearchWillBeSubmited"/>
+        <click selector="{{AdminOrdersGridSection.firstRow}}" stepKey="clickOrderRow"/>
+        <waitForPageLoad time="30" stepKey="waitForOrderPageWillBeOpened"/>
+        <see selector="{{AdminOrderItemsOrderedSection.itemQty('1')}}" userInput="Ordered 1001" stepKey="seeOrderedQty"/>
+        <see selector="{{AdminOrderItemsOrderedSection.itemProductName('1')}}" userInput="$$createProduct.product[name]$$" stepKey="seeOrderedProductName"/>
+        <see selector="{{AdminOrderItemsOrderedSection.itemProductSku('1')}}" userInput="$$createProduct.product[sku]$$" stepKey="seeOrderedProductSku"/>
+    </test>
+</tests>


### PR DESCRIPTION
### Description

URL to [hiptest scenario](https://app.hiptest.com/projects/69435/test-plan/folders/432631/scenarios/2125570)

### Fixed Issues (if relevant)

1. [magento-engcom/msi-1552](https://github.com/magento-engcom/msi/issues/1552): MFTF Backorders enabled on Configuration page and applied from Homepage to Simple product on Single Stock mode

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
