### PR TITLE
FIX for issue 1889

### DIFF
--- a/app/code/Magento/InventoryCatalogAdminUi/Ui/DataProvider/Product/Form/Modifier/Quantity.php
+++ b/app/code/Magento/InventoryCatalogAdminUi/Ui/DataProvider/Product/Form/Modifier/Quantity.php
@@ -66,6 +66,30 @@ class Quantity extends AbstractModifier
     }
 
     /**
+     * Disable qty field
+     *
+     * @param string $stockQtyPath
+     * @param array $meta
+     * @return array
+     */
+    private function disableQtyField(string $stockQtyPath, array $meta): array
+    {
+        $meta = $this->arrayManager->merge(
+            $stockQtyPath . '/children/qty/arguments/data/config',
+            $meta,
+            [
+                'disabled' => true,
+            ]
+        );
+        $meta = $this->arrayManager->remove(
+            $stockQtyPath . '/children/qty/arguments/data/config/imports/disabled',
+            $meta
+        );
+
+        return $meta;
+    }
+
+    /**
      * @inheritdoc
      */
     public function modifyMeta(array $meta)
@@ -79,6 +103,7 @@ class Quantity extends AbstractModifier
         $product = $this->locator->getProduct();
 
         if ($this->isSourceItemManagementAllowedForProductType->execute($product->getTypeId()) === false) {
+            $meta = $this->disableQtyField($stockQtyPath, $meta);
             return $meta;
         }
 


### PR DESCRIPTION
### Description
Quantity field should not be enabled in configurables product
More in general, qty field should not be handled by any non-source-item product type

### Fixed Issues (if relevant)
1. magento-engcom/msi#1889: "Quantity" field is present on Configurable product creation page in multisource mode.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
