### PR TITLE
Renamed "Assigned sources" label to "Assigned Sources"

### DIFF
--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminAddRemoveStockColumnsTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminAddRemoveStockColumnsTest.xml
@@ -38,7 +38,7 @@
         <see selector="{{AdminGridHeaders.headerByName('ID')}}" userInput="ID" stepKey="seeTheHeaderId1"/>
         <see selector="{{AdminGridHeaders.headerByName('Name')}}" userInput="Name" stepKey="seeTheHeaderName1"/>
         <see selector="{{AdminGridHeaders.headerByName('Sales Channels')}}" userInput="Sales Channels" stepKey="seeTheHeaderSalesChannel1"/>
-        <see selector="{{AdminGridHeaders.headerByName('Assigned sources')}}" userInput="Assigned sources" stepKey="seeTheHeaderAssignedSources1"/>
+        <see selector="{{AdminGridHeaders.headerByName('Assigned Sources')}}" userInput="Assigned Sources" stepKey="seeTheHeaderAssignedSources1"/>
         <see selector="{{AdminGridHeaders.headerByName('Action')}}" userInput="Action" stepKey="seeTheHeaderAction1"/>
 
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen2"/>
@@ -50,20 +50,20 @@
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen5"/>
         <click selector="{{AdminGridColumnsControls.columnName('Sales Channels')}}" stepKey="disableSalesChannelColumn1"/>
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen6"/>
-        <click selector="{{AdminGridColumnsControls.columnName('Assigned sources')}}" stepKey="disableAssignedSourcesColumn1"/>
+        <click selector="{{AdminGridColumnsControls.columnName('Assigned Sources')}}" stepKey="disableAssignedSourcesColumn1"/>
 
         <see selector="{{AdminGridHeaders.headerByName('Action')}}" userInput="Action" stepKey="seeTheHeaderAction2"/>
         <dontSee selector="{{AdminGridHeaders.headerByName('ID')}}" userInput="ID" stepKey="dontSeeIdColumn1"/>
         <dontSee selector="{{AdminGridHeaders.headerByName('Name')}}" userInput="Name" stepKey="dontSeeNameColumn1"/>
         <dontSee selector="{{AdminGridHeaders.headerByName('Sales Channels')}}" userInput="Sales Channels" stepKey="dontSeeSalesChannelColumn1"/>
-        <dontSee selector="{{AdminGridHeaders.headerByName('Assigned sources')}}" userInput="Assigned sources" stepKey="dontSeeAssignedSourcesColumn1"/>
+        <dontSee selector="{{AdminGridHeaders.headerByName('Assigned Sources')}}" userInput="Assigned Sources" stepKey="dontSeeAssignedSourcesColumn1"/>
 
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen7"/>
         <click selector="{{AdminGridColumnsControls.reset}}" stepKey="clickOnResetColumnReaders2"/>
         <see selector="{{AdminGridHeaders.headerByName('ID')}}" userInput="ID" stepKey="seeTheHeaderId2"/>
         <see selector="{{AdminGridHeaders.headerByName('Name')}}" userInput="Name" stepKey="seeTheHeaderName2"/>
         <see selector="{{AdminGridHeaders.headerByName('Sales Channels')}}" userInput="Sales Channels" stepKey="seeTheHeaderSalesChannel2"/>
-        <see selector="{{AdminGridHeaders.headerByName('Assigned sources')}}" userInput="Assigned sources" stepKey="seeTheHeaderAssignedSources2"/>
+        <see selector="{{AdminGridHeaders.headerByName('Assigned Sources')}}" userInput="Assigned Sources" stepKey="seeTheHeaderAssignedSources2"/>
         <see selector="{{AdminGridHeaders.headerByName('Action')}}" userInput="Action" stepKey="seeTheHeaderAction3"/>
 
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen8"/>
@@ -73,14 +73,14 @@
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen10"/>
         <click selector="{{AdminGridColumnsControls.columnName('Action')}}" stepKey="disableActionColumn3"/>
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen11"/>
-        <click selector="{{AdminGridColumnsControls.columnName('Assigned sources')}}" stepKey="disableAssignedSourcesColumn3"/>
+        <click selector="{{AdminGridColumnsControls.columnName('Assigned Sources')}}" stepKey="disableAssignedSourcesColumn3"/>
         <conditionalClick selector="{{AdminGridColumnsControls.columns}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-action-columns-menu" visible="false" stepKey="clickOnColumnsIfNotOpen12"/>
         <click selector="{{AdminGridColumnsControls.cancel}}" stepKey="clickOnCancel1"/>
 
         <see selector="{{AdminGridHeaders.headerByName('ID')}}" userInput="ID" stepKey="seeTheHeaderId3"/>
         <see selector="{{AdminGridHeaders.headerByName('Name')}}" userInput="Name" stepKey="seeTheHeaderName3"/>
         <see selector="{{AdminGridHeaders.headerByName('Sales Channels')}}" userInput="Sales Channels" stepKey="seeTheHeaderSalesChannel3"/>
-        <see selector="{{AdminGridHeaders.headerByName('Assigned sources')}}" userInput="Assigned sources" stepKey="seeTheHeaderAssignedSources3"/>
+        <see selector="{{AdminGridHeaders.headerByName('Assigned Sources')}}" userInput="Assigned Sources" stepKey="seeTheHeaderAssignedSources3"/>
         <see selector="{{AdminGridHeaders.headerByName('Action')}}" userInput="Action" stepKey="seeTheHeaderAction4"/>
     </test>
 </tests>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminManageStockGridChangeColumnOrderByDragAndDropTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminManageStockGridChangeColumnOrderByDragAndDropTest.xml
@@ -46,7 +46,7 @@
         <grabMultiple selector="{{AdminGridHeaders.columnsNames}}" stepKey="grabColumnsDefaultOrder" />
         <assertEquals stepKey="assertDefaultOrder">
             <actualResult type="variable">grabColumnsDefaultOrder</actualResult>
-            <expectedResult type="array">["ID", "Name", "Sales Channels", "Assigned sources", "Action"]</expectedResult>
+            <expectedResult type="array">["ID", "Name", "Sales Channels", "Assigned Sources", "Action"]</expectedResult>
         </assertEquals>
 
         <dragAndDrop selector1="{{AdminGridHeaders.headerByName('ID')}}"
@@ -56,7 +56,7 @@
         <grabMultiple selector="{{AdminGridHeaders.columnsNames}}" stepKey="grabColumnsAfterIdColumnMoved" />
         <assertEquals stepKey="assertOrderAfterIdColumnMoved">
             <actualResult type="variable">grabColumnsAfterIdColumnMoved</actualResult>
-            <expectedResult type="array">["Name", "Sales Channels", "ID", "Assigned sources", "Action"]</expectedResult>
+            <expectedResult type="array">["Name", "Sales Channels", "ID", "Assigned Sources", "Action"]</expectedResult>
         </assertEquals>
 
         <dragAndDrop selector1="{{AdminGridHeaders.headerByName('Name')}}"
@@ -66,7 +66,7 @@
         <grabMultiple selector="{{AdminGridHeaders.columnsNames}}" stepKey="grabColumnsAfterNameColumnMoved" />
         <assertEquals stepKey="assertOrderAfterNameColumnMoved">
             <actualResult type="variable">grabColumnsAfterNameColumnMoved</actualResult>
-            <expectedResult type="array">["Sales Channels", "Name", "ID", "Assigned sources", "Action"]</expectedResult>
+            <expectedResult type="array">["Sales Channels", "Name", "ID", "Assigned Sources", "Action"]</expectedResult>
         </assertEquals>
     </test>
 </tests>

--- a/app/code/Magento/InventoryAdminUi/i18n/en_US.csv
+++ b/app/code/Magento/InventoryAdminUi/i18n/en_US.csv
@@ -24,7 +24,7 @@ List,List
 "The Stock has been saved.","The Stock has been saved."
 "The Stock does not exist.","The Stock does not exist."
 "Could not save Stock.","Could not save Stock."
-"Assigned sources:","Assigned sources:"
+"Assigned Sources:","Assigned Sources:"
 "Are you sure you want to delete this stock?","Are you sure you want to delete this stock?"
 Inventory,Inventory
 Stocks,Stocks
@@ -63,4 +63,4 @@ Done,Done
 "Delete items","Delete items"
 Delete,Delete
 ID,ID
-"Assigned sources","Assigned sources"
+"Assigned Sources","Assigned Sources"

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_stock_listing.xml
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/ui_component/inventory_stock_listing.xml
@@ -123,7 +123,7 @@
                 component="Magento_InventoryAdminUi/js/stock/grid/cell/assigned-sources"
                 sortOrder="40">
             <settings>
-                <label translate="true">Assigned sources</label>
+                <label translate="true">Assigned Sources</label>
                 <sortable>false</sortable>
             </settings>
         </column>

--- a/app/code/Magento/InventoryAdminUi/view/adminhtml/web/template/stock/grid/cell/assigned-sources-cell.html
+++ b/app/code/Magento/InventoryAdminUi/view/adminhtml/web/template/stock/grid/cell/assigned-sources-cell.html
@@ -22,7 +22,7 @@
     track: false,
     strict: true">
     <div>
-        <div class="data-tooltip-title" data-bind="i18n: 'Assigned sources:'"></div>
+        <div class="data-tooltip-title" data-bind="i18n: 'Assigned Sources:'"></div>
         <div class="data-tooltip-content">
             <!-- ko foreach: { data: $col.getTooltipData($row()), as: '$assignedSource' } -->
             <div><span data-bind="text: $assignedSource.name"></span>: <span data-bind="text: $assignedSource.sourceCode"></span></div>


### PR DESCRIPTION
### Description (*)
The pull request provides a fix for the Assigned Sources column label for the Manage Stock grid and other places where Assigned Sources is used.

### Manual testing scenarios (*)
1. Navigate to Stores -> Inventory -> Stocks page
2. Observe the Assigned Sources column label

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
