### PR TITLE
Fixed #1978 Negative as well as decimal values are been accepted while assigning quantity against a source in the product creation form

### DIFF
--- a/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/ui_component/product_form.xml
@@ -153,7 +153,7 @@
                         <validation>
                             <rule name="required-entry" xsi:type="boolean">true</rule>
                             <rule name="less-than-equals-to" xsi:type="number">99999999</rule>
-                            <rule name="validate-number" xsi:type="boolean">true</rule>
+                            <rule name="validate-digits" xsi:type="boolean">true</rule>
                         </validation>
                         <disabled>true</disabled>
                         <imports>


### PR DESCRIPTION
Fixed #1978 Negative, as well as decimal values, are been accepted while assigning quantity against a source in the product creation form

### Preconditions (*)

1.Magento version 2.3.0
2.php version 7.2

### Steps to reproduce (*)

1)Login to Admin Panel
2)On left navigation goto Stores-> Inventory->sources
3)Create two source
4)Now goto left navigation Stores-> Inventory->stocks
5)Create stock with Sales Channels: the Main website, and add source created above to the stock
6)Go to Catalog->products
7)Click the edit button of any products which is a type of simple product 
8)fill in the required fields of the form
9)go to the sources option 
10)click on assign source
11)select a source and in the qty column enter a negative value or a decimal value. For example enter -15 or 2.3
12)save the product form
### Expected result (*)

1. Negative quantity should not be accepted while creating a product.
2. An appropriate error msg should be returned as soon as a user enters a negative value or a decimal value in the Qty field.

### Actual result (*)

1. The error message was not received when the user entered a negative value or a decimal value against the qty field
2. The product got created/saved successfully.
![screenshot_2019-01-10_18-13-31](https://user-images.githubusercontent.com/25763126/51015868-d33ee100-1593-11e9-9daa-1a3c3b4ad960.png)
![screenshot_2019-01-10_18-14-24](https://user-images.githubusercontent.com/25763126/51015869-d33ee100-1593-11e9-8d1f-66b68f1ef64d.png)


