### PR TITLE
1906 cancellation of partially invoiced order with fixed bundle product isn't create

### DIFF
--- a/app/code/Magento/InventorySales/Model/GetItemsToCancelFromOrderItem.php
+++ b/app/code/Magento/InventorySales/Model/GetItemsToCancelFromOrderItem.php
@@ -113,7 +113,11 @@ class GetItemsToCancelFromOrderItem
                 );
                 if ($bundleSelectionAttributes) {
                     $shippedQty = $bundleSelectionAttributes['qty'] * $orderItem->getQtyShipped();
-                    $qty = $item->getQtyOrdered() - max($shippedQty, $item->getQtyInvoiced()) - $item->getQtyCanceled();
+
+                    $invoicedQty = $bundleSelectionAttributes['qty'] * $item->getParentItem()->getQtyInvoiced();
+                    $canceledQty = $bundleSelectionAttributes['qty'] * $item->getParentItem()->getQtyCanceled();
+                    $qty = $item->getQtyOrdered() - max($shippedQty, $invoicedQty) - $canceledQty;
+                    
                     $itemSku = $this->getSkuFromOrderItem->execute($item);
                     $itemsToCancel[] = $this->itemsToSellFactory->create([
                         'sku' => $itemSku,


### PR DESCRIPTION
https://github.com/magento-engcom/msi/issues/1906 Cancellation of partially invoiced order with fixed bundle product isn't create
### Description
Cancellation of partially invoiced order with fixed bundle product isn't create

### Fixed Issues (if relevant)
Check reserved bundle childrens

### Manual testing scenarios
1.Create order with bundle product with quantity equal to 5
2.Create invoice with quantity equal to 3
3.Cancel order


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
