### PR TITLE
MSI-1938: Some headings are not indented on Source Selection page

### DIFF
--- a/app/code/Magento/Ui/view/base/web/templates/dynamic-rows/templates/default.html
+++ b/app/code/Magento/Ui/view/base/web/templates/dynamic-rows/templates/default.html
@@ -18,12 +18,11 @@
                     <span repeat="8"/>
                 </div>
             </div>
-
             <table class="admin__dynamic-rows admin__control-table" data-role="grid" attr="{'data-index': index}">
                 <thead if="element.columnsHeader">
                     <tr>
                         <th if="dndConfig.enabled" />
-                        <th repeat="foreach: labels, item: '$label'"
+                        <th class="data-grid-th" repeat="foreach: labels, item: '$label'"
                             css="setClasses($label())"
                             visible="$label().visible"
                             disable="$label().disabled">


### PR DESCRIPTION
### Description
Style changes for Source Selection grid

### Fixed Issues 
magento-engcom/msi#1938: Some headings are not indented on Source Selection page

### Manual testing scenarios
Described in Issue

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
