### PR TITLE
MSI-1895: Fixed wrong refund processing on multi source

### DIFF
--- a/app/code/Magento/InventorySales/Model/ReturnProcessor/GetInvoicedItemsPerSourceByPriority.php
+++ b/app/code/Magento/InventorySales/Model/ReturnProcessor/GetInvoicedItemsPerSourceByPriority.php
@@ -155,6 +155,7 @@ class GetInvoicedItemsPerSourceByPriority implements GetSourceDeductedOrderItems
                 }
             }
         } catch (LocalizedException $e) {
+            //Use Default Source if the source can't be resolved
         }
 
         return $sourceCode;

--- a/app/code/Magento/InventorySales/Model/ReturnProcessor/GetInvoicedItemsPerSourceByPriority.php
+++ b/app/code/Magento/InventorySales/Model/ReturnProcessor/GetInvoicedItemsPerSourceByPriority.php
@@ -142,6 +142,7 @@ class GetInvoicedItemsPerSourceByPriority implements GetSourceDeductedOrderItems
      */
     private function getSourceCodeWithHighestPriorityBySku(string $sku, int $stockId): string
     {
+        $sourceCode = $this->defaultSourceProvider->getCode();
         try {
             $availableSourcesForProduct = $this->getSourceItemsBySku->execute($sku);
             $assignedSourcesToStock = $this->getSourcesAssignedToStockOrderedByPriority->execute($stockId);
@@ -154,7 +155,6 @@ class GetInvoicedItemsPerSourceByPriority implements GetSourceDeductedOrderItems
                 }
             }
         } catch (LocalizedException $e) {
-            $sourceCode = $this->defaultSourceProvider->getCode();
         }
 
         return $sourceCode;

--- a/app/code/Magento/InventorySales/Model/ReturnProcessor/GetInvoicedItemsPerSourceByPriority.php
+++ b/app/code/Magento/InventorySales/Model/ReturnProcessor/GetInvoicedItemsPerSourceByPriority.php
@@ -145,8 +145,8 @@ class GetInvoicedItemsPerSourceByPriority implements GetSourceDeductedOrderItems
         try {
             $availableSourcesForProduct = $this->getSourceItemsBySku->execute($sku);
             $assignedSourcesToStock = $this->getSourcesAssignedToStockOrderedByPriority->execute($stockId);
-            foreach ($availableSourcesForProduct as $availableSource) {
-                foreach ($assignedSourcesToStock as $assignedSource) {
+            foreach ($assignedSourcesToStock as $assignedSource) {
+                foreach ($availableSourcesForProduct as $availableSource) {
                     if ($assignedSource->getSourceCode() == $availableSource->getSourceCode()) {
                         $sourceCode = $assignedSource->getSourceCode();
                         break 2;


### PR DESCRIPTION
### Description
The issue has appeared due to wrong order of loops in `app/code/Magento/InventorySales/Model/ReturnProcessor/GetInvoicedItemsPerSourceByPriority.php:146`.

### Fixed Issues (if relevant)
1. magento-engcom/msi#1895: Return to stock during Credit memo for order with virtual product not respecting sources priority for stock
