### PR TITLE
MSI-2018: Rename "Shipping Methods" to "Delivery Methods" in adminhtml

### DIFF
--- a/app/code/Magento/Shipping/etc/acl.xml
+++ b/app/code/Magento/Shipping/etc/acl.xml
@@ -14,7 +14,7 @@
                         <resource id="Magento_Config::config">
                             <resource id="Magento_Shipping::config_shipping" title="Shipping Settings Section" translate="title" sortOrder="5" />
                             <resource id="Magento_Shipping::shipping_policy" title="Shipping Policy Parameters Section" translate="title" sortOrder="5" />
-                            <resource id="Magento_Shipping::carriers" title="Shipping Methods Section" translate="title" sortOrder="5" />
+                            <resource id="Magento_Shipping::carriers" title="Delivery Methods Section" translate="title" sortOrder="5" />
                         </resource>
                     </resource>
                 </resource>

--- a/app/code/Magento/Shipping/etc/adminhtml/system.xml
+++ b/app/code/Magento/Shipping/etc/adminhtml/system.xml
@@ -49,7 +49,7 @@
             </group>
         </section>
         <section id="carriers" translate="label" type="text" sortOrder="320" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Shipping Methods</label>
+            <label>Delivery Methods</label>
             <tab>sales</tab>
             <resource>Magento_Shipping::carriers</resource>
         </section>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Renames the "Shipping Methods" section of the admin to "Delivery Methods" now that MSI allows for store pickup.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#2028: Rename "Shipping Step" into "Delivery Method" on Magento Checkout

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to admin
2. Navigate to Store -> Configuration
3. Expand the 'Sales' section and note the renamed "Delivery Methods" section

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
