### PR TITLE
MSI-1740: Failed web API tests

### DIFF
--- a/app/code/Magento/InventorySalesApi/Test/Api/StockRepository/PreventAssignedToSalesChannelsStockDeletingTest.php
+++ b/app/code/Magento/InventorySalesApi/Test/Api/StockRepository/PreventAssignedToSalesChannelsStockDeletingTest.php
@@ -14,6 +14,7 @@ use Magento\TestFramework\TestCase\WebapiAbstract;
 class PreventAssignedToSalesChannelsStockDeletingTest extends WebapiAbstract
 {
     /**
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_with_sales_channels.php
      * @throws \Exception
      */

--- a/app/code/Magento/InventorySalesApi/Test/Api/StockRepository/SalesChannelManagementTest.php
+++ b/app/code/Magento/InventorySalesApi/Test/Api/StockRepository/SalesChannelManagementTest.php
@@ -235,6 +235,12 @@ class SalesChannelManagementTest extends WebapiAbstract
                                 'field' => SalesChannelInterface::CODE,
                             ],
                         ],
+                        [
+                            'message' => 'The website with code "%code" does not exist.',
+                            'parameters' => [
+                                'code' => '',
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -252,6 +258,12 @@ class SalesChannelManagementTest extends WebapiAbstract
                             'message' => '"%field" can not be empty.',
                             'parameters' => [
                                 'field' => SalesChannelInterface::CODE,
+                            ],
+                        ],
+                        [
+                            'message' => 'The website with code "%code" does not exist.',
+                            'parameters' => [
+                                'code' => '',
                             ],
                         ],
                     ],


### PR DESCRIPTION
### Description
Fix all API tests, but don't fix `\Magento\InventoryLowQuantityNotificationApi\Test\Api\DeleteSourceItemConfigurationTest::testDeleteSourceItemConfiguration` because it fixed in [PR 1739](https://github.com/magento-engcom/msi/pull/1739)

### Fixed Issues (if relevant)

1. [magento-engcom/msi-1740](Failed web API tests): Failed web API tests

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
