### PR TITLE
FIX for issue https://github.com/magento-engcom/msi/issues/1652

### DIFF
--- a/app/code/Magento/InventoryCatalogAdminUi/Model/GetSourceItemsDataBySku.php
+++ b/app/code/Magento/InventoryCatalogAdminUi/Model/GetSourceItemsDataBySku.php
@@ -34,6 +34,7 @@ class GetSourceItemsDataBySku
      * @param SourceItemRepositoryInterface $sourceItemRepository
      * @param SourceRepositoryInterface $sourceRepository
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @SuppressWarnings(PHPMD.LongVariable)
      */
     public function __construct(
         SourceItemRepositoryInterface $sourceItemRepository,
@@ -47,8 +48,8 @@ class GetSourceItemsDataBySku
 
     /**
      * @param string $sku
-     *
      * @return array
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function execute(string $sku): array
     {
@@ -59,8 +60,14 @@ class GetSourceItemsDataBySku
             ->create();
         $sourceItems = $this->sourceItemRepository->getList($searchCriteria)->getItems();
 
+        $sourcesCache = [];
         foreach ($sourceItems as $sourceItem) {
-            $source = $this->sourceRepository->get($sourceItem->getSourceCode());
+            $sourceCode = $sourceItem->getSourceCode();
+            if (!isset($sourcesCache[$sourceCode])) {
+                $sourcesCache[$sourceCode] = $this->sourceRepository->get($sourceCode);
+            }
+
+            $source = $sourcesCache[$sourceCode];
 
             $sourceItemsData[] = [
                 SourceItemInterface::SOURCE_CODE => $sourceItem->getSourceCode(),

--- a/app/code/Magento/InventoryCatalogAdminUi/Test/Integration/GetSourceItemsDataBySkuTest.php
+++ b/app/code/Magento/InventoryCatalogAdminUi/Test/Integration/GetSourceItemsDataBySkuTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalogAdminUi\Test\Integration;
+
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryCatalogAdminUi\Model\GetSourceItemsDataBySku;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class GetSourceItemsDataBySkuTest extends TestCase
+{
+    /**
+     * @var GetSourceItemsDataBySku
+     */
+    private $getSourceItemsDataBySku;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->getSourceItemsDataBySku = Bootstrap::getObjectManager()->get(GetSourceItemsDataBySku::class);
+    }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items.php
+     */
+    public function testExecute()
+    {
+        $sourceItems = $this->getSourceItemsDataBySku->execute('SKU-1');
+
+        $sourceCodes = [];
+        foreach ($sourceItems as $sourceItem) {
+            $sourceCodes[] = $sourceItem[SourceItemInterface::SOURCE_CODE];
+        }
+
+        self::assertContains('eu-1', $sourceCodes);
+        self::assertContains('eu-2', $sourceCodes);
+        self::assertContains('eu-3', $sourceCodes);
+        self::assertContains('eu-disabled', $sourceCodes);
+    }
+}


### PR DESCRIPTION
### Description
`\Magento\InventoryCatalogAdminUi\Model\GetSourceItemsDataBySku::execute` was calling the `SourceRepository` for each item in the iteration.

A cache was added to avoid unnecessary MySQL calls.

A missing test coverage for `\Magento\InventoryCatalogAdminUi\Model\GetSourceItemsDataBySku::execute` was also added.

### Fixed Issues (if relevant)
1. magento-engcom/msi#1652: Reduce the number of calls to MySQL in \Magento\InventoryCatalogAdminUi\Model\GetSourceItemsDataBySku

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
