### PR TITLE
MSI-1948: Invalid type cast and status calculation based on quantity column during stock_sources import

### DIFF
--- a/app/code/Magento/InventoryImportExport/Model/Import/SourceItemConvert.php
+++ b/app/code/Magento/InventoryImportExport/Model/Import/SourceItemConvert.php
@@ -40,7 +40,7 @@ class SourceItemConvert
             $sourceItem->setSku($rowData[Sources::COL_SKU]);
             $sourceItem->setQuantity((float)$rowData[Sources::COL_QTY]);
 
-            $status = (int)$rowData[Sources::COL_QTY] > 0;
+            $status = (int)($rowData[Sources::COL_QTY] > 0);
             if (isset($rowData[Sources::COL_STATUS])) {
                 $status = (int)$rowData[Sources::COL_STATUS];
             }


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento-engcom/msi#1948: Invalid type cast and status calculation based on quantity column during stock_sources import
