### PR TITLE
MSI-1980: Bulk Inventory Transfer from backend doesn't work with numerical skus

### DIFF
--- a/app/code/Magento/InventoryCatalog/Model/ResourceModel/BulkInventoryTransfer.php
+++ b/app/code/Magento/InventoryCatalog/Model/ResourceModel/BulkInventoryTransfer.php
@@ -205,7 +205,7 @@ class BulkInventoryTransfer
         $connection->beginTransaction();
         foreach ($types as $sku => $type) {
             if ($this->isSourceItemManagementAllowedForProductType->execute($type)) {
-                $this->transferInventory($sku, $originSource, $destinationSource);
+                $this->transferInventory((string)$sku, $originSource, $destinationSource);
             }
         }
 


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento-engcom/msi#1980: Bulk Inventory Transfer from backend doesn't work with numerical skus
