### PR TITLE
Created tooltip for qty per source more than 5 sources for product

### DIFF
--- a/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/web/js/product/grid/cell/quantity-per-source.js
+++ b/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/web/js/product/grid/cell/quantity-per-source.js
@@ -28,7 +28,7 @@ define([
          * @returns {Array} Result array
          */
         getSourceItemsDataCut: function (record) {
-            return this.getSourceItemsData(record).slice(0, this.itemsToDisplay)
+            return this.getSourceItemsData(record).slice(0, this.itemsToDisplay);
         }
     });
 });

--- a/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/web/js/product/grid/cell/quantity-per-source.js
+++ b/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/web/js/product/grid/cell/quantity-per-source.js
@@ -9,7 +9,8 @@ define([
 
     return Column.extend({
         defaults: {
-            bodyTmpl: 'Magento_InventoryCatalogAdminUi/product/grid/cell/source-items.html'
+            bodyTmpl: 'Magento_InventoryCatalogAdminUi/product/grid/cell/source-items.html',
+            itemsToDisplay: 5
         },
 
         /**
@@ -20,6 +21,14 @@ define([
          */
         getSourceItemsData: function (record) {
             return record[this.index] ? record[this.index] : [];
+        },
+
+        /**
+         * @param {Object} record - Record object
+         * @returns {Array} Result array
+         */
+        getSourceItemsDataCut: function (record) {
+            return this.getSourceItemsData(record).slice(0, this.itemsToDisplay)
         }
     });
 });

--- a/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/web/template/product/grid/cell/source-items.html
+++ b/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/web/template/product/grid/cell/source-items.html
@@ -4,12 +4,31 @@
  * See COPYING.txt for license details.
  */
 -->
-<div class="data-grid-cell-content">
-    <ul data-bind="foreach: { data: $col.getSourceItemsData($row()), as: '$sourceItemData' }">
+
+<div class="data-grid-cell-content" attr="'data-tooltip-trigger': ++ko.uid">
+    <ul data-bind="foreach: { data: $col.getSourceItemsDataCut($row()), as: '$sourceItemData' }">
         <li>
-            <strong data-bind="text: $sourceItemData.source_name"></strong>
-            :
-            <span data-bind="text: $sourceItemData.qty"></span>
+            <span data-bind="text: $sourceItemData.source_name"></span>
+            (<span data-bind="text: $sourceItemData.qty"></span>)
         </li>
     </ul>
+</div>
+<div tooltip="
+    trigger: '[data-tooltip-trigger=' + ko.uid + ']',
+    action: 'hover',
+    closeOnScroll: false,
+    delay: 0,
+    position: 'top',
+    step: 30,
+    track: false,
+    strict: true">
+    <div>
+        <div class="data-tooltip-title" data-bind="i18n: 'Quantity per Source:'"></div>
+        <div class="data-tooltip-content">
+            <!-- ko foreach: { data: $col.getSourceItemsData($row()), as: '$sourceItemData' } -->
+            <div><span data-bind="text: $sourceItemData.source_name"></span>: <span
+                    data-bind="text: $sourceItemData.qty"></span></div>
+            <!-- /ko -->
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
### Description
Created tooltip for qty per source field at product grid if more than 5 sources assigned for product

### Fixed Issues
1. magento-engcom/msi#1730: "Show more - Show less" sources in field "quantity per source" at product grid

### Manual testing scenarios
#### Preconditions
1. Create more than 10 sources
2. Create new stock
3. Assign all sources to new stock

#### Steps to reproduce
1. Create a new product
2. Assign all available sources to  the product and fill QTY fields with 1 or more and set "in stock" for all sources
3. Save
4. Go to the product grid

#### Expected result
1. Field "quantity per source" limited by 5 items and "show more" link.
2. All other sources and qty are shown in a tooltip when hovering over the "qty per source"

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
