### PR TITLE
Fix for issue 1658 - Fix Dynamic Rows for Sources

### DIFF
--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_stock_form.xml
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_stock_form.xml
@@ -139,6 +139,7 @@
                         <dataType>text</dataType>
                         <dataScope>source_code</dataScope>
                         <label translate="true">Code</label>
+                        <labelVisible>false</labelVisible>
                     </settings>
                 </field>
                 <field name="name" formElement="input" sortOrder="20">
@@ -147,6 +148,7 @@
                         <dataType>text</dataType>
                         <dataScope>name</dataScope>
                         <label translate="true">Name</label>
+                        <labelVisible>false</labelVisible>
                     </settings>
                 </field>
                 <field name="priority" formElement="input" sortOrder="30">

--- a/app/code/Magento/Ui/view/base/web/templates/form/field.html
+++ b/app/code/Magento/Ui/view/base/web/templates/form/field.html
@@ -8,8 +8,8 @@
      visible="visible"
      css="$data.additionalClasses"
      attr="'data-index': index">
-    <div class="admin__field-label">
-        <label if="$data.label" visible="$data.labelVisible"  attr="for: uid">
+    <div class="admin__field-label" if="$data.label" visible="$data.labelVisible">
+        <label attr="for: uid">
             <span translate="label" attr="'data-config-scope': $data.scopeLabel" />
         </label>
     </div>


### PR DESCRIPTION
### Description
A regression for dynamic rows was added in eb173dd1b90cf3c729ec10dd115652b56586108a .
This fix partially reverts it keeping a backward compatibility.

### Fixed Issues (if relevant)
1. magento-engcom/msi#1658: Fix Dynamic Rows for Sources

### Manual testing scenarios
1. access admin panel
2. go to stores > stocks
3. open one stock with sources
4. the grid should not have UI misalignments

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
