### PR TITLE
MSI-1965: Change active menu id for New Stock and Manage Stock actions

### DIFF
--- a/app/code/Magento/InventoryAdminUi/Controller/Adminhtml/Stock/Index.php
+++ b/app/code/Magento/InventoryAdminUi/Controller/Adminhtml/Stock/Index.php
@@ -30,7 +30,7 @@ class Index extends Action implements HttpGetActionInterface
     {
         /** @var Page $resultPage */
         $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
-        $resultPage->setActiveMenu('Magento_InventoryApi::stock')
+        $resultPage->setActiveMenu('Magento_InventoryAdminUi::stock')
             ->addBreadcrumb(__('Sources'), __('List'));
         $resultPage->getConfig()->getTitle()->prepend(__('Manage Stock'));
 

--- a/app/code/Magento/InventoryAdminUi/Controller/Adminhtml/Stock/NewAction.php
+++ b/app/code/Magento/InventoryAdminUi/Controller/Adminhtml/Stock/NewAction.php
@@ -31,7 +31,7 @@ class NewAction extends Action implements HttpGetActionInterface
     {
         /** @var Page $resultPage */
         $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
-        $resultPage->setActiveMenu('Magento_InventoryApi::stock');
+        $resultPage->setActiveMenu('Magento_InventoryAdminUi::stock');
         $resultPage->getConfig()->getTitle()->prepend(__('New Stock'));
 
         return $resultPage;


### PR DESCRIPTION
### Fixed Issues 
1. magento-engcom/msi#1965: 
Wrong argument for method setActiveMenu() in module-inventory-admin-ui/Controller/Adminhtml/* 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
