### PR TITLE
magento-engcom/msi#1755 [MFTF] Admin Add Remove Stock Columns Broken Test

### DIFF
--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminAddRemoveStockColumnsTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminAddRemoveStockColumnsTest.xml
@@ -34,11 +34,12 @@
 
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen1"/>
         <click selector="{{AdminGridColumnsControls.reset}}" stepKey="clickOnResetToRestoreDefaultColumns1"/>
-        <see selector="{{AdminManageSourcesGridColumnControls.dropDown}}" userInput="4 out of 4 visible" stepKey="seeAllColumnsAreActive1"/>
+        <see selector="{{AdminManageSourcesGridColumnControls.dropDown}}" userInput="5 out of 5 visible" stepKey="seeAllColumnsAreActive1"/>
 
         <see selector="{{AdminGridHeaders.headerByName('ID')}}" userInput="ID" stepKey="seeTheHeaderId1"/>
         <see selector="{{AdminGridHeaders.headerByName('Name')}}" userInput="Name" stepKey="seeTheHeaderName1"/>
         <see selector="{{AdminGridHeaders.headerByName('Sales Channels')}}" userInput="Sales Channels" stepKey="seeTheHeaderSalesChannel1"/>
+        <see selector="{{AdminGridHeaders.headerByName('Assigned sources')}}" userInput="Assigned sources" stepKey="seeTheHeaderAssignedSources1"/>
         <see selector="{{AdminGridHeaders.headerByName('Action')}}" userInput="Action" stepKey="seeTheHeaderAction1"/>
 
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen2"/>
@@ -49,30 +50,38 @@
         <click selector="{{AdminGridColumnsControls.columnName('Name')}}" stepKey="disableNameColumn1"/>
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen5"/>
         <click selector="{{AdminGridColumnsControls.columnName('Sales Channels')}}" stepKey="disableSalesChannelColumn1"/>
+        <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen6"/>
+        <click selector="{{AdminGridColumnsControls.columnName('Assigned sources')}}" stepKey="disableAssignedSourcesColumn1"/>
+
         <see selector="{{AdminGridHeaders.headerByName('Action')}}" userInput="Action" stepKey="seeTheHeaderAction2"/>
         <dontSee selector="{{AdminGridHeaders.headerByName('ID')}}" userInput="ID" stepKey="dontSeeIdColumn1"/>
         <dontSee selector="{{AdminGridHeaders.headerByName('Name')}}" userInput="Name" stepKey="dontSeeNameColumn1"/>
         <dontSee selector="{{AdminGridHeaders.headerByName('Sales Channels')}}" userInput="Sales Channels" stepKey="dontSeeSalesChannelColumn1"/>
+        <dontSee selector="{{AdminGridHeaders.headerByName('Assigned sources')}}" userInput="Assigned sources" stepKey="dontSeeAssignedSourcesColumn1"/>
 
-        <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen6"/>
+        <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen7"/>
         <click selector="{{AdminGridColumnsControls.reset}}" stepKey="clickOnResetColumnReaders2"/>
         <see selector="{{AdminGridHeaders.headerByName('ID')}}" userInput="ID" stepKey="seeTheHeaderId2"/>
         <see selector="{{AdminGridHeaders.headerByName('Name')}}" userInput="Name" stepKey="seeTheHeaderName2"/>
         <see selector="{{AdminGridHeaders.headerByName('Sales Channels')}}" userInput="Sales Channels" stepKey="seeTheHeaderSalesChannel2"/>
+        <see selector="{{AdminGridHeaders.headerByName('Assigned sources')}}" userInput="Assigned sources" stepKey="seeTheHeaderAssignedSources2"/>
         <see selector="{{AdminGridHeaders.headerByName('Action')}}" userInput="Action" stepKey="seeTheHeaderAction3"/>
 
-        <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen7"/>
-        <click selector="{{AdminGridColumnsControls.columnName('ID')}}" stepKey="disableIdColumn3"/>
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen8"/>
-        <click selector="{{AdminGridColumnsControls.columnName('Name')}}" stepKey="disableNameColumn3"/>
+        <click selector="{{AdminGridColumnsControls.columnName('ID')}}" stepKey="disableIdColumn3"/>
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen9"/>
-        <click selector="{{AdminGridColumnsControls.columnName('Action')}}" stepKey="disableActionColumn3"/>
+        <click selector="{{AdminGridColumnsControls.columnName('Name')}}" stepKey="disableNameColumn3"/>
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen10"/>
+        <click selector="{{AdminGridColumnsControls.columnName('Action')}}" stepKey="disableActionColumn3"/>
+        <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen11"/>
+        <click selector="{{AdminGridColumnsControls.columnName('Assigned sources')}}" stepKey="disableAssignedSourcesColumn3"/>
+        <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen12"/>
         <click selector="{{AdminGridColumnsControls.cancel}}" stepKey="clickOnCancel1"/>
 
         <see selector="{{AdminGridHeaders.headerByName('ID')}}" userInput="ID" stepKey="seeTheHeaderId3"/>
         <see selector="{{AdminGridHeaders.headerByName('Name')}}" userInput="Name" stepKey="seeTheHeaderName3"/>
         <see selector="{{AdminGridHeaders.headerByName('Sales Channels')}}" userInput="Sales Channels" stepKey="seeTheHeaderSalesChannel3"/>
+        <see selector="{{AdminGridHeaders.headerByName('Assigned sources')}}" userInput="Assigned sources" stepKey="seeTheHeaderAssignedSources3"/>
         <see selector="{{AdminGridHeaders.headerByName('Action')}}" userInput="Action" stepKey="seeTheHeaderAction4"/>
     </test>
 </tests>


### PR DESCRIPTION
### Fixed Issues (if relevant)
This PR contains the updates to the "AdminAddRemoveStockColumnsTest" that recently broke due to a UI change. The "Assigned sources" column was added to the UI and therefore needed added to the assertion.

1. Fix test Magento\FunctionalTestingFramework.functional\MSI_Multi_Mode.AdminAddRemoveStockColumnsTest: https://github.com/magento-engcom/msi/issues/1755

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
