### PR TITLE
MSI-1939: Configurable product out of stock after mass transfer from default source

### DIFF
--- a/app/code/Magento/InventoryCatalog/Model/ResourceModel/BulkInventoryTransfer.php
+++ b/app/code/Magento/InventoryCatalog/Model/ResourceModel/BulkInventoryTransfer.php
@@ -201,15 +201,20 @@ class BulkInventoryTransfer
     ): void {
         $connection = $this->resourceConnection->getConnection();
         $types = $this->getProductTypesBySkus->execute($skus);
+        $processedSkus = [];
 
         $connection->beginTransaction();
         foreach ($types as $sku => $type) {
             if ($this->isSourceItemManagementAllowedForProductType->execute($type)) {
                 $this->transferInventory($sku, $originSource, $destinationSource);
+                $processedSkus[] = $sku;
             }
         }
 
-        $this->clearSource($skus, $originSource, $unassignFromOrigin);
+        if (!empty($processedSkus)) {
+            $this->clearSource($processedSkus, $originSource, $unassignFromOrigin);
+        }
+
         $connection->commit();
     }
 }


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento-engcom/msi#1939: Configurable product out of stock after mass transfer from default source