### PR TITLE
magento-engcom/msi#1756 [MFTF] Admin Manage Stock Grid Broken Test

### DIFF
--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminManageStockGridChangeColumnOrderByDragAndDropTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminManageStockGridChangeColumnOrderByDragAndDropTest.xml
@@ -47,7 +47,7 @@
         <grabMultiple selector="{{AdminGridHeaders.columnsNames}}" stepKey="grabColumnsDefaultOrder" />
         <assertEquals stepKey="assertDefaultOrder">
             <actualResult type="variable">grabColumnsDefaultOrder</actualResult>
-            <expectedResult type="array">["ID", "Name", "Sales Channels", "Action"]</expectedResult>
+            <expectedResult type="array">["ID", "Name", "Sales Channels", "Assigned sources", "Action"]</expectedResult>
         </assertEquals>
 
         <dragAndDrop selector1="{{AdminGridHeaders.headerByName('ID')}}"
@@ -57,7 +57,7 @@
         <grabMultiple selector="{{AdminGridHeaders.columnsNames}}" stepKey="grabColumnsAfterIdColumnMoved" />
         <assertEquals stepKey="assertOrderAfterIdColumnMoved">
             <actualResult type="variable">grabColumnsAfterIdColumnMoved</actualResult>
-            <expectedResult type="array">["Name", "Sales Channels", "ID", "Action"]</expectedResult>
+            <expectedResult type="array">["Name", "Sales Channels", "ID", "Assigned sources", "Action"]</expectedResult>
         </assertEquals>
 
         <dragAndDrop selector1="{{AdminGridHeaders.headerByName('Name')}}"
@@ -67,7 +67,7 @@
         <grabMultiple selector="{{AdminGridHeaders.columnsNames}}" stepKey="grabColumnsAfterNameColumnMoved" />
         <assertEquals stepKey="assertOrderAfterNameColumnMoved">
             <actualResult type="variable">grabColumnsAfterNameColumnMoved</actualResult>
-            <expectedResult type="array">["Sales Channels", "Name", "ID", "Action"]</expectedResult>
+            <expectedResult type="array">["Sales Channels", "Name", "ID", "Assigned sources", "Action"]</expectedResult>
         </assertEquals>
     </test>
 </tests>


### PR DESCRIPTION
### Fixed Issues (if relevant)
This PR contains the updates to the "AdminManageStockGridChangeColumnOrderByDragAndDropTest" that recently broke due to a UI change. The "Assigned sources" column was added to the UI and therefore needed added to the assertion.
1. Fix test Magento\FunctionalTestingFramework.functional\MSI_Multi_Mode.AdminManageStockGridChangeColumnOrderByDragAndDropTest: https://github.com/magento-engcom/msi/issues/1756

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
