### PR TITLE
MSI-1995: Magento_InventorySalesApi is missing acl.xml

### DIFF
--- a/app/code/Magento/InventorySalesApi/etc/acl.xml
+++ b/app/code/Magento/InventorySalesApi/etc/acl.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_InventoryApi::inventory" title="Inventory" translate="title" sortOrder="10">
+                        <resource id="Magento_InventorySalesApi::stock" title="Sales Stock" translate="title" sortOrder="10" />
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/app/code/Magento/InventorySalesApi/etc/webapi.xml
+++ b/app/code/Magento/InventorySalesApi/etc/webapi.xml
@@ -10,25 +10,25 @@
     <route url="/V1/inventory/get-product-salable-quantity/:sku/:stockId" method="GET">
         <service class="Magento\InventorySalesApi\Api\GetProductSalableQtyInterface" method="execute"/>
         <resources>
-            <resource ref="InventorySalesApi::stock"/>
+            <resource ref="Magento_InventorySalesApi::stock"/>
         </resources>
     </route>
     <route url="/V1/inventory/is-product-salable/:sku/:stockId" method="GET">
         <service class="Magento\InventorySalesApi\Api\IsProductSalableInterface" method="execute"/>
         <resources>
-            <resource ref="InventorySalesApi::stock"/>
+            <resource ref="Magento_InventorySalesApi::stock"/>
         </resources>
     </route>
     <route url="/V1/inventory/is-product-salable-for-requested-qty/:sku/:stockId/:requestedQty" method="GET">
         <service class="Magento\InventorySalesApi\Api\IsProductSalableForRequestedQtyInterface" method="execute"/>
         <resources>
-            <resource ref="InventorySalesApi::stock"/>
+            <resource ref="Magento_InventorySalesApi::stock"/>
         </resources>
     </route>
     <route url="/V1/inventory/stock-resolver/:type/:code" method="GET">
         <service class="Magento\InventorySalesApi\Api\StockResolverInterface" method="execute"/>
         <resources>
-            <resource ref="InventorySalesApi::stock"/>
+            <resource ref="Magento_InventorySalesApi::stock"/>
         </resources>
     </route>
 </routes>


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento-engcom/msi#1995: Magento_InventorySalesApi is missing acl.xml

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
