### PR TITLE
Fix issue 1922

### DIFF
--- a/app/code/Magento/InventoryLowQuantityNotification/Model/ResourceModel/BulkConfigurationTransfer.php
+++ b/app/code/Magento/InventoryLowQuantityNotification/Model/ResourceModel/BulkConfigurationTransfer.php
@@ -77,15 +77,16 @@ class BulkConfigurationTransfer
         $destinationItemsQuery = $connection
             ->select()
             ->from($tableName, ['sku', 'notify_stock_qty'])
+            ->where('sku IN (?)', array_keys($skuTypes))
             ->where('source_code = ?', $destinationSource);
         $destinationQueryResult = $connection->fetchPairs($destinationItemsQuery);
 
-        $destinationSkus = array_diff_key($skuTypes, $destinationQueryResult);
-        if (!empty($destinationSkus)) {
+        $skusForDestination = array_diff_key($skuTypes, $destinationQueryResult);
+        if (!empty($skusForDestination)) {
             /**
              * Get configuration from DB to transfer
              */
-            $allowedSkus = array_keys($destinationSkus);
+            $allowedSkus = array_keys($skusForDestination);
             $sourceItemsQuery = $connection
                 ->select()
                 ->from($tableName, ['sku','notify_stock_qty'])
@@ -97,7 +98,7 @@ class BulkConfigurationTransfer
              * Collect information about items to be copied
              * and also create an array of items that are not presented in original source
              */
-            $notPresentedSkus = $destinationSkus;
+            $notPresentedSkus = $skusForDestination;
             $itemsAllowedToMove = [];
             foreach ($sourceQueryResult as $inventoryNotificationItem) {
                 $inventoryNotificationItem['source_code'] = $destinationSource;

--- a/app/code/Magento/InventoryLowQuantityNotification/Model/ResourceModel/BulkConfigurationTransfer.php
+++ b/app/code/Magento/InventoryLowQuantityNotification/Model/ResourceModel/BulkConfigurationTransfer.php
@@ -65,37 +65,35 @@ class BulkConfigurationTransfer
 
         $types = $this->getProductTypesBySkus->execute($skus);
 
-        foreach ($types as $sku => $type) {
-            if ($this->isSourceItemManagementAllowedForProductType->execute($type)) {
-                foreach ($skus as $sku) {
-                    $qry = $connection
-                        ->select()
-                        ->from($tableName, 'notify_stock_qty')
-                        ->where('sku = ?', $sku)
-                        ->where('source_code = ?', $originSource);
+        foreach ($skus as $sku) {
+            if ($this->isSourceItemManagementAllowedForProductType->execute($types[$sku])) {
+                $qry = $connection
+                    ->select()
+                    ->from($tableName, 'notify_stock_qty')
+                    ->where('sku = ?', $sku)
+                    ->where('source_code = ?', $originSource);
 
-                    $res = $connection->fetchOne($qry);
+                $res = $connection->fetchOne($qry);
 
-                    $notifyStockQty = ($res === null || $res === false) ? null : (float) $res;
-                    try {
-                        $connection->insert(
+                $notifyStockQty = ($res === null || $res === false) ? null : (float) $res;
+                try {
+                    $connection->insert(
+                        $tableName,
+                        [
+                            'source_code' => $destinationSource,
+                            'sku' => $sku,
+                            'notify_stock_qty' => $notifyStockQty,
+                        ]
+                    );
+                } catch (DuplicateException $e) {
+                    // Do not overwrite an existing configuration if the item was not assigned to the source
+                    if ($res !== false) {
+                        $connection->update(
                             $tableName,
-                            [
-                                'source_code' => $destinationSource,
-                                'sku' => $sku,
-                                'notify_stock_qty' => $notifyStockQty,
-                            ]
+                            ['notify_stock_qty' => $notifyStockQty],
+                            $connection->quoteInto('sku = ?', $sku) . ' AND ' .
+                            $connection->quoteInto('source_code = ?', $destinationSource)
                         );
-                    } catch (DuplicateException $e) {
-                        // Do not overwrite an existing configuration if the item was not assigned to the source
-                        if ($res !== false) {
-                            $connection->update(
-                                $tableName,
-                                ['notify_stock_qty' => $notifyStockQty],
-                                $connection->quoteInto('sku = ?', $sku) . ' AND ' .
-                                $connection->quoteInto('source_code = ?', $destinationSource)
-                            );
-                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description
This PR fixing memory leak issue https://github.com/magento-engcom/msi/issues/1922

### Fixed Issues (if relevant)
Problem happening in Magento\InventoryLowQuantityNotification\Model\ResourceModel\BulkConfigurationTransfer

On a step when we are transferring stock notification between sources we have 2 foreaches in the code. And as I found out, that first of them is only used to get product SKUs types and then validate is it allowed to transfer stock for this type.

We could use only 1 foreach on this step and only validate of product type of each product is allowed to be transferred

### Manual testing scenarios
Can be found in https://github.com/magento-engcom/msi/issues/1922

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
