### PR TITLE
#2063 Fix for adding decimal orderitems

### DIFF
--- a/app/code/Magento/InventorySales/Model/IsProductSalableForRequestedQtyCondition/IsSalableWithReservationsCondition.php
+++ b/app/code/Magento/InventorySales/Model/IsProductSalableForRequestedQtyCondition/IsSalableWithReservationsCondition.php
@@ -90,7 +90,7 @@ class IsSalableWithReservationsCondition implements IsProductSalableForRequested
         $qtyWithReservation = $stockItemData[GetStockItemDataInterface::QUANTITY] +
             $this->getReservationsQuantity->execute($sku, $stockId);
         $qtyLeftInStock = $qtyWithReservation - $stockItemConfiguration->getMinQty();
-        $isInStock = abs($qtyLeftInStock - $requestedQty) < 0.1;
+        $isInStock = bccomp((string)$qtyLeftInStock, (string)$requestedQty, 4) === 1;
         $isEnoughQty = (bool)$stockItemData[GetStockItemDataInterface::IS_SALABLE] && $isInStock;
         if (!$isEnoughQty) {
             $errors = [

--- a/app/code/Magento/InventorySales/Model/IsProductSalableForRequestedQtyCondition/IsSalableWithReservationsCondition.php
+++ b/app/code/Magento/InventorySales/Model/IsProductSalableForRequestedQtyCondition/IsSalableWithReservationsCondition.php
@@ -89,8 +89,9 @@ class IsSalableWithReservationsCondition implements IsProductSalableForRequested
 
         $qtyWithReservation = $stockItemData[GetStockItemDataInterface::QUANTITY] +
             $this->getReservationsQuantity->execute($sku, $stockId);
-        $qtyLeftInStock = $qtyWithReservation - $stockItemConfiguration->getMinQty() - $requestedQty;
-        $isEnoughQty = (bool)$stockItemData[GetStockItemDataInterface::IS_SALABLE] && $qtyLeftInStock >= 0;
+        $qtyLeftInStock = $qtyWithReservation - $stockItemConfiguration->getMinQty();
+        $isInStock = abs($qtyLeftInStock - $requestedQty) < 0.1;
+        $isEnoughQty = (bool)$stockItemData[GetStockItemDataInterface::IS_SALABLE] && $isInStock;
         if (!$isEnoughQty) {
             $errors = [
                 $this->productSalabilityErrorFactory->create([

--- a/app/code/Magento/InventorySales/Model/IsProductSalableForRequestedQtyCondition/IsSalableWithReservationsCondition.php
+++ b/app/code/Magento/InventorySales/Model/IsProductSalableForRequestedQtyCondition/IsSalableWithReservationsCondition.php
@@ -90,8 +90,9 @@ class IsSalableWithReservationsCondition implements IsProductSalableForRequested
         $qtyWithReservation = $stockItemData[GetStockItemDataInterface::QUANTITY] +
             $this->getReservationsQuantity->execute($sku, $stockId);
         $qtyLeftInStock = $qtyWithReservation - $stockItemConfiguration->getMinQty();
-        $isInStock = bccomp((string)$qtyLeftInStock, (string)$requestedQty, 4) === 1;
+        $isInStock = bccomp((string)$qtyLeftInStock, (string)$requestedQty, 4) >= 0;
         $isEnoughQty = (bool)$stockItemData[GetStockItemDataInterface::IS_SALABLE] && $isInStock;
+
         if (!$isEnoughQty) {
             $errors = [
                 $this->productSalabilityErrorFactory->create([

--- a/app/code/Magento/InventorySales/Test/Integration/IsProductSalableForRequestedQty/IsSalableWithReservationsConditionTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/IsProductSalableForRequestedQty/IsSalableWithReservationsConditionTest.php
@@ -230,4 +230,44 @@ class IsSalableWithReservationsConditionTest extends TestCase
         ]);
         $this->cleanupReservations->execute();
     }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
+     *
+     * @magentoDbIsolation disabled
+     */
+    public function testProductIsSalableWithMinQtyAndReservationArePresent()
+    {
+        $sku = 'SKU-1';
+        $stockId = 10;
+
+        $stockItemConfiguration = $this->getStockItemConfiguration->execute($sku, $stockId);
+        $stockItemConfiguration->setUseConfigMinQty(false);
+        $stockItemConfiguration->setIsQtyDecimal(true);
+        $stockItemConfiguration->setMaxSaleQty(0.001);
+        $stockItemConfiguration->setMinQty(-1.0);
+        $stockItemConfiguration->setUseConfigBackorders(false);
+        $stockItemConfiguration->setBackorders(StockItemConfigurationInterface::BACKORDERS_YES_NONOTIFY);
+        $this->saveStockItemConfiguration->execute($sku, $stockId, $stockItemConfiguration);
+
+        $this->appendReservations->execute([
+            $this->reservationBuilder->setStockId($stockId)->setSku($sku )->setQuantity(-8.33)->build(),
+        ]);
+
+        self::assertEquals(
+            true,
+            $this->isProductSalableForRequestedQty->execute($sku, $stockId, 1.17)->isSalable()
+        );
+
+        $this->appendReservations->execute([
+            $this->reservationBuilder->setStockId(10)->setSku('SKU-1')->setQuantity(8.33)->build(),
+        ]);
+
+        $this->cleanupReservations->execute();
+    }
 }

--- a/app/code/Magento/InventorySales/Test/Integration/IsProductSalableForRequestedQty/IsSalableWithReservationsConditionTest.php
+++ b/app/code/Magento/InventorySales/Test/Integration/IsProductSalableForRequestedQty/IsSalableWithReservationsConditionTest.php
@@ -248,24 +248,25 @@ class IsSalableWithReservationsConditionTest extends TestCase
 
         $stockItemConfiguration = $this->getStockItemConfiguration->execute($sku, $stockId);
         $stockItemConfiguration->setUseConfigMinQty(false);
+        $stockItemConfiguration->setUseConfigMinSaleQty(false);
         $stockItemConfiguration->setIsQtyDecimal(true);
-        $stockItemConfiguration->setMaxSaleQty(0.001);
+        $stockItemConfiguration->setMinSaleQty(-1.0);
         $stockItemConfiguration->setMinQty(-1.0);
         $stockItemConfiguration->setUseConfigBackorders(false);
         $stockItemConfiguration->setBackorders(StockItemConfigurationInterface::BACKORDERS_YES_NONOTIFY);
         $this->saveStockItemConfiguration->execute($sku, $stockId, $stockItemConfiguration);
 
         $this->appendReservations->execute([
-            $this->reservationBuilder->setStockId($stockId)->setSku($sku )->setQuantity(-8.33)->build(),
+            $this->reservationBuilder->setStockId($stockId)->setSku($sku )->setQuantity(-9.33)->build(),
         ]);
 
         self::assertEquals(
             true,
-            $this->isProductSalableForRequestedQty->execute($sku, $stockId, 1.17)->isSalable()
+            $this->isProductSalableForRequestedQty->execute($sku, $stockId, 0.17)->isSalable()
         );
 
         $this->appendReservations->execute([
-            $this->reservationBuilder->setStockId(10)->setSku('SKU-1')->setQuantity(8.33)->build(),
+            $this->reservationBuilder->setStockId(10)->setSku('SKU-1')->setQuantity(9.33)->build(),
         ]);
 
         $this->cleanupReservations->execute();


### PR DESCRIPTION
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
-->

### Preconditions
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Create simple product with Qty = 2, set  'backorders' and 'use decimal'  - on, set ' Out-of-Stock Threshold' = -1; 

### Steps to reproduce
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Place 9 orders with such ordered Qtys: 0.59, 0.37, 0.24, 0.1, 0.2, 0.41, 0.1, 0.82, 0.17


### Expected result
<!--- Tell us what do you expect to happen. -->
1. Orders placed correctly

### More Info
https://andy-carter.com/blog/don-t-trust-php-floating-point-numbers-when-equating
