### PR TITLE
Created tooltip for assigned sources more than 5 for every stock item

### DIFF
--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
@@ -3,9 +3,8 @@
  * See COPYING.txt for license details.
  */
 define([
-    'Magento_Ui/js/grid/columns/column',
-    'underscore'
-], function (Column, _) {
+    'Magento_Ui/js/grid/columns/column'
+], function (Column) {
     'use strict';
 
     return Column.extend({

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
@@ -4,26 +4,14 @@
  */
 define([
     'Magento_Ui/js/grid/columns/column',
-    'underscore',
-    'mage/translate'
-], function (Column, _, $t) {
+    'underscore'
+], function (Column, _) {
     'use strict';
 
     return Column.extend({
         defaults: {
             bodyTmpl: 'Magento_InventoryAdminUi/stock/grid/cell/assigned-sources-cell.html',
-            showFullListDescription: $t('Show more...'),
             itemsToDisplay: 5
-        },
-
-        /**
-         *
-         * @returns {exports}
-         */
-        initObservable: function () {
-            this._super();
-
-            return this;
         },
 
         /**

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
@@ -16,7 +16,7 @@ define([
 
         /**
          *
-         * @param record
+         * @param {Array} record
          * @returns {Array}
          */
         getTooltipData: function (record) {
@@ -24,7 +24,7 @@ define([
                 return {
                     sourceCode: source.sourceCode,
                     name: source.name
-                }
+                };
             });
         },
 
@@ -33,7 +33,7 @@ define([
          * @returns {Array} Result array
          */
         getSourcesAssignedToStockOrderedByPriority: function (record) {
-            return this.getTooltipData(record).slice(0, this.itemsToDisplay)
+            return this.getTooltipData(record).slice(0, this.itemsToDisplay);
         }
     });
 });

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/js/stock/grid/cell/assigned-sources.js
@@ -4,13 +4,40 @@
  */
 define([
     'Magento_Ui/js/grid/columns/column',
-    'underscore'
-], function (Column, _) {
+    'underscore',
+    'mage/translate'
+], function (Column, _, $t) {
     'use strict';
 
     return Column.extend({
         defaults: {
-            bodyTmpl: 'Magento_InventoryAdminUi/stock/grid/cell/assigned-sources-cell.html'
+            bodyTmpl: 'Magento_InventoryAdminUi/stock/grid/cell/assigned-sources-cell.html',
+            showFullListDescription: $t('Show more...'),
+            itemsToDisplay: 5
+        },
+
+        /**
+         *
+         * @returns {exports}
+         */
+        initObservable: function () {
+            this._super();
+
+            return this;
+        },
+
+        /**
+         *
+         * @param record
+         * @returns {Array}
+         */
+        getTooltipData: function (record) {
+            return record[this.index].map(function (source) {
+                return {
+                    sourceCode: source.sourceCode,
+                    name: source.name
+                }
+            });
         },
 
         /**
@@ -18,16 +45,7 @@ define([
          * @returns {Array} Result array
          */
         getSourcesAssignedToStockOrderedByPriority: function (record) {
-            var result = [];
-
-            _.each(record[this.index], function (source) {
-                result.push({
-                    sourceCode: source.sourceCode,
-                    name: source.name
-                });
-            });
-
-            return result;
+            return this.getTooltipData(record).slice(0, this.itemsToDisplay)
         }
     });
 });

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/template/stock/grid/cell/assigned-sources-cell.html
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/template/stock/grid/cell/assigned-sources-cell.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div class="data-grid-cell-content">
+<div class="data-grid-cell-content" attr="'data-tooltip-trigger': ++ko.uid">
     <ul data-bind="foreach: { data: $col.getSourcesAssignedToStockOrderedByPriority($row()), as: '$assignedSource' }">
         <li>
             <span data-bind="text: $assignedSource.name"></span>
@@ -12,3 +12,22 @@
         </li>
     </ul>
 </div>
+<div tooltip="
+    trigger: '[data-tooltip-trigger=' + ko.uid + ']',
+    action: 'hover',
+    closeOnScroll: false,
+    delay: 0,
+    position: 'top',
+    step: 30,
+    track: false,
+    strict: true">
+    <div>
+        <div class="data-tooltip-title" data-bind="i18n: 'Assigned sources:'"></div>
+        <div class="data-tooltip-content">
+            <!-- ko foreach: { data: $col.getTooltipData($row()), as: '$assignedSource' } -->
+            <div><span data-bind="text: $assignedSource.name"></span>: <span data-bind="text: $assignedSource.sourceCode"></span></div>
+            <!-- /ko -->
+        </div>
+    </div>
+</div>
+


### PR DESCRIPTION
### Description
Created tooltip for assigned sources with more than 5 sources per stock in a stock grid

### Manual testing scenarios
#### Preconditions
1. Create more than 10 sources
2. Create new stock
3. Assign all sources to new stock

#### Steps to reproduce
4. Go to the stock grid and see how big every row become

#### Expected result
1. Field "assigned sources" limited by 5 item .
2. All other sources are shown in a tooltip when hovering over the "assigned sources field"

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
