### PR TITLE
Adding 'Assigned sources list' column to 'Manage Stock' grid

### DIFF
--- a/app/code/Magento/InventoryAdminUi/Ui/DataProvider/StockDataProvider.php
+++ b/app/code/Magento/InventoryAdminUi/Ui/DataProvider/StockDataProvider.php
@@ -77,6 +77,8 @@ class StockDataProvider extends DataProvider
      * @param SourceRepositoryInterface $sourceRepository
      * @param SearchCriteriaBuilder $apiSearchCriteriaBuilder
      * @param SortOrderBuilder $sortOrderBuilder
+     * @param array $meta
+     * @param array $data
      * @param GetSourcesAssignedToStockOrderedByPriorityInterface $getSourcesAssignedToStockOrderedByPriority
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) All parameters are needed for backward compatibility
      */

--- a/app/code/Magento/InventoryAdminUi/Ui/DataProvider/StockDataProvider.php
+++ b/app/code/Magento/InventoryAdminUi/Ui/DataProvider/StockDataProvider.php
@@ -142,8 +142,7 @@ class StockDataProvider extends DataProvider
             } else {
                 $data = [];
             }
-        }
-        if ('inventory_stock_listing_data_stock' === $this->name) {
+        } elseif ('inventory_stock_listing_data_stock' === $this->name) {
             if ($data['totalRecords'] > 0) {
                 foreach ($data['items'] as $index => $stock) {
                     $data['items'][$index]['assigned_sources'] = $this->getAssignedSourcesById($stock['stock_id']);
@@ -220,7 +219,7 @@ class StockDataProvider extends DataProvider
         $sourcesData = [];
         foreach ($sources as $source) {
             $sourcesData[] = [
-                'source_code' => $source->getSourceCode(),
+                'sourceCode' => $source->getSourceCode(),
                 'name' => $source->getName()
             ];
         }

--- a/app/code/Magento/InventoryAdminUi/Ui/DataProvider/StockDataProvider.php
+++ b/app/code/Magento/InventoryAdminUi/Ui/DataProvider/StockDataProvider.php
@@ -17,6 +17,7 @@ use Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider;
 use Magento\InventoryApi\Api\Data\SourceInterface;
 use Magento\InventoryApi\Api\Data\StockInterface;
 use Magento\InventoryApi\Api\Data\StockSourceLinkInterface;
+use Magento\InventoryApi\Api\GetSourcesAssignedToStockOrderedByPriorityInterface;
 use Magento\InventoryApi\Api\GetStockSourceLinksInterface;
 use Magento\InventoryApi\Api\SourceRepositoryInterface;
 use Magento\InventoryApi\Api\StockRepositoryInterface;
@@ -57,6 +58,10 @@ class StockDataProvider extends DataProvider
      * @var SortOrderBuilder
      */
     private $sortOrderBuilder;
+    /**
+     * @var GetSourcesAssignedToStockOrderedByPriorityInterface
+     */
+    private $getSourcesAssignedToStockOrderedByPriority;
 
     /**
      * @param string $name
@@ -72,8 +77,7 @@ class StockDataProvider extends DataProvider
      * @param SourceRepositoryInterface $sourceRepository
      * @param SearchCriteriaBuilder $apiSearchCriteriaBuilder
      * @param SortOrderBuilder $sortOrderBuilder
-     * @param array $meta
-     * @param array $data
+     * @param GetSourcesAssignedToStockOrderedByPriorityInterface $getSourcesAssignedToStockOrderedByPriority
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) All parameters are needed for backward compatibility
      */
     public function __construct(
@@ -90,6 +94,7 @@ class StockDataProvider extends DataProvider
         SourceRepositoryInterface $sourceRepository,
         SearchCriteriaBuilder $apiSearchCriteriaBuilder,
         SortOrderBuilder $sortOrderBuilder,
+        GetSourcesAssignedToStockOrderedByPriorityInterface $getSourcesAssignedToStockOrderedByPriority,
         array $meta = [],
         array $data = []
     ) {
@@ -110,6 +115,7 @@ class StockDataProvider extends DataProvider
         $this->sourceRepository = $sourceRepository;
         $this->apiSearchCriteriaBuilder = $apiSearchCriteriaBuilder;
         $this->sortOrderBuilder = $sortOrderBuilder;
+        $this->getSourcesAssignedToStockOrderedByPriority = $getSourcesAssignedToStockOrderedByPriority;
     }
 
     /**
@@ -135,6 +141,16 @@ class StockDataProvider extends DataProvider
                 $data = [];
             }
         }
+        if ('inventory_stock_listing_data_stock' === $this->name) {
+            if ($data['totalRecords'] > 0) {
+                foreach ($data['items'] as $index => $stock) {
+                    $data['items'][$index]['assigned_sources'] = $this->getAssignedSourcesById($stock['stock_id']);
+                }
+            } else {
+                $data = [];
+            }
+        }
+
         return $data;
     }
 
@@ -188,5 +204,25 @@ class StockDataProvider extends DataProvider
             ];
         }
         return $assignedSourcesData;
+    }
+
+    /**
+     * @param int $stockId
+     * @return array
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    private function getAssignedSourcesById(int $stockId): array
+    {
+        $sources = $this->getSourcesAssignedToStockOrderedByPriority->execute($stockId);
+        $sourcesData = [];
+        foreach ($sources as $source) {
+            $sourcesData[] = [
+                'source_code' => $source->getSourceCode(),
+                'name' => $source->getName()
+            ];
+        }
+
+        return $sourcesData;
     }
 }

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_stock_listing.xml
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_stock_listing.xml
@@ -123,7 +123,7 @@
                 component="Magento_InventoryAdminUi/js/stock/grid/cell/assigned-sources"
                 sortOrder="40">
             <settings>
-                <label translate="true">Assigned sources list</label>
+                <label translate="true">Assigned sources</label>
                 <sortable>false</sortable>
             </settings>
         </column>

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_stock_listing.xml
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_stock_listing.xml
@@ -119,6 +119,14 @@
                 </editor>
             </settings>
         </column>
+        <column name="assigned_sources"
+                component="Magento_InventoryAdminUi/js/stock/grid/cell/assigned-sources"
+                sortOrder="40">
+            <settings>
+                <label translate="true">Assigned sources list</label>
+                <sortable>false</sortable>
+            </settings>
+        </column>
         <actionsColumn name="actions" class="Magento\Backend\Ui\Component\Listing\Column\EditAction" sortOrder="100">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
@@ -3,8 +3,9 @@
  * See COPYING.txt for license details.
  */
 define([
-    'Magento_Ui/js/grid/columns/column'
-], function (Column) {
+    'Magento_Ui/js/grid/columns/column',
+    'underscore'
+], function (Column, _) {
     'use strict';
 
     return Column.extend({

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define([
+    'Magento_Ui/js/grid/columns/column'
+], function (Column) {
+    'use strict';
+
+    return Column.extend({
+        defaults: {
+            bodyTmpl: 'Magento_InventoryAdminUi/stock/grid/cell/assigned-sources-cell.html'
+        },
+
+        /**
+         * Get sales channels grouped by type
+         *
+         * @param {Object} record - Record object
+         * @returns {Array} Result array
+         */
+        getSourcesAssignedToStockOrderedByPriority: function (record) {
+            var result = [];
+
+            _.each(record[this.index], function (source) {
+                result.push({
+                    source_code: source.source_code,
+                    name: source.name
+                });
+            });
+
+            return result;
+        }
+    });
+});

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
@@ -21,7 +21,7 @@ define([
 
             _.each(record[this.index], function (source) {
                 result.push({
-                    source_code: source.source_code,
+                    sourceCode: source.sourceCode,
                     name: source.name
                 });
             });

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
@@ -13,8 +13,6 @@ define([
         },
 
         /**
-         * Get sales channels grouped by type
-         *
          * @param {Object} record - Record object
          * @returns {Array} Result array
          */

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/template/stock/grid/cell/assigned-sources-cell.html
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/template/stock/grid/cell/assigned-sources-cell.html
@@ -8,7 +8,7 @@
     <ul data-bind="foreach: { data: $col.getSourcesAssignedToStockOrderedByPriority($row()), as: '$assignedSource' }">
         <li>
             <span data-bind="text: $assignedSource.name"></span>
-            (<span data-bind="text: $assignedSource.source_code"></span>)
+            (<span data-bind="text: $assignedSource.sourceCode"></span>)
         </li>
     </ul>
 </div>

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/template/stock/grid/cell/assigned-sources-cell.html
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/template/stock/grid/cell/assigned-sources-cell.html
@@ -1,0 +1,14 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<div class="data-grid-cell-content">
+    <ul data-bind="foreach: { data: $col.getSourcesAssignedToStockOrderedByPriority($row()), as: '$assignedSource' }">
+        <li>
+            <span data-bind="text: $assignedSource.name"></span>
+            (<span data-bind="text: $assignedSource.source_code"></span>)
+        </li>
+    </ul>
+</div>


### PR DESCRIPTION
### Description
Added new column to manage stock grid

### Fixed Issues
1. [Add 'Assigned sources list' column to 'Manage Stock' grid #1711](https://github.com/magento-engcom/msi/issues/1711)

### Manual testing scenarios
1. Go to Admin Panel->Menu->Stores->Inventory->Stocks.
2. Check if column "Assigned sources list" exists.
