### PR TITLE
MSI-1941: Unnecessary conversion of product to SKU and back to ID using GetProductIdsBySkus

### DIFF
--- a/app/code/Magento/InventoryCatalog/Model/GetProductIdsBySkus.php
+++ b/app/code/Magento/InventoryCatalog/Model/GetProductIdsBySkus.php
@@ -43,14 +43,16 @@ class GetProductIdsBySkus implements GetProductIdsBySkusInterface
         $cacheKey = hash('md5', implode(',', $skus));
 
         if (!isset($this->productIdsBySkus[$cacheKey])) {
-            $this->productIdsBySkus[$cacheKey] = $this->productResource->getProductsIdsBySkus($skus);
-            $notFoundedSkus = array_diff($skus, array_keys($this->productIdsBySkus[$cacheKey]));
+            $idsBySkus = $this->productResource->getProductsIdsBySkus($skus);
+            $notFoundedSkus = array_diff($skus, array_keys($idsBySkus));
 
             if (!empty($notFoundedSkus)) {
                 throw new NoSuchEntityException(
                     __('Following products with requested skus were not found: %1', implode($notFoundedSkus, ', '))
                 );
             }
+
+            $this->productIdsBySkus[$cacheKey] = $idsBySkus;
         }
 
         return $this->productIdsBySkus[$cacheKey];


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento-engcom/msi#1941: Unnecessary conversion of product to SKU and back to ID using GetProductIdsBySkus
