### PR TITLE
Fix a performance bottleneck bug related to full page cache, when save multiple products.

### DIFF
--- a/app/code/Magento/InventoryCache/Model/FlushCacheByProductIds.php
+++ b/app/code/Magento/InventoryCache/Model/FlushCacheByProductIds.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace Magento\InventoryCache\Model;
 
 use Magento\Framework\EntityManager\EventManager;
-use Magento\Framework\Indexer\CacheContext;
+use Magento\Framework\Indexer\CacheContextFactory;
 
 /**
  * Clean cache for given product ids.
@@ -16,9 +16,9 @@ use Magento\Framework\Indexer\CacheContext;
 class FlushCacheByProductIds
 {
     /**
-     * @var CacheContext
+     * @var CacheContextFactory
      */
-    private $cacheContext;
+    private $cacheContextFactory;
 
     /**
      * @var EventManager
@@ -31,16 +31,16 @@ class FlushCacheByProductIds
     private $productCacheTag;
 
     /**
-     * @param CacheContext $cacheContext
+     * @param CacheContextFactory $cacheContextFactory
      * @param EventManager $eventManager
      * @param string $productCacheTag
      */
     public function __construct(
-        CacheContext $cacheContext,
+        CacheContextFactory $cacheContextFactory,
         EventManager $eventManager,
         string $productCacheTag
     ) {
-        $this->cacheContext = $cacheContext;
+        $this->cacheContextFactory = $cacheContextFactory;
         $this->eventManager = $eventManager;
         $this->productCacheTag = $productCacheTag;
     }
@@ -54,8 +54,9 @@ class FlushCacheByProductIds
     public function execute(array $productIds)
     {
         if ($productIds) {
-            $this->cacheContext->registerEntities($this->productCacheTag, $productIds);
-            $this->eventManager->dispatch('clean_cache_by_tags', ['object' => $this->cacheContext]);
+            $cacheContext = $this->cacheContextFactory->create();
+            $cacheContext->registerEntities($this->productCacheTag, $productIds);
+            $this->eventManager->dispatch('clean_cache_by_tags', ['object' => $cacheContext]);
         }
     }
 }


### PR DESCRIPTION
### Description
There is a bug in msi SourceItemIndexer and CacheFlush Plugin. When indexer mode is "update by schedule" after every product change event , the inventory cache module triggers FPC cleanup by related product cache tags.

`\Magento\InventoryCache\Plugin\InventoryIndexer\Indexer\Source\SourceItemIndexer\CacheFlush`

the cache flush uses:
`\Magento\InventoryCache\Model\FlushCacheByProductIds::execute` 
Injected cacheContext is a singleton and stateful and the plugin is also a singleton (stateful classes). cacheContext->registerEntities() will reuse product ids from previous runs.

When saving multiple products .. it causes a Linear bottleneck in performance. (every new product save time is increased with all tags invalidation time)

happens in
`\Magento\PageCache\Model\Cache\Type::clean`

this patch simply makes a new instance of current cached items from the related product ids. (there is absolutely no reason to store ids between runs)

### Manual testing scenarios
1. set magento indexer to update by schedule, enable full page cache
2. admin area at catalog product list select a bunch of products (at least 200-500 for a good test)
3. choose bulk operation update attributes, and change something that is related to inventory. like qty or backorders etc.
4. save and wait a lot. 
5. with this patch the same progress will be fast.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
