### PR TITLE
FIX for issue #1672 - Wrong contract in `\Magento\InventorySales\Plug…

### DIFF
--- a/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
@@ -106,7 +106,7 @@ class CheckQuoteItemQtyPlugin
         $itemQty,
         $qtyToCheck,
         $origQty,
-        $scopeId
+        $scopeId = null
     ) {
         $result = $this->objectFactory->create();
         $result->setHasError(false);

--- a/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
@@ -66,6 +66,7 @@ class CheckQuoteItemQtyPlugin
      * @param StockResolverInterface $stockResolver
      * @param StoreManagerInterface $storeManager
      * @param BackOrderNotifyCustomerCondition $backOrderNotifyCustomerCondition
+     * @SuppressWarnings(PHPMD.LongVariable)
      */
     public function __construct(
         ObjectFactory $objectFactory,
@@ -86,6 +87,8 @@ class CheckQuoteItemQtyPlugin
     }
 
     /**
+     * Replace legacy quote item check
+     *
      * @param StockStateInterface $subject
      * @param \Closure $proceed
      * @param int $productId

--- a/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
@@ -21,6 +21,9 @@ use Magento\InventorySalesApi\Api\IsProductSalableForRequestedQtyInterface;
 use Magento\InventorySalesApi\Api\StockResolverInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
+/**
+ * Replace legacy quote item check
+ */
 class CheckQuoteItemQtyPlugin
 {
     /**
@@ -145,6 +148,8 @@ class CheckQuoteItemQtyPlugin
     }
 
     /**
+     * Convert quantity to a valid float
+     *
      * @param string|float|int|null $qty
      *
      * @return float|null

--- a/app/code/Magento/InventorySales/Plugin/StockState/SuggestQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/SuggestQtyPlugin.php
@@ -49,6 +49,7 @@ class SuggestQtyPlugin
      * @param StockResolverInterface $stockResolver
      * @param StoreManagerInterface $storeManager
      * @param GetStockItemConfigurationInterface $getStockItemConfiguration
+     * @SuppressWarnings(PHPMD.LongVariable)
      */
     public function __construct(
         GetProductSalableQtyInterface $getProductSalableQty,
@@ -65,6 +66,8 @@ class SuggestQtyPlugin
     }
 
     /**
+     * Replace legacy suggest quantity
+     *
      * @param StockStateInterface $subject
      * @param \Closure $proceed
      * @param int $productId
@@ -74,6 +77,7 @@ class SuggestQtyPlugin
      *
      * @return float
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @SuppressWarnings(PHPMD.LongVariable)
      */
     public function aroundSuggestQty(
         StockStateInterface $subject,

--- a/app/code/Magento/InventorySales/Plugin/StockState/SuggestQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/SuggestQtyPlugin.php
@@ -16,6 +16,9 @@ use Magento\InventorySalesApi\Api\GetProductSalableQtyInterface;
 use Magento\InventorySalesApi\Api\StockResolverInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
+/**
+ * Replace legacy suggest quantity
+ */
 class SuggestQtyPlugin
 {
     /**

--- a/app/code/Magento/InventorySales/Plugin/StockState/SuggestQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/SuggestQtyPlugin.php
@@ -80,7 +80,7 @@ class SuggestQtyPlugin
         \Closure $proceed,
         $productId,
         $qty,
-        $scopeId
+        $scopeId = null
     ): float {
         try {
             $skus = $this->getSkusByProductIds->execute([$productId]);


### PR DESCRIPTION
### Description
`\Magento\InventorySales\Plugin\StockState\CheckQuoteItemQtyPlugin::aroundCheckQuoteItemQty` should respect the pluginized method contract:

public function checkQuoteItemQty($productId, $itemQty, $qtyToCheck, $origQty, $scopeId = null);

But the last method in the plugin in not optional:

```
public function aroundCheckQuoteItemQty(
        StockStateInterface $subject,
        \Closure $proceed,
        $productId,
        $itemQty,
        $qtyToCheck,
        $origQty,
        $scopeId <-----
    ) {
```

Same problem in:
\Magento\InventorySales\Plugin\StockState\SuggestQtyPlugin::aroundSuggestQty

### Fixed Issues (if relevant)
1. magento/magento2#1672: Wrong contract

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
