### PR TITLE
MSI-1696: Configurable isn't available on custom website

### DIFF
--- a/app/code/Magento/InventoryCatalog/etc/di.xml
+++ b/app/code/Magento/InventoryCatalog/etc/di.xml
@@ -21,7 +21,7 @@
                 type="Magento\InventoryCatalog\Plugin\InventoryApi\SetDataToLegacyCatalogInventoryAtSourceItemsSavePlugin"/>
     </type>
     <type name="Magento\InventoryIndexer\Indexer\SourceItem\SourceItemIndexer">
-        <plugin name="priceIndexUpdater" type="Magento\InventoryCatalog\Plugin\InventoryIndexer\Indexer\SourceItem\PriceIndexUpdater"/>
+        <plugin name="priceIndexUpdater" type="Magento\InventoryCatalog\Plugin\InventoryIndexer\Indexer\SourceItem\PriceIndexUpdater" sortOrder="20"/>
     </type>
     <type name="Magento\InventoryIndexer\Indexer\Stock\StockIndexer">
         <plugin name="priceIndexUpdater" type="Magento\InventoryCatalog\Plugin\InventoryIndexer\Indexer\Stock\PriceIndexUpdater"/>

--- a/app/code/Magento/InventoryConfigurableProductIndexer/etc/di.xml
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/etc/di.xml
@@ -8,7 +8,7 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\InventoryIndexer\Indexer\SourceItem\SourceItemIndexer">
-        <plugin name="configurable_product_index" type="Magento\InventoryConfigurableProductIndexer\Plugin\InventoryIndexer\SourceItemIndexerPlugin"/>
+        <plugin name="configurable_product_index" type="Magento\InventoryConfigurableProductIndexer\Plugin\InventoryIndexer\SourceItemIndexerPlugin" sortOrder="10"/>
     </type>
     <type name="Magento\InventoryIndexer\Indexer\Stock\StockIndexer">
         <plugin name="configurable_product_index" type="Magento\InventoryConfigurableProductIndexer\Plugin\InventoryIndexer\StockIndexerPlugin"/>


### PR DESCRIPTION
### Description

It's happened because configurable was indexed after price index, I've added sort order to plugins.

### Fixed Issues (if relevant)
1. [magento-engcom/msi-1696](https://github.com/magento-engcom/msi/issues/1696): Configurable isn't available on custom website

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
