### PR TITLE
Replace traversable with iterable

### DIFF
--- a/app/code/Magento/InventoryShipping/Model/GetSourceSelectionResultFromInvoice.php
+++ b/app/code/Magento/InventoryShipping/Model/GetSourceSelectionResultFromInvoice.php
@@ -101,10 +101,10 @@ class GetSourceSelectionResultFromInvoice
     }
 
     /**
-     * @param InvoiceItemInterface[]|Traversable $invoiceItems
+     * @param InvoiceItemInterface[]|iterable $invoiceItems
      * @return array
      */
-    private function getSelectionRequestItems(Traversable $invoiceItems): array
+    private function getSelectionRequestItems(iterable $invoiceItems): array
     {
         $selectionRequestItems = [];
         foreach ($invoiceItems as $invoiceItem) {


### PR DESCRIPTION

### Description
Replace traversable with iterable

### Fixed Issues
1. magento-engcom/msi#1952: Argument 1 passed to Magento\InventoryShipping\Model\GetSourceSelectionResultFromInvoice::getSelectionRequestItems() must implement interface Traversable, array given

### Manual testing scenarios
Described in issue

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
