### PR TITLE
magento-engcom/msi - MFTF MSI suite enabling dbBackup

### DIFF
--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Suite/msi-suite.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Suite/msi-suite.xml
@@ -26,7 +26,7 @@
         <after>
             <magentoCLI stepKey="dbRollback" command="setup:rollback" arguments="--db-file%3D%24%28ls%20..%2F..%2F..%2F..%2Fvar%2Fbackups%29%20-n" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
-            <magentoCLI stepKey="enableBackup" command = "config:set system/backup/functionality_enabled 0" />
+            <magentoCLI stepKey="disableBackup" command = "config:set system/backup/functionality_enabled 0" />
         </after>
     </suite>
     <suite name="MSI_Multi_Mode">
@@ -46,7 +46,7 @@
         <after>
             <magentoCLI stepKey="dbRollback" command="setup:rollback" arguments="--db-file%3D%24%28ls%20..%2F..%2F..%2F..%2Fvar%2Fbackups%29%20-n" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
-            <magentoCLI stepKey="enableBackup" command = "config:set system/backup/functionality_enabled 0" />
+            <magentoCLI stepKey="disableBackup" command = "config:set system/backup/functionality_enabled 0" />
         </after>
     </suite>
     <suite name="MSI_Sort_Order_Tests">
@@ -67,7 +67,7 @@
         <after>
             <magentoCLI stepKey="dbRollback" command="setup:rollback" arguments="--db-file%3D%24%28ls%20..%2F..%2F..%2F..%2Fvar%2Fbackups%29%20-n" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
-            <magentoCLI stepKey="enableBackup" command = "config:set system/backup/functionality_enabled 0" />
+            <magentoCLI stepKey="disableBackup" command = "config:set system/backup/functionality_enabled 0" />
         </after>
     </suite>
 </suites>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Suite/msi-suite.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Suite/msi-suite.xml
@@ -10,6 +10,7 @@
         xsi:noNamespaceSchemaLocation="../../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Suite/etc/suiteSchema.xsd">
     <suite name="MSI_Single_Mode">
         <before>
+            <magentoCLI stepKey="enableBackup" command = "config:set system/backup/functionality_enabled 1" />
             <magentoCLI stepKey="dbBackup" command="setup:backup" arguments="--db" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
             <magentoCLI stepKey="disableWYSYWYG" command="config:set cms/wysiwyg/enabled disabled"/>
@@ -25,10 +26,12 @@
         <after>
             <magentoCLI stepKey="dbRollback" command="setup:rollback" arguments="--db-file%3D%24%28ls%20..%2F..%2F..%2F..%2Fvar%2Fbackups%29%20-n" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
+            <magentoCLI stepKey="enableBackup" command = "config:set system/backup/functionality_enabled 0" />
         </after>
     </suite>
     <suite name="MSI_Multi_Mode">
         <before>
+            <magentoCLI stepKey="enableBackup" command = "config:set system/backup/functionality_enabled 1" />
             <magentoCLI stepKey="dbBackup" command="setup:backup" arguments="--db" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
             <magentoCLI stepKey="disableWYSYWYG" command="config:set cms/wysiwyg/enabled disabled"/>
@@ -43,10 +46,12 @@
         <after>
             <magentoCLI stepKey="dbRollback" command="setup:rollback" arguments="--db-file%3D%24%28ls%20..%2F..%2F..%2F..%2Fvar%2Fbackups%29%20-n" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
+            <magentoCLI stepKey="enableBackup" command = "config:set system/backup/functionality_enabled 0" />
         </after>
     </suite>
     <suite name="MSI_Sort_Order_Tests">
         <before>
+            <magentoCLI stepKey="enableBackup" command = "config:set system/backup/functionality_enabled 1" />
             <magentoCLI stepKey="dbBackup" command="setup:backup" arguments="--db" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
             <magentoCLI stepKey="disableWYSYWYG" command="config:set cms/wysiwyg/enabled disabled"/>
@@ -62,6 +67,7 @@
         <after>
             <magentoCLI stepKey="dbRollback" command="setup:rollback" arguments="--db-file%3D%24%28ls%20..%2F..%2F..%2F..%2Fvar%2Fbackups%29%20-n" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
+            <magentoCLI stepKey="enableBackup" command = "config:set system/backup/functionality_enabled 0" />
         </after>
     </suite>
 </suites>


### PR DESCRIPTION
Change to Magento2 Core - dbBackup is disabled by default
Update to MSI MFTF suite file to enable DB backup config to support suite before/after DB backup

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
