### PR TITLE
MSI-1664: Decimal qty could be added to cart when it's not configured for product.

### DIFF
--- a/app/code/Magento/InventoryApi/Test/_files/products.php
+++ b/app/code/Magento/InventoryApi/Test/_files/products.php
@@ -28,7 +28,8 @@ $stockData = [
     'SKU-1' => [
         'qty' => 8.5,
         'is_in_stock' => true,
-        'manage_stock' => true
+        'manage_stock' => true,
+        'is_qty_decimal' => 1,
     ],
     'SKU-2' => [
         'qty' => 5,

--- a/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
@@ -123,9 +123,9 @@ class CheckQuoteItemQtyPlugin
         $result->setItemIsQtyDecimal($stockItem->getIsQtyDecimal());
         if (!$stockItem->getIsQtyDecimal()) {
             $result->setHasQtyOptionUpdate(true);
-            $itemQty = intval($itemQty);
+            $itemQty = (int)$itemQty;
             $result->setItemQty($itemQty);
-            $origQty = intval($origQty);
+            $origQty = (int)$origQty;
             $result->setOrigQty($origQty);
         }
 

--- a/app/code/Magento/InventorySales/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnDefaultStockTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnDefaultStockTest.php
@@ -74,13 +74,16 @@ class AddSalesQuoteItemOnDefaultStockTest extends TestCase
      * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
      * @magentoDataFixture ../../../../app/code/Magento/InventoryCatalog/Test/_files/source_items_on_default_source.php
      * @magentoDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
+     * @dataProvider addInStockProductToQuoteDataProvider
+     *
+     * @param string $productSku
+     * @param float $productQty
+     * @param float $expectedQtyInCart
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
      */
-    public function testAddInStockProductToQuote()
+    public function testAddInStockProductToQuote(string $productSku, float $productQty, float $expectedQtyInCart): void
     {
-        $productSku = 'SKU-1';
-        $productQty = 4;
-        $expectedQtyInCart = 4;
-
         $product = $this->getProductBySku($productSku);
         $quote = $this->getQuote();
 
@@ -89,6 +92,21 @@ class AddSalesQuoteItemOnDefaultStockTest extends TestCase
         /** @var CartItemInterface $quoteItem */
          $quoteItem = current($quote->getAllItems());
          self::assertEquals($expectedQtyInCart, $quoteItem->getQty());
+    }
+
+    /**
+     * Data Provider for testAddInStockProductToQuote.
+     *
+     * @return array
+     */
+    public function addInStockProductToQuoteDataProvider() : array
+    {
+        return [
+            'Add integer quantity while decimal product quantity is enabled' => ['SKU-1', 4, 4],
+            'Add decimal quantity while decimal product quantity is enabled' => ['SKU-1', 4.5, 4.5],
+            'Add integer quantity while decimal product quantity is disabled' => ['SKU-2', 4, 4],
+            'Add decimal quantity while decimal product quantity is disabled' => ['SKU-2', 4.5, 4],
+        ];
     }
 
     /**

--- a/app/code/Magento/InventorySales/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnNotDefaultStockTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnNotDefaultStockTest.php
@@ -84,13 +84,10 @@ class AddSalesQuoteItemOnNotDefaultStockTest extends TestCase
      * @param string $sku
      * @param int $stockId
      * @param float $qty
+     * @param float $expectedQtyInCar
      *
      * @throws LocalizedException
      * @throws NoSuchEntityException
-     * @throws CouldNotSaveException
-     * @throws InputException
-     * @throws ValidationException
-     *
      * @dataProvider productsInStockDataProvider
      *
      * @magentoDbIsolation disabled
@@ -98,7 +95,8 @@ class AddSalesQuoteItemOnNotDefaultStockTest extends TestCase
     public function testAddInStockProductToQuote(
         string $sku,
         int $stockId,
-        float $qty
+        float $qty,
+        float $expectedQtyInCar
     ) {
         $quote = $this->getQuote($stockId);
         $product = $this->getProductBySku($sku);
@@ -107,7 +105,7 @@ class AddSalesQuoteItemOnNotDefaultStockTest extends TestCase
 
         /** @var CartItemInterface $quoteItem */
         $quoteItem = current($quote->getAllItems());
-        self::assertEquals($qty, $quoteItem->getQty());
+        self::assertEquals($expectedQtyInCar, $quoteItem->getQty());
     }
 
     /**
@@ -117,10 +115,10 @@ class AddSalesQuoteItemOnNotDefaultStockTest extends TestCase
     public function productsInStockDataProvider(): array
     {
         return [
-            ['SKU-1', 10, 4],
-            ['SKU-1', 10, 2],
-            ['SKU-2', 30, 3],
-            ['SKU-2', 30, 1]
+            'Add integer quantity while decimal product quantity is enabled' => ['SKU-1', 10, 4, 4],
+            'Add decimal quantity while decimal product quantity is enabled' => ['SKU-1', 10, 4.5, 4.5],
+            'Add integer quantity while decimal product quantity is disabled' => ['SKU-2', 30, 4, 4],
+            'Add decimal quantity while decimal product quantity is disabled' => ['SKU-2', 30, 4.5, 4]
         ];
     }
 
@@ -173,7 +171,7 @@ class AddSalesQuoteItemOnNotDefaultStockTest extends TestCase
             ['SKU-1', 20, 6],
             ['SKU-1', 30, 9],
             ['SKU-2', 10, 1.5],
-            ['SKU-2', 30, 5.5],
+            ['SKU-2', 30, 6.5],
             ['SKU-3', 20, 1.9]
         ];
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
'is_qty_decimal' Product value is now taken into consideration while adding decimal Product quantity to Cart.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#1664: Decimal qty could be added to cart when it's not configured for product.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Simple product created with turned 'Off' - 'Use decimals' in Advanced inventory
2. Open product page on frontend
3. Set qty 1.34 and add it to shopping cart
4. To shopping cart should be added 1 item

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
