### PR TITLE
Small Perfomance fixes

### DIFF
--- a/app/code/Magento/Inventory/Model/ResourceModel/SourceItem/DeleteMultiple.php
+++ b/app/code/Magento/Inventory/Model/ResourceModel/SourceItem/DeleteMultiple.php
@@ -39,7 +39,7 @@ class DeleteMultiple
      */
     public function execute(array $sourceItems)
     {
-        if (!count($sourceItems)) {
+        if (!\count($sourceItems)) {
             return;
         }
         $connection = $this->resourceConnection->getConnection();

--- a/app/code/Magento/Inventory/Model/ResourceModel/SourceItem/SaveMultiple.php
+++ b/app/code/Magento/Inventory/Model/ResourceModel/SourceItem/SaveMultiple.php
@@ -39,7 +39,7 @@ class SaveMultiple
      */
     public function execute(array $sourceItems)
     {
-        if (!count($sourceItems)) {
+        if (!\count($sourceItems)) {
             return;
         }
         $connection = $this->resourceConnection->getConnection();
@@ -86,7 +86,7 @@ class SaveMultiple
      */
     private function buildValuesSqlPart(array $sourceItems): string
     {
-        $sql = rtrim(str_repeat('(?, ?, ?, ?), ', count($sourceItems)), ', ');
+        $sql = rtrim(str_repeat('(?, ?, ?, ?), ', \count($sourceItems)), ', ');
         return $sql;
     }
 
@@ -98,14 +98,14 @@ class SaveMultiple
     {
         $bind = [];
         foreach ($sourceItems as $sourceItem) {
-            $bind = array_merge($bind, [
+            $bind[] = [
                 $sourceItem->getSourceCode(),
                 $sourceItem->getSku(),
                 $sourceItem->getQuantity(),
                 $sourceItem->getStatus(),
-            ]);
+            ];
         }
-        return $bind;
+        return array_merge(...$bind);
     }
 
     /**

--- a/app/code/Magento/Inventory/Model/ResourceModel/StockSourceLink/DeleteMultiple.php
+++ b/app/code/Magento/Inventory/Model/ResourceModel/StockSourceLink/DeleteMultiple.php
@@ -39,7 +39,7 @@ class DeleteMultiple
      */
     public function execute(array $links)
     {
-        if (!count($links)) {
+        if (!\count($links)) {
             return;
         }
 

--- a/app/code/Magento/Inventory/Model/ResourceModel/StockSourceLink/SaveMultiple.php
+++ b/app/code/Magento/Inventory/Model/ResourceModel/StockSourceLink/SaveMultiple.php
@@ -40,7 +40,7 @@ class SaveMultiple
      */
     public function execute(array $links)
     {
-        if (!count($links)) {
+        if (!\count($links)) {
             return;
         }
         $connection = $this->resourceConnection->getConnection();
@@ -86,7 +86,7 @@ class SaveMultiple
      */
     private function buildValuesSqlPart(array $links): string
     {
-        $sql = rtrim(str_repeat('(?, ?, ?), ', count($links)), ', ');
+        $sql = rtrim(str_repeat('(?, ?, ?), ', \count($links)), ', ');
         return $sql;
     }
 
@@ -98,13 +98,13 @@ class SaveMultiple
     {
         $bind = [];
         foreach ($links as $link) {
-            $bind = array_merge($bind, [
+            $bind[] =  [
                 $link->getSourceCode(),
                 $link->getStockId(),
                 $link->getPriority(),
-            ]);
+            ];
         }
-        return $bind;
+        return array_merge(...$bind);
     }
 
     /**

--- a/app/code/Magento/Inventory/Model/SourceCarrierLinkManagement.php
+++ b/app/code/Magento/Inventory/Model/SourceCarrierLinkManagement.php
@@ -77,7 +77,7 @@ class SourceCarrierLinkManagement implements SourceCarrierLinkManagementInterfac
         $this->deleteCurrentCarrierLinks($source);
 
         $carrierLinks = $source->getCarrierLinks();
-        if (null !== $carrierLinks && count($carrierLinks)) {
+        if (null !== $carrierLinks && \count($carrierLinks)) {
             $this->saveNewCarrierLinks($source);
         }
     }

--- a/app/code/Magento/Inventory/Model/SourceItem/Validator/StatusValidator.php
+++ b/app/code/Magento/Inventory/Model/SourceItem/Validator/StatusValidator.php
@@ -55,7 +55,7 @@ class StatusValidator implements SourceItemValidatorInterface
         }
 
         $errors = [];
-        if (!in_array((int)$value, array_values($this->allowedSourceItemStatuses), true)) {
+        if (!\in_array((int)$value, array_values($this->allowedSourceItemStatuses), true)) {
             $errors[] = __(
                 '"%field" should a known status.',
                 ['field' => SourceItemInterface::STATUS]

--- a/app/code/Magento/InventoryAdminUi/Controller/Adminhtml/Source/InlineEdit.php
+++ b/app/code/Magento/InventoryAdminUi/Controller/Adminhtml/Source/InlineEdit.php
@@ -111,7 +111,7 @@ class InlineEdit extends Action implements HttpPostActionInterface
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setData([
             'messages' => $errorMessages,
-            'error' => count($errorMessages),
+            'error' => \count($errorMessages),
         ]);
 
         return $resultJson;

--- a/app/code/Magento/InventoryAdminUi/Controller/Adminhtml/Stock/InlineEdit.php
+++ b/app/code/Magento/InventoryAdminUi/Controller/Adminhtml/Stock/InlineEdit.php
@@ -98,7 +98,7 @@ class InlineEdit extends Action implements HttpPostActionInterface
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setData([
             'messages' => $errorMessages,
-            'error' => count($errorMessages),
+            'error' => \count($errorMessages),
         ]);
 
         return $resultJson;

--- a/app/code/Magento/InventoryAdminUi/Model/Stock/StockSaveProcessor.php
+++ b/app/code/Magento/InventoryAdminUi/Model/Stock/StockSaveProcessor.php
@@ -99,7 +99,7 @@ class StockSaveProcessor
 
         $assignedSources =
             isset($requestData['sources']['assigned_sources'])
-            && is_array($requestData['sources']['assigned_sources'])
+            && \is_array($requestData['sources']['assigned_sources'])
                 ? $requestData['sources']['assigned_sources']
                 : [];
         $this->stockSourceLinkProcessor->process($stockId, $assignedSources);

--- a/app/code/Magento/InventoryAdminUi/Model/Stock/StockSourceLinkProcessor.php
+++ b/app/code/Magento/InventoryAdminUi/Model/Stock/StockSourceLinkProcessor.php
@@ -104,10 +104,10 @@ class StockSourceLinkProcessor
             unset($linksForDelete[$sourceCode]);
         }
 
-        if (count($linksForSave) > 0) {
+        if (\count($linksForSave) > 0) {
             $this->stockSourceLinksSave->execute($linksForSave);
         }
-        if (count($linksForDelete) > 0) {
+        if (\count($linksForDelete) > 0) {
             $this->stockSourceLinksDelete->execute($linksForDelete);
         }
     }

--- a/app/code/Magento/InventoryApi/Model/SourceItemValidatorChain.php
+++ b/app/code/Magento/InventoryApi/Model/SourceItemValidatorChain.php
@@ -60,9 +60,9 @@ class SourceItemValidatorChain implements SourceItemValidatorInterface
             $validationResult = $validator->validate($sourceItem);
 
             if (!$validationResult->isValid()) {
-                $errors = array_merge($errors, $validationResult->getErrors());
+                $errors[] = $validationResult->getErrors();
             }
         }
-        return $this->validationResultFactory->create(['errors' => $errors]);
+        return $this->validationResultFactory->create(['errors' => array_merge(...$errors)]);
     }
 }

--- a/app/code/Magento/InventoryApi/Model/SourceValidatorChain.php
+++ b/app/code/Magento/InventoryApi/Model/SourceValidatorChain.php
@@ -61,9 +61,9 @@ class SourceValidatorChain implements SourceValidatorInterface
             $validationResult = $validator->validate($source);
 
             if (!$validationResult->isValid()) {
-                $errors = array_merge($errors, $validationResult->getErrors());
+                $errors[] =  $validationResult->getErrors();
             }
         }
-        return $this->validationResultFactory->create(['errors' => $errors]);
+        return $this->validationResultFactory->create(['errors' => array_merge(...$errors)]);
     }
 }

--- a/app/code/Magento/InventoryApi/Model/StockSourceLinkValidatorChain.php
+++ b/app/code/Magento/InventoryApi/Model/StockSourceLinkValidatorChain.php
@@ -61,9 +61,9 @@ class StockSourceLinkValidatorChain implements StockSourceLinkValidatorInterface
             $validationResult = $validator->validate($link);
 
             if (!$validationResult->isValid()) {
-                $errors = array_merge($errors, $validationResult->getErrors());
+                $errors[] =  $validationResult->getErrors();
             }
         }
-        return $this->validationResultFactory->create(['errors' => $errors]);
+        return $this->validationResultFactory->create(['errors' => array_merge(...$errors)]);
     }
 }

--- a/app/code/Magento/InventoryApi/Model/StockValidatorChain.php
+++ b/app/code/Magento/InventoryApi/Model/StockValidatorChain.php
@@ -60,9 +60,9 @@ class StockValidatorChain implements StockValidatorInterface
             $validationResult = $validator->validate($stock);
 
             if (!$validationResult->isValid()) {
-                $errors = array_merge($errors, $validationResult->getErrors());
+                $errors[] =  $validationResult->getErrors();
             }
         }
-        return $this->validationResultFactory->create(['errors' => $errors]);
+        return $this->validationResultFactory->create(['errors' => array_merge(...$errors)]);
     }
 }

--- a/app/code/Magento/InventoryBundleProduct/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnDefaultStockTest.php
+++ b/app/code/Magento/InventoryBundleProduct/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnDefaultStockTest.php
@@ -72,7 +72,7 @@ class AddSalesQuoteItemOnDefaultStockTest extends TestCase
 
         self::expectException(LocalizedException::class);
         $quote->addProduct($product, $this->getBuyRequest($product, $productQty));
-        $quoteItemCount = count($quote->getAllItems());
+        $quoteItemCount = \count($quote->getAllItems());
         self::assertEquals($expectedItemsInCart, $quoteItemCount);
     }
 

--- a/app/code/Magento/InventoryBundleProduct/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnNotDefaultStockTest.php
+++ b/app/code/Magento/InventoryBundleProduct/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnNotDefaultStockTest.php
@@ -126,7 +126,7 @@ class AddSalesQuoteItemOnNotDefaultStockTest extends TestCase
 
         self::expectException(LocalizedException::class);
         $quote->addProduct($product, $this->getBuyRequest($product, $productQty));
-        $quoteItemCount = count($quote->getAllItems());
+        $quoteItemCount = \count($quote->getAllItems());
         self::assertEquals($expectedItemsInCart, $quoteItemCount);
     }
 

--- a/app/code/Magento/InventoryCatalog/Model/BulkSourceUnassign.php
+++ b/app/code/Magento/InventoryCatalog/Model/BulkSourceUnassign.php
@@ -101,7 +101,7 @@ class BulkSourceUnassign implements BulkSourceUnassignInterface
         $res = $this->bulkSourceUnassign->execute($skus, $sourceCodes);
 
         $this->sourceIndexer->executeList($sourceCodes);
-        if (in_array($this->defaultSourceProvider->getCode(), $sourceCodes, true)) {
+        if (\in_array($this->defaultSourceProvider->getCode(), $sourceCodes, true)) {
             $this->reindexLegacy($skus);
         }
 

--- a/app/code/Magento/InventoryCatalog/Model/GetDefaultSourceItemBySku.php
+++ b/app/code/Magento/InventoryCatalog/Model/GetDefaultSourceItemBySku.php
@@ -59,6 +59,6 @@ class GetDefaultSourceItemBySku
             ->create();
 
         $sourceItems = $this->sourceItemRepository->getList($searchCriteria)->getItems();
-        return count($sourceItems) ? reset($sourceItems) : null;
+        return \count($sourceItems) ? reset($sourceItems) : null;
     }
 }

--- a/app/code/Magento/InventoryCatalog/Model/GetSkusByProductIds.php
+++ b/app/code/Magento/InventoryCatalog/Model/GetSkusByProductIds.php
@@ -49,7 +49,7 @@ class GetSkusByProductIds implements GetSkusByProductIdsInterface
             );
         }
 
-        $skuByIds = array_map('strval', $skuByIds);
+        $skuByIds = array_map('\strval', $skuByIds);
         return $skuByIds;
     }
 }

--- a/app/code/Magento/InventoryCatalog/Model/ResourceModel/BulkSourceUnassign.php
+++ b/app/code/Magento/InventoryCatalog/Model/ResourceModel/BulkSourceUnassign.php
@@ -71,7 +71,7 @@ class BulkSourceUnassign
         ]);
 
         // Legacy stock update
-        if (in_array($this->defaultSourceProvider->getCode(), $sourceCodes)) {
+        if (\in_array($this->defaultSourceProvider->getCode(), $sourceCodes)) {
             $this->bulkZeroLegacyStockItem->execute($skus);
         }
 

--- a/app/code/Magento/InventoryCatalog/Test/Api/StockSourceLink/PreventAssignSourcesToDefaultStockTest.php
+++ b/app/code/Magento/InventoryCatalog/Test/Api/StockSourceLink/PreventAssignSourcesToDefaultStockTest.php
@@ -134,7 +134,7 @@ class PreventAssignSourcesToDefaultStockTest extends WebapiAbstract
         }
         $actualErrors = [];
         foreach ($errorDetails->$wrappedErrorsNode->$wrappedErrorNode as $error) {
-            if (is_object($error)) {
+            if (\is_object($error)) {
                 $actualErrors[] = $error->message;
             } else {
                 $actualErrors[] = $error;

--- a/app/code/Magento/InventoryCatalogAdminUi/Ui/Component/AssignSources/Button.php
+++ b/app/code/Magento/InventoryCatalogAdminUi/Ui/Component/AssignSources/Button.php
@@ -48,7 +48,7 @@ class Button extends Container
         if ($stockId === $this->defaultStockProvider->getId()) {
             $config = $this->getData('config');
             $config['disabled'] = true;
-            $config['notice'] = __("<strong>NOTE</strong>: Assign sources is disabled for default stock");
+            $config['notice'] = __('<strong>NOTE</strong>: Assign sources is disabled for default stock');
             $this->setData('config', $config);
         }
     }

--- a/app/code/Magento/InventoryCatalogAdminUi/ViewModel/SourcesSelection.php
+++ b/app/code/Magento/InventoryCatalogAdminUi/ViewModel/SourcesSelection.php
@@ -90,6 +90,6 @@ class SourcesSelection implements ArgumentInterface
      */
     public function getProductsCount(): int
     {
-        return count($this->bulkSessionProductsStorage->getProductsSkus());
+        return \count($this->bulkSessionProductsStorage->getProductsSkus());
     }
 }

--- a/app/code/Magento/InventoryCatalogApi/Model/BulkInventoryTransferValidatorChain.php
+++ b/app/code/Magento/InventoryCatalogApi/Model/BulkInventoryTransferValidatorChain.php
@@ -60,9 +60,9 @@ class BulkInventoryTransferValidatorChain implements BulkInventoryTransferValida
             $validationResult = $validator->validate($skus, $originSource, $destinationSource);
 
             if (!$validationResult->isValid()) {
-                $errors = array_merge($errors, $validationResult->getErrors());
+                $errors[] = $validationResult->getErrors();
             }
         }
-        return $this->validationResultFactory->create(['errors' => $errors]);
+        return $this->validationResultFactory->create(['errors' => array_merge(...$errors)]);
     }
 }

--- a/app/code/Magento/InventoryCatalogApi/Model/BulkSourceAssignValidatorChain.php
+++ b/app/code/Magento/InventoryCatalogApi/Model/BulkSourceAssignValidatorChain.php
@@ -60,9 +60,9 @@ class BulkSourceAssignValidatorChain implements BulkSourceAssignValidatorInterfa
             $validationResult = $validator->validate($skus, $sourceCodes);
 
             if (!$validationResult->isValid()) {
-                $errors = array_merge($errors, $validationResult->getErrors());
+                $errors[] =  $validationResult->getErrors();
             }
         }
-        return $this->validationResultFactory->create(['errors' => $errors]);
+        return $this->validationResultFactory->create(['errors' => array_merge($errors)]);
     }
 }

--- a/app/code/Magento/InventoryCatalogApi/Model/BulkSourceUnassignValidatorChain.php
+++ b/app/code/Magento/InventoryCatalogApi/Model/BulkSourceUnassignValidatorChain.php
@@ -60,9 +60,9 @@ class BulkSourceUnassignValidatorChain implements BulkSourceUnassignValidatorInt
             $validationResult = $validator->validate($skus, $sourceCodes);
 
             if (!$validationResult->isValid()) {
-                $errors = array_merge($errors, $validationResult->getErrors());
+                $errors[] = $validationResult->getErrors();
             }
         }
-        return $this->validationResultFactory->create(['errors' => $errors]);
+        return $this->validationResultFactory->create(['errors' => array_merge($errors)]);
     }
 }

--- a/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Adapter/Mysql/Aggregation/DataProvider/ApplyStockConditionToSelectTest.php
+++ b/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Adapter/Mysql/Aggregation/DataProvider/ApplyStockConditionToSelectTest.php
@@ -80,7 +80,7 @@ class ApplyStockConditionToSelectTest extends TestCase
 
         $this->applyStockConditionToSelect->execute($select);
 
-        self::assertEquals($expectedSize, count($select->query()->fetchAll()));
+        self::assertEquals($expectedSize, \count($select->query()->fetchAll()));
     }
 
     /**

--- a/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Adapter/Mysql/Aggregation/DataProvider/ApplyStockConditionToSelectWithDefaultStockTest.php
+++ b/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Adapter/Mysql/Aggregation/DataProvider/ApplyStockConditionToSelectWithDefaultStockTest.php
@@ -52,6 +52,6 @@ class ApplyStockConditionToSelectWithDefaultStockTest extends TestCase
         )->distinct();
 
         $this->applyStockConditionToSelect->execute($select);
-        self::assertEquals(3, count($select->query()->fetchAll()));
+        self::assertEquals(3, \count($select->query()->fetchAll()));
     }
 }

--- a/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Search/FilterMapper/TermDropdownStrategy/ApplyStockConditionToSelectOnDefaultStockTest.php
+++ b/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Search/FilterMapper/TermDropdownStrategy/ApplyStockConditionToSelectOnDefaultStockTest.php
@@ -81,14 +81,14 @@ class ApplyStockConditionToSelectOnDefaultStockTest extends TestCase
          * Taking into account that `inventory_stock_1` is a MySQL View referring cataloginventory_stock_status table
          * all the legacy StockItems will get into the Default Index
          */
-        self::assertEquals(5, count($result));
+        self::assertEquals(5, \count($result));
 
         $searchCriteria = $this->searchCriteriaBuilder
             ->addFilter(SourceItemInterface::SKU, ['SKU-1', 'SKU-2', 'SKU-3', 'SKU-4', 'SKU-5'], 'in')
             ->addFilter(SourceItemInterface::SOURCE_CODE, $this->defaultSourceProvider->getCode())
             ->create();
         $sourceItems = $this->sourceItemRepository->getList($searchCriteria)->getItems();
-        self::assertEquals(4, count($sourceItems));
+        self::assertEquals(4, \count($sourceItems));
 
         /**
          * For SKU-5 we should not have Source Item created

--- a/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Search/FilterMapper/TermDropdownStrategy/ApplyStockConditionToSelectTest.php
+++ b/app/code/Magento/InventoryCatalogSearch/Test/Integration/Model/Search/FilterMapper/TermDropdownStrategy/ApplyStockConditionToSelectTest.php
@@ -78,7 +78,7 @@ class ApplyStockConditionToSelectTest extends TestCase
 
         $result = $select->query()->fetchAll();
 
-        self::assertEquals($expectedSize, count($result));
+        self::assertEquals($expectedSize, \count($result));
     }
 
     /**

--- a/app/code/Magento/InventoryConfigurableProduct/Test/Integration/Options/OptionsAvailabilityTest.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/Integration/Options/OptionsAvailabilityTest.php
@@ -79,7 +79,7 @@ class OptionsAvailabilityTest extends TestCase
         $this->configurableView->setProduct($configurableProduct);
         $result = $this->serializer->unserialize($this->configurableView->getJsonConfig());
         $attributes = reset($result['attributes']);
-        $actual = count($attributes['options'] ?? []);
+        $actual = \count($attributes['options'] ?? []);
 
         $this->assertEquals(
             $expected,

--- a/app/code/Magento/InventoryConfigurableProduct/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnDefaultStockTest.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnDefaultStockTest.php
@@ -74,7 +74,7 @@ class AddSalesQuoteItemOnDefaultStockTest extends TestCase
 
         self::expectException(LocalizedException::class);
         $quote->addProduct($product, $this->getBuyRequest($product, $productQty));
-        $quoteItemCount = count($quote->getAllItems());
+        $quoteItemCount = \count($quote->getAllItems());
         self::assertEquals($expectedItemsInCart, $quoteItemCount);
     }
 

--- a/app/code/Magento/InventoryConfigurableProduct/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnNotDefaultStockTest.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnNotDefaultStockTest.php
@@ -95,7 +95,7 @@ class AddSalesQuoteItemOnNotDefaultStockTest extends TestCase
         self::expectException(LocalizedException::class);
         $quote->addProduct($product, $this->getBuyRequest($product, $productQty));
 
-        $quoteItemCount = count($quote->getAllItems());
+        $quoteItemCount = \count($quote->getAllItems());
         self::assertEquals($expectedItemsInCart, $quoteItemCount);
     }
 

--- a/app/code/Magento/InventoryConfigurableProductAdminUi/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryConfigurableProductAdminUi/Observer/ProcessSourceItemsObserver.php
@@ -63,7 +63,7 @@ class ProcessSourceItemsObserver implements ObserverInterface
             $productsData = json_decode($configurableMatrix, true);
             foreach ($productsData as $key => $productData) {
                 if (isset($productData['quantity_per_source'])) {
-                    $quantityPerSource = is_array($productData['quantity_per_source'])
+                    $quantityPerSource = \is_array($productData['quantity_per_source'])
                         ? $productData['quantity_per_source']
                         : [];
 

--- a/app/code/Magento/InventoryConfigurableProductAdminUi/Plugin/Block/AddQuantityPerSourceToVariationsMatrix.php
+++ b/app/code/Magento/InventoryConfigurableProductAdminUi/Plugin/Block/AddQuantityPerSourceToVariationsMatrix.php
@@ -51,7 +51,7 @@ class AddQuantityPerSourceToVariationsMatrix
         Matrix $subject,
         $result
     ) {
-        if ($this->isSingleSourceMode->execute() === false && is_array($result)) {
+        if ($this->isSingleSourceMode->execute() === false && \is_array($result)) {
             foreach ($result as $key => $variation) {
                 $result[$key]['quantityPerSource'] = $this->getQuantityInformationPerSource->execute($variation['sku']);
             }

--- a/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SourceItem/IndexDataBySkuListProvider.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SourceItem/IndexDataBySkuListProvider.php
@@ -48,7 +48,7 @@ class IndexDataBySkuListProvider
     {
         $select = $this->selectBuilder->execute($stockId);
 
-        if (count($skuList)) {
+        if (\count($skuList)) {
             $select->where('stock.' . IndexStructure::SKU . ' IN (?)', $skuList);
         }
 

--- a/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SourceItem/SiblingSkuListInStockProvider.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SourceItem/SiblingSkuListInStockProvider.php
@@ -98,7 +98,7 @@ class SiblingSkuListInStockProvider
                 ['source_item' => $sourceItemTable],
                 [
                     SourceItemInterface::SKU =>
-                        "GROUP_CONCAT(DISTINCT sibling_product_entity." . SourceItemInterface::SKU . " SEPARATOR ',')"
+                        'GROUP_CONCAT(DISTINCT sibling_product_entity.' . SourceItemInterface::SKU . " SEPARATOR ',')"
                 ]
             )->joinInner(
                 ['stock_source_link' => $sourceStockLinkTable],

--- a/app/code/Magento/InventoryConfiguration/Model/IsSourceItemManagementAllowedForProductType.php
+++ b/app/code/Magento/InventoryConfiguration/Model/IsSourceItemManagementAllowedForProductType.php
@@ -33,6 +33,6 @@ class IsSourceItemManagementAllowedForProductType implements IsSourceItemManagem
      */
     public function execute(string $productType): bool
     {
-        return in_array($productType, array_keys(array_filter($this->stockConfiguration->getIsQtyTypeIds())), true);
+        return \array_key_exists($productType, array_filter($this->stockConfiguration->getIsQtyTypeIds()));
     }
 }

--- a/app/code/Magento/InventoryGroupedProduct/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnDefaultStockTest.php
+++ b/app/code/Magento/InventoryGroupedProduct/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnDefaultStockTest.php
@@ -78,7 +78,7 @@ class AddSalesQuoteItemOnDefaultStockTest extends TestCase
 
         self::expectException(LocalizedException::class);
         $quote->addProduct($product, $request);
-        $quoteItemCount = count($quote->getAllItems());
+        $quoteItemCount = \count($quote->getAllItems());
         self::assertEquals(0, $quoteItemCount);
     }
 

--- a/app/code/Magento/InventoryGroupedProductIndexer/Indexer/SourceItem/IndexDataBySkuListProvider.php
+++ b/app/code/Magento/InventoryGroupedProductIndexer/Indexer/SourceItem/IndexDataBySkuListProvider.php
@@ -47,7 +47,7 @@ class IndexDataBySkuListProvider
     public function execute(int $stockId, array $skuList): ArrayIterator
     {
         $select = $this->selectBuilder->execute($stockId);
-        if (count($skuList)) {
+        if (\count($skuList)) {
             $select->where('stock.' . IndexStructure::SKU . ' IN (?)', $skuList);
         }
         $connection = $this->resourceConnection->getConnection();

--- a/app/code/Magento/InventoryGroupedProductIndexer/Indexer/SourceItem/SiblingSkuListInStockProvider.php
+++ b/app/code/Magento/InventoryGroupedProductIndexer/Indexer/SourceItem/SiblingSkuListInStockProvider.php
@@ -99,7 +99,7 @@ class SiblingSkuListInStockProvider
                 ['source_item' => $sourceItemTable],
                 [
                     SourceItemInterface::SKU =>
-                        "GROUP_CONCAT(DISTINCT sibling_product_entity." . SourceItemInterface::SKU . " SEPARATOR ',')"
+                        'GROUP_CONCAT(DISTINCT sibling_product_entity.' . SourceItemInterface::SKU . " SEPARATOR ',')"
                 ]
             )->joinInner(
                 ['stock_source_link' => $sourceStockLinkTable],

--- a/app/code/Magento/InventoryImportExport/Model/Export/AttributeCollectionProvider.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/AttributeCollectionProvider.php
@@ -47,7 +47,7 @@ class AttributeCollectionProvider
      */
     public function get(): Collection
     {
-        if (count($this->collection) === 0) {
+        if (\count($this->collection) === 0) {
             /** @var \Magento\Eav\Model\Entity\Attribute $sourceCodeAttribute */
             $sourceCodeAttribute = $this->attributeFactory->create();
             $sourceCodeAttribute->setId(SourceItemInterface::SOURCE_CODE);

--- a/app/code/Magento/InventoryImportExport/Model/Export/ColumnProvider.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/ColumnProvider.php
@@ -30,7 +30,7 @@ class ColumnProvider implements ColumnProviderInterface
             return $columns;
         }
 
-        if (count($filters[Export::FILTER_ELEMENT_SKIP]) === count($columns)) {
+        if (\count($filters[Export::FILTER_ELEMENT_SKIP]) === \count($columns)) {
             throw new LocalizedException(__('There is no data for the export.'));
         }
 

--- a/app/code/Magento/InventoryImportExport/Model/Export/Filter/IntFilter.php
+++ b/app/code/Magento/InventoryImportExport/Model/Export/Filter/IntFilter.php
@@ -23,7 +23,7 @@ class IntFilter implements FilterProcessorInterface
      */
     public function process(Collection $collection, string $columnName, $value): void
     {
-        if (is_array($value)) {
+        if (\is_array($value)) {
             $from = $value[0] ?? null;
             $to = $value[1] ?? null;
 

--- a/app/code/Magento/InventoryImportExport/Plugin/Import/SourceItemImporter.php
+++ b/app/code/Magento/InventoryImportExport/Plugin/Import/SourceItemImporter.php
@@ -74,7 +74,7 @@ class SourceItemImporter
     ) {
         $sourceItems = [];
         foreach ($stockData as $sku => $stockDatum) {
-            $inStock = (isset($stockDatum['is_in_stock'])) ? intval($stockDatum['is_in_stock']) : 0;
+            $inStock = (isset($stockDatum['is_in_stock'])) ? \intval($stockDatum['is_in_stock']) : 0;
             $qty = (isset($stockDatum['qty'])) ? $stockDatum['qty'] : 0;
             /** @var SourceItemInterface $sourceItem */
             $sourceItem = $this->sourceItemFactory->create();
@@ -84,7 +84,7 @@ class SourceItemImporter
             $sourceItem->setStatus($inStock);
             $sourceItems[] = $sourceItem;
         }
-        if (count($sourceItems) > 0) {
+        if (\count($sourceItems) > 0) {
             /** SourceItemInterface[] $sourceItems */
             $this->sourceItemsSave->execute($sourceItems);
         }

--- a/app/code/Magento/InventoryIndexer/Indexer/Source/GetAssignedStockIds.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/Source/GetAssignedStockIds.php
@@ -48,7 +48,7 @@ class GetAssignedStockIds
             ->group(StockSourceLink::STOCK_ID);
 
         $stockIds = $connection->fetchCol($select);
-        $stockIds = array_map('intval', $stockIds);
+        $stockIds = array_map('\intval', $stockIds);
         return $stockIds;
     }
 }

--- a/app/code/Magento/InventoryIndexer/Indexer/SourceItem/IndexDataBySkuListProvider.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/SourceItem/IndexDataBySkuListProvider.php
@@ -48,7 +48,7 @@ class IndexDataBySkuListProvider
     {
         $select = $this->selectBuilder->execute($stockId);
 
-        if (count($skuList)) {
+        if (\count($skuList)) {
             $select->where('source_item.' . SourceItemInterface::SKU . ' IN (?)', $skuList);
         }
 

--- a/app/code/Magento/InventoryIndexer/Indexer/Stock/GetAllStockIds.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/Stock/GetAllStockIds.php
@@ -40,7 +40,7 @@ class GetAllStockIds
         $select = $connection->select()->from($stockTable, StockSourceLink::STOCK_ID);
 
         $stockIds = $connection->fetchCol($select);
-        $stockIds = array_map('intval', $stockIds);
+        $stockIds = array_map('\intval', $stockIds);
 
         return $stockIds;
     }

--- a/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsDeletePlugin.php
+++ b/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsDeletePlugin.php
@@ -48,7 +48,7 @@ class ReindexAfterSourceItemsDeletePlugin
 
         $proceed($sourceItems);
 
-        if (count($sourceCodes)) {
+        if (\count($sourceCodes)) {
             $this->sourceIndexer->executeList($sourceCodes);
         }
     }

--- a/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsSavePlugin.php
+++ b/app/code/Magento/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsSavePlugin.php
@@ -50,7 +50,7 @@ class ReindexAfterSourceItemsSavePlugin
         array $sourceItems
     ) {
         $sourceItemIds = $this->getSourceItemIds->execute($sourceItems);
-        if (count($sourceItemIds)) {
+        if (\count($sourceItemIds)) {
             $this->sourceItemIndexer->executeList($sourceItemIds);
         }
     }

--- a/app/code/Magento/InventoryLowQuantityNotification/Model/ResourceModel/SourceItemConfiguration/SaveMultiple.php
+++ b/app/code/Magento/InventoryLowQuantityNotification/Model/ResourceModel/SourceItemConfiguration/SaveMultiple.php
@@ -36,7 +36,7 @@ class SaveMultiple
      */
     public function execute(array $sourceItemConfigurations)
     {
-        if (!count($sourceItemConfigurations)) {
+        if (!\count($sourceItemConfigurations)) {
             return;
         }
         $connection = $this->resourceConnection->getConnection();
@@ -83,7 +83,7 @@ class SaveMultiple
      */
     private function buildValuesSqlPart(array $sourceItemConfigurations): string
     {
-        $sql = rtrim(str_repeat('(?, ?, ?), ', count($sourceItemConfigurations)), ', ');
+        $sql = rtrim(str_repeat('(?, ?, ?), ', \count($sourceItemConfigurations)), ', ');
         return $sql;
     }
 
@@ -95,13 +95,13 @@ class SaveMultiple
     {
         $bind = [];
         foreach ($sourceItemConfigurations as $sourceItemConfiguration) {
-            $bind = array_merge($bind, [
+            $bind[] = [
                 $sourceItemConfiguration->getSourceCode(),
                 $sourceItemConfiguration->getSku(),
                 $sourceItemConfiguration->getNotifyStockQty()
-            ]);
+            ];
         }
-        return $bind;
+        return array_merge(...$bind);
     }
 
     /**

--- a/app/code/Magento/InventoryLowQuantityNotification/Plugin/InventoryLowQuantityNotificationApi/UpdateLegacyStockItemConfigurationAtSourceItemConfigurationSavePlugin.php
+++ b/app/code/Magento/InventoryLowQuantityNotification/Plugin/InventoryLowQuantityNotificationApi/UpdateLegacyStockItemConfigurationAtSourceItemConfigurationSavePlugin.php
@@ -157,7 +157,7 @@ class UpdateLegacyStockItemConfigurationAtSourceItemConfigurationSavePlugin
      */
     private function buildValuesSqlPart(array $sourceItemConfigurations): string
     {
-        $sql = rtrim(str_repeat('(?, ?, ?, ?), ', count($sourceItemConfigurations)), ', ');
+        $sql = rtrim(str_repeat('(?, ?, ?, ?), ', \count($sourceItemConfigurations)), ', ');
         return $sql;
     }
 
@@ -169,14 +169,14 @@ class UpdateLegacyStockItemConfigurationAtSourceItemConfigurationSavePlugin
     {
         $bind = [];
         foreach ($sourceItemConfigurations as $sourceItemConfiguration) {
-            $bind = array_merge($bind, [
+            $bind[] = [
                 $this->defaultStockProvider->getId(),
                 $sourceItemConfiguration[StockItemInterface::PRODUCT_ID],
                 $sourceItemConfiguration[StockItemInterface::NOTIFY_STOCK_QTY],
                 $sourceItemConfiguration[StockItemInterface::USE_CONFIG_NOTIFY_STOCK_QTY],
-            ]);
+            ];
         }
-        return $bind;
+        return array_merge(...$bind);
     }
 
     /**

--- a/app/code/Magento/InventoryLowQuantityNotification/Test/Integration/Model/RssFeedTest.php
+++ b/app/code/Magento/InventoryLowQuantityNotification/Test/Integration/Model/RssFeedTest.php
@@ -93,7 +93,7 @@ class RssFeedTest extends TestCase
 
         $data = $this->dataProvider->getRssData();
 
-        $this->assertEquals($expectedCount, count($data['entries']));
+        $this->assertEquals($expectedCount, \count($data['entries']));
     }
 
     /**
@@ -130,7 +130,7 @@ class RssFeedTest extends TestCase
 
         $data = $this->dataProvider->getRssData();
 
-        $this->assertEquals($expectedCount, count($data['entries']));
+        $this->assertEquals($expectedCount, \count($data['entries']));
     }
 
     /**

--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/Model/SourceItemsConfigurationProcessor.php
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/Model/SourceItemsConfigurationProcessor.php
@@ -91,7 +91,7 @@ class SourceItemsConfigurationProcessor
             $sourceItemConfigurations[] = $sourceItemConfiguration;
         }
 
-        if (count($sourceItemConfigurations) > 0) {
+        if (\count($sourceItemConfigurations) > 0) {
             $this->deleteSourceItemsConfiguration($sourceItemConfigurations);
             $this->sourceItemConfigurationsSave->execute($sourceItemConfigurations);
         }

--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/Observer/ProcessSourceItemConfigurationsObserver.php
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/Observer/ProcessSourceItemConfigurationsObserver.php
@@ -89,7 +89,7 @@ class ProcessSourceItemConfigurationsObserver implements ObserverInterface
             ];
         } else {
             $sources = $controller->getRequest()->getParam('sources', []);
-            if (isset($sources['assigned_sources']) && is_array($sources['assigned_sources'])) {
+            if (isset($sources['assigned_sources']) && \is_array($sources['assigned_sources'])) {
                 $assignedSources = $sources['assigned_sources'];
             }
         }

--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/Ui/Component/Product/Form/Element/UseConfigSettings.php
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/Ui/Component/Product/Form/Element/UseConfigSettings.php
@@ -62,7 +62,7 @@ class UseConfigSettings extends Checkbox
             && $config['valueFromConfig'] instanceof ValueSourceInterface
         ) {
             $keyInConfiguration = $config['valueFromConfig']->getValue($config['keyInConfiguration']);
-            if (!empty($config['unserialized']) && is_string($keyInConfiguration)) {
+            if (!empty($config['unserialized']) && \is_string($keyInConfiguration)) {
                 if ($this->jsonValidator->isValid($keyInConfiguration)) {
                     $keyInConfiguration = $this->serializer->unserialize($keyInConfiguration);
                 }

--- a/app/code/Magento/InventoryMultiDimensionalIndexerApi/Model/IndexTableSwitcher.php
+++ b/app/code/Magento/InventoryMultiDimensionalIndexerApi/Model/IndexTableSwitcher.php
@@ -92,11 +92,11 @@ class IndexTableSwitcher implements IndexTableSwitcherInterface
                     'newName' => $replicaTableName,
                 ]
             ];
-            $toRename = array_merge($toRename, $renameBatch);
+            $toRename[] = $renameBatch;
         }
 
         if (!empty($toRename)) {
-            $connection->renameTablesBatch($toRename);
+            $connection->renameTablesBatch(array_merge(...$toRename));
         }
     }
 }

--- a/app/code/Magento/InventorySales/Model/GetUnassignedSalesChannelsForStock.php
+++ b/app/code/Magento/InventorySales/Model/GetUnassignedSalesChannelsForStock.php
@@ -51,7 +51,7 @@ class GetUnassignedSalesChannelsForStock
 
         foreach ($assignedSalesChannels as $salesChannel) {
             if ($salesChannel->getType() === SalesChannel::TYPE_WEBSITE
-                && !in_array($salesChannel->getCode(), $newWebsiteCodes, true)
+                && !\in_array($salesChannel->getCode(), $newWebsiteCodes, true)
             ) {
                 $result[] = $salesChannel;
             }

--- a/app/code/Magento/InventorySales/Model/IsProductSalableForRequestedQtyCondition/IsProductSalableForRequestedQtyConditionChain.php
+++ b/app/code/Magento/InventorySales/Model/IsProductSalableForRequestedQtyCondition/IsProductSalableForRequestedQtyConditionChain.php
@@ -155,12 +155,12 @@ class IsProductSalableForRequestedQtyConditionChain implements IsProductSalableF
 
         try {
             $requiredConditionsErrors = $this->processRequiredConditions($sku, $stockId, $requestedQty);
-            if (count($requiredConditionsErrors)) {
+            if (\count($requiredConditionsErrors)) {
                 return $this->productSalableResultFactory->create(['errors' => $requiredConditionsErrors]);
             }
 
             $sufficientConditionsErrors = $this->processSufficientConditions($sku, $stockId, $requestedQty);
-            if (count($sufficientConditionsErrors)) {
+            if (\count($sufficientConditionsErrors)) {
                 return $this->productSalableResultFactory->create(['errors' => $sufficientConditionsErrors]);
             }
         } catch (SkuIsNotAssignedToStockException $e) {

--- a/app/code/Magento/InventorySales/Model/ResourceModel/GetAssignedStockIdForWebsite.php
+++ b/app/code/Magento/InventorySales/Model/ResourceModel/GetAssignedStockIdForWebsite.php
@@ -45,7 +45,7 @@ class GetAssignedStockIdForWebsite implements GetAssignedStockIdForWebsiteInterf
 
         $result = $connection->fetchCol($select);
 
-        if (count($result) === 0) {
+        if (\count($result) === 0) {
             return null;
         }
         return (int)reset($result);

--- a/app/code/Magento/InventorySales/Model/ResourceModel/ReplaceSalesChannelsDataForStock.php
+++ b/app/code/Magento/InventorySales/Model/ResourceModel/ReplaceSalesChannelsDataForStock.php
@@ -43,7 +43,7 @@ class ReplaceSalesChannelsDataForStock implements ReplaceSalesChannelsForStockIn
 
         $connection->delete($tableName, ['stock_id = ?' => $stockId]);
 
-        if (count($salesChannels)) {
+        if (\count($salesChannels)) {
             $salesChannelsToInsert = [];
             foreach ($salesChannels as $salesChannel) {
                 $salesChannelsToInsert[] = [

--- a/app/code/Magento/InventorySales/Model/ReturnProcessor/GetInvoicedItemsPerSourceByPriority.php
+++ b/app/code/Magento/InventorySales/Model/ReturnProcessor/GetInvoicedItemsPerSourceByPriority.php
@@ -167,8 +167,8 @@ class GetInvoicedItemsPerSourceByPriority implements GetSourceDeductedOrderItems
      */
     private function isValidItem(OrderItemModel $orderItem, array $returnToStockItems): bool
     {
-        return (in_array($orderItem->getId(), $returnToStockItems)
-                || in_array($orderItem->getParentItemId(), $returnToStockItems))
+        return (\in_array($orderItem->getId(), $returnToStockItems)
+                || \in_array($orderItem->getParentItemId(), $returnToStockItems))
                 && $orderItem->getIsVirtual()
                 && !$orderItem->isDummy();
     }

--- a/app/code/Magento/InventorySales/Model/Stock/Validator/SalesChannelsValidator.php
+++ b/app/code/Magento/InventorySales/Model/Stock/Validator/SalesChannelsValidator.php
@@ -51,7 +51,7 @@ class SalesChannelsValidator implements StockValidatorInterface
         $salesChannels = $extensionAttributes->getSalesChannels();
 
         $errors = [];
-        if (is_array($salesChannels)) {
+        if (\is_array($salesChannels)) {
             foreach ($salesChannels as $salesChannel) {
                 $type = (string)$salesChannel->getType();
                 if ('' === trim($type)) {

--- a/app/code/Magento/InventorySales/Observer/Stock/PopulateWithWebsiteSalesChannelsObserver.php
+++ b/app/code/Magento/InventorySales/Observer/Stock/PopulateWithWebsiteSalesChannelsObserver.php
@@ -61,7 +61,7 @@ class PopulateWithWebsiteSalesChannelsObserver implements ObserverInterface
         }
 
         if (isset($requestData['sales_channels'][SalesChannelInterface::TYPE_WEBSITE])
-            && is_array($requestData['sales_channels'][SalesChannelInterface::TYPE_WEBSITE])
+            && \is_array($requestData['sales_channels'][SalesChannelInterface::TYPE_WEBSITE])
         ) {
             foreach ($requestData['sales_channels'][SalesChannelInterface::TYPE_WEBSITE] as $websiteCode) {
                 $assignedSalesChannels[] = $this->createSalesChannelByWebsiteCode($websiteCode);

--- a/app/code/Magento/InventorySales/Plugin/InventoryApi/StockRepository/PreventDeletingAssignedToSalesChannelsStockPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/InventoryApi/StockRepository/PreventDeletingAssignedToSalesChannelsStockPlugin.php
@@ -42,7 +42,7 @@ class PreventDeletingAssignedToSalesChannelsStockPlugin
     public function beforeDeleteById(StockRepositoryInterface $subject, int $stockId)
     {
         $assignSalesChannels = $this->assignedSalesChannelsForStock->execute($stockId);
-        if (count($assignSalesChannels)) {
+        if (\count($assignSalesChannels)) {
             throw new CouldNotDeleteException(__('Stock has at least one sale channel and could not be deleted.'));
         }
     }

--- a/app/code/Magento/InventorySales/Plugin/InventoryApi/StockRepository/SaveSalesChannelsLinksPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/InventoryApi/StockRepository/SaveSalesChannelsLinksPlugin.php
@@ -89,7 +89,7 @@ class SaveSalesChannelsLinksPlugin
         try {
             $this->replaceSalesChannelsOnStock->execute($salesChannels, $stockId);
 
-            if (count($unAssignedSalesChannels)) {
+            if (\count($unAssignedSalesChannels)) {
                 $mergedSalesChannels = array_merge(
                     $unAssignedSalesChannels,
                     $this->getAssignedSalesChannelsForStock->execute($this->defaultStockProvider->getId())

--- a/app/code/Magento/InventorySales/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnDefaultStockTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnDefaultStockTest.php
@@ -66,7 +66,7 @@ class AddSalesQuoteItemOnDefaultStockTest extends TestCase
 
         self::expectException(LocalizedException::class);
         $quote->addProduct($product, $productQty);
-        $quoteItemCount = count($quote->getAllItems());
+        $quoteItemCount = \count($quote->getAllItems());
         self::assertEquals(0, $quoteItemCount);
     }
 

--- a/app/code/Magento/InventorySales/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnNotDefaultStockTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/SalesQuoteItem/AddSalesQuoteItemOnNotDefaultStockTest.php
@@ -159,7 +159,7 @@ class AddSalesQuoteItemOnNotDefaultStockTest extends TestCase
         self::expectException(LocalizedException::class);
         $quote->addProduct($product, $qty);
 
-        $quoteItemCount = count($quote->getAllItems());
+        $quoteItemCount = \count($quote->getAllItems());
         self::assertEquals(0, $quoteItemCount);
     }
 

--- a/app/code/Magento/InventorySales/Test/Integration/StockResolverTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/StockResolverTest.php
@@ -64,7 +64,7 @@ class StockResolverTest extends TestCase
         $this->assertEquals(10, $stock->getStockId());
         $this->assertEquals('EU-stock', $stock->getName());
         $salesChannels = $stock->getExtensionAttributes()->getSalesChannels();
-        $this->assertEquals(1, count($salesChannels));
+        $this->assertEquals(1, \count($salesChannels));
         /** @var SalesChannelInterface $salesChannel */
         $salesChannel = $salesChannels[0];
         $this->assertEquals('website', $salesChannel->getType());
@@ -86,7 +86,7 @@ class StockResolverTest extends TestCase
         $this->assertEquals($stockId, $stock->getStockId());
         $this->assertEquals('US-stock', $stock->getName());
         $salesChannels = $stock->getExtensionAttributes()->getSalesChannels();
-        $this->assertEquals(1, count($salesChannels));
+        $this->assertEquals(1, \count($salesChannels));
         /** @var SalesChannelInterface $salesChannel */
         $salesChannel = $salesChannels[0];
         $this->assertEquals('website', $salesChannel->getType());
@@ -104,7 +104,7 @@ class StockResolverTest extends TestCase
         $this->assertEquals($stockId, $stock->getStockId());
         $this->assertEquals('US-stock', $stock->getName());
         $salesChannels = $stock->getExtensionAttributes()->getSalesChannels();
-        $this->assertEquals(1, count($salesChannels));
+        $this->assertEquals(1, \count($salesChannels));
         /** @var SalesChannelInterface $salesChannel */
         $salesChannel = $salesChannels[0];
         $this->assertEquals('website', $salesChannel->getType());

--- a/app/code/Magento/InventorySalesAdminUi/Model/GetSalableQuantityDataBySku.php
+++ b/app/code/Magento/InventorySalesAdminUi/Model/GetSalableQuantityDataBySku.php
@@ -63,7 +63,7 @@ class GetSalableQuantityDataBySku
     {
         $stockInfo = [];
         $stockIds = $this->getAssignedStockIdsBySku->execute($sku);
-        if (count($stockIds)) {
+        if (\count($stockIds)) {
             foreach ($stockIds as $stockId) {
                 $stockId = (int)$stockId;
                 $stock = $this->stockRepository->get($stockId);

--- a/app/code/Magento/InventorySalesAdminUi/Plugin/InventoryAdminUi/Ui/StockDataProvider/SalesChannels.php
+++ b/app/code/Magento/InventorySalesAdminUi/Plugin/InventoryAdminUi/Ui/StockDataProvider/SalesChannels.php
@@ -48,7 +48,7 @@ class SalesChannels
         if ('inventory_stock_form_data_source' === $subject->getName()) {
             foreach ($data as &$stockData) {
                 $salesChannelsData = $this->getSalesChannelsDataForStock($stockData['general']);
-                if (count($salesChannelsData)) {
+                if (\count($salesChannelsData)) {
                     $stockData['sales_channels'] = $salesChannelsData;
                 }
             }
@@ -56,7 +56,7 @@ class SalesChannels
         } elseif (isset($data['totalRecords']) && $data['totalRecords'] > 0) {
             foreach ($data['items'] as &$stockData) {
                 $salesChannelsData = $this->getSalesChannelsDataForStock($stockData);
-                if (count($salesChannelsData)) {
+                if (\count($salesChannelsData)) {
                     $stockData['sales_channels'] = $salesChannelsData;
                 }
             }

--- a/app/code/Magento/InventorySalesAdminUi/Plugin/InventoryApi/StockRepository/AddNoticeForUnassignedSalesChannels.php
+++ b/app/code/Magento/InventorySalesAdminUi/Plugin/InventoryApi/StockRepository/AddNoticeForUnassignedSalesChannels.php
@@ -59,7 +59,7 @@ class AddNoticeForUnassignedSalesChannels
     ): int {
         $unAssignedSalesChannels = $this->getUnassignedSalesChannelsForStock($stock);
 
-        if (count($unAssignedSalesChannels)) {
+        if (\count($unAssignedSalesChannels)) {
             $this->messageManager->addNoticeMessage(
                 __('All unassigned sales channels will be assigned to the Default Stock')
             );
@@ -89,7 +89,7 @@ class AddNoticeForUnassignedSalesChannels
 
         foreach ($assignedSalesChannels as $salesChannel) {
             if ($salesChannel->getType() === SalesChannelInterface::TYPE_WEBSITE
-                && !in_array($salesChannel->getCode(), $newWebsiteCodes, true)
+                && !\in_array($salesChannel->getCode(), $newWebsiteCodes, true)
             ) {
                 $result[] = $salesChannel;
             }

--- a/app/code/Magento/InventorySalesAdminUi/Ui/Component/Control/Stock/DeleteButton.php
+++ b/app/code/Magento/InventorySalesAdminUi/Ui/Component/Control/Stock/DeleteButton.php
@@ -65,7 +65,7 @@ class DeleteButton implements ButtonProviderInterface
     {
         $stockId = (int)$this->request->getParam(StockInterface::STOCK_ID);
         $assignSalesChannels = $this->assignedSalesChannelsForStock->execute($stockId);
-        if ($stockId === $this->defaultStockProvider->getId() || count($assignSalesChannels)) {
+        if ($stockId === $this->defaultStockProvider->getId() || \count($assignSalesChannels)) {
             return [];
         }
 

--- a/app/code/Magento/InventorySalesApi/Model/ReturnProcessor/GetSourceDeductedOrderItemsChain.php
+++ b/app/code/Magento/InventorySalesApi/Model/ReturnProcessor/GetSourceDeductedOrderItemsChain.php
@@ -36,7 +36,7 @@ class GetSourceDeductedOrderItemsChain implements GetSourceDeductedOrderItemsInt
         foreach ($sourceDeductedItemsSelector as $selector) {
             if (!$selector instanceof GetSourceDeductedOrderItemsInterface) {
                 throw new InputException(
-                    __('%1 doesn\'t implement GetSourceDeductedOrderItemsInterface', get_class($selector))
+                    __('%1 doesn\'t implement GetSourceDeductedOrderItemsInterface', \get_class($selector))
                 );
             }
         }

--- a/app/code/Magento/InventorySalesApi/Test/Api/StockResolverTest.php
+++ b/app/code/Magento/InventorySalesApi/Test/Api/StockResolverTest.php
@@ -85,7 +85,7 @@ class StockResolverTest extends WebapiAbstract
 
         $this->assertEquals(10, $stockData['stock_id']);
         $this->assertEquals('EU-stock', $stockData['name']);
-        $this->assertEquals(1, count($stockData['extension_attributes']['sales_channels']));
+        $this->assertEquals(1, \count($stockData['extension_attributes']['sales_channels']));
         $this->assertEquals(
             [
                 'type' => 'website',
@@ -125,7 +125,7 @@ class StockResolverTest extends WebapiAbstract
 
         $this->assertEquals($stockId, $stockData['stock_id']);
         $this->assertEquals('US-stock', $stockData['name']);
-        $this->assertEquals(1, count($stockData['extension_attributes']['sales_channels']));
+        $this->assertEquals(1, \count($stockData['extension_attributes']['sales_channels']));
         $this->assertEquals(
             [
                 'type' => 'website',
@@ -162,7 +162,7 @@ class StockResolverTest extends WebapiAbstract
 
         $this->assertEquals($stockId, $stockData['stock_id']);
         $this->assertEquals('US-stock', $stockData['name']);
-        $this->assertEquals(1, count($stockData['extension_attributes']['sales_channels']));
+        $this->assertEquals(1, \count($stockData['extension_attributes']['sales_channels']));
         $this->assertEquals(
             [
                 'type' => 'website',

--- a/app/code/Magento/InventoryShipping/Model/Source/Validator/CarrierLinksValidator.php
+++ b/app/code/Magento/InventoryShipping/Model/Source/Validator/CarrierLinksValidator.php
@@ -52,14 +52,14 @@ class CarrierLinksValidator implements SourceValidatorInterface
             return $this->buildValidationResult($errors);
         }
 
-        if (!is_array($carrierLinks)) {
+        if (!\is_array($carrierLinks)) {
             $errors[] = __('"%field" must be list of SourceCarrierLinkInterface.', [
                 'field' => SourceInterface::CARRIER_LINKS
             ]);
             return $this->buildValidationResult($errors);
         }
 
-        if (count($carrierLinks) && $source->isUseDefaultCarrierConfig()) {
+        if (\count($carrierLinks) && $source->isUseDefaultCarrierConfig()) {
             $errors[] = __('You can\'t configure "%field" because you have chosen Global Shipping configuration.', [
                 'field' => SourceInterface::CARRIER_LINKS
             ]);

--- a/app/code/Magento/InventoryShipping/Plugin/Sales/Shipment/AssignSourceCodeToShipmentPlugin.php
+++ b/app/code/Magento/InventoryShipping/Plugin/Sales/Shipment/AssignSourceCodeToShipmentPlugin.php
@@ -81,7 +81,7 @@ class AssignSourceCodeToShipmentPlugin
             $stockId = $this->stockByWebsiteIdResolver->execute((int)$websiteId)->getStockId();
             $sources = $this->getSourcesAssignedToStockOrderedByPriority->execute((int)$stockId);
             //TODO: need ro rebuild this logic | create separate service
-            if (!empty($sources) && count($sources) == 1) {
+            if (!empty($sources) && \count($sources) == 1) {
                 $sourceCode = $sources[0]->getSourceCode();
             } else {
                 $sourceCode = $this->defaultSourceProvider->getCode();

--- a/app/code/Magento/InventoryShippingAdminUi/Model/ShipmentProvider.php
+++ b/app/code/Magento/InventoryShippingAdminUi/Model/ShipmentProvider.php
@@ -48,6 +48,6 @@ class ShipmentProvider implements ShipmentProviderInterface
             }
         }
 
-        return count($shipmentItems) > 0 ? $shipmentItems : [];
+        return \count($shipmentItems) > 0 ? $shipmentItems : [];
     }
 }

--- a/app/code/Magento/InventoryShippingAdminUi/Observer/NewShipmentLoadBefore.php
+++ b/app/code/Magento/InventoryShippingAdminUi/Observer/NewShipmentLoadBefore.php
@@ -83,7 +83,5 @@ class NewShipmentLoadBefore implements ObserverInterface
                 'sales/order/index'
             );
         }
-
-        return;
     }
 }

--- a/app/code/Magento/InventoryShippingAdminUi/Plugin/Sales/Block/Order/Invoice/Create/DisallowCreateShipmentPlugin.php
+++ b/app/code/Magento/InventoryShippingAdminUi/Plugin/Sales/Block/Order/Invoice/Create/DisallowCreateShipmentPlugin.php
@@ -51,7 +51,7 @@ class DisallowCreateShipmentPlugin
             $websiteId = $subject->getOrder()->getStore()->getWebsiteId();
             $stockId = $this->stockByWebsiteIdResolver->execute((int)$websiteId)->getStockId();
             $sources = $this->getSourcesAssignedToStockOrderedByPriority->execute((int)$stockId);
-            if (count($sources) > 1) {
+            if (\count($sources) > 1) {
                 return false;
             }
         } catch (LocalizedException $e) {

--- a/app/code/Magento/InventoryShippingAdminUi/Ui/DataProvider/SourceSelectionDataProvider.php
+++ b/app/code/Magento/InventoryShippingAdminUi/Ui/DataProvider/SourceSelectionDataProvider.php
@@ -204,7 +204,7 @@ class SourceSelectionDataProvider extends AbstractDataProvider
                 if (isset($productOptions['attributes_info'])) {
                     $options = array_merge($options, $productOptions['attributes_info']);
                 }
-                if (count($options)) {
+                if (\count($options)) {
                     foreach ($options as $option) {
                         $name .= '<dd>' . $option['label'] . ': ' . $option['value'] .'</dd>';
                     }


### PR DESCRIPTION
Fixes for Slow array and missing absolute references.

**Benchmark for missing absolute reference**
https://github.com/Roave/FunctionFQNReplacer

## Slow array function used in loop

> Note: you might want to check benchmarks first - [one](https://gist.github.com/Ocramius/8399625), [two](https://github.com/kalessil/phpinspectionsea/issues/138#issuecomment-279457133)

Synopsis: merging arrays in a loop is slow and causes high CPU usage.

Let's start with an example demonstrating the case:
```php
    $options = [];
    foreach ($configurationSources as $source) {
        /* something happens here */
        $options = array_merge($options, $source->getOptions());
    }
```

In order to reduce execution time we can modify the code and perform the merge operation only once:
```php
    /* the inner empty array covers cases when no loops were made */
    $options = [[]];
    foreach ($configurationSources as $source) {
        /* something happens here */
        $options[] = $source->getOptions(); // <- yes, we'll use a little bit more memory
    }
    /* PHP below 5.6 */
    $options = call_user_func_array('array_merge', $options);

    /* PHP 5.6+: more friendly to refactoring as less magic involved */
    $options = array_merge(...$options);
```