### PR TITLE
MSI-1674: Adapt Static Test which checks DevBlocks to exclude all Inventory* modules.

### DIFF
--- a/dev/tests/static/framework/Magento/ruleset.xml
+++ b/dev/tests/static/framework/Magento/ruleset.xml
@@ -26,18 +26,21 @@
         <exclude-pattern>*/_files/*</exclude-pattern>
         <exclude-pattern>*/Test/*</exclude-pattern>
         <exclude-pattern>*Test.php</exclude-pattern>
+        <exclude-pattern>*/Inventory*/*</exclude-pattern>
     </rule>
     <rule ref="Magento.Annotation.MethodAnnotationStructure">
         <include-pattern>*\.(php)</include-pattern>
         <exclude-pattern>*/Test/*</exclude-pattern>
         <exclude-pattern>*Test.php</exclude-pattern>
         <exclude-pattern>*/_files/*</exclude-pattern>
+        <exclude-pattern>*/Inventory*/*</exclude-pattern>
     </rule>
     <rule ref="Magento.Annotation.ClassAnnotationStructure">
         <include-pattern>*\.(php)</include-pattern>
         <exclude-pattern>*/Test/*</exclude-pattern>
         <exclude-pattern>*Test.php</exclude-pattern>
         <exclude-pattern>*/_files/*</exclude-pattern>
+        <exclude-pattern>*/Inventory*/*</exclude-pattern>
     </rule>
     <rule ref="Magento.Functions.OutputBuffering">
         <include-pattern>*/(app/code|vendor|setup/src|lib/internal/Magento)/*</include-pattern>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#1674: Adapt Static Test which checks DevBlocks to exclude all Inventory* modules.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Delete Class Annotation and add a redundant blank lines in any MSI project class.
2. Run dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
3. Only one error found:
```
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 23 | ERROR | Code must not contain multiple empty lines in a row;
    |       | found 3 empty lines
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
