### PR TITLE
Passed correct websiteCode to check stock quantity when order is created using backoffice

### DIFF
--- a/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
@@ -123,7 +123,8 @@ class CheckQuoteItemQtyPlugin
         $skus = $this->getSkusByProductIds->execute([$productId]);
         $productSku = $skus[$productId];
 
-        $websiteCode = $this->storeManager->getWebsite()->getCode();
+        $websiteId = $this->resolveWebsiteId($scopeId);
+        $websiteCode = $this->storeManager->getWebsite($websiteId)->getCode();
         $stock = $this->stockResolver->execute(SalesChannelInterface::TYPE_WEBSITE, $websiteCode);
         $stockId = $stock->getStockId();
 
@@ -162,5 +163,26 @@ class CheckQuoteItemQtyPlugin
         }
 
         return $qty;
+    }
+
+    /**
+     * Returns websiteId assigned to store when scopeId is passed
+     * Returns default websiteId if no scopeId is passed
+     * @param int $scopeId
+     * @return string
+     */
+    private function resolveWebsiteId($scopeId = null) {
+        if($scopeId == null) {
+            return $this->storeManager->getWebsite()->getId();
+        }
+
+        try {
+            return $this->storeManager
+                ->getStore($scopeId)
+                ->getWebsiteId();
+        }
+        catch(NoSuchEntityException $exception) {
+            return $this->storeManager->getWebsite()->getId();
+        }
     }
 }

--- a/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
@@ -123,7 +123,7 @@ class CheckQuoteItemQtyPlugin
         $skus = $this->getSkusByProductIds->execute([$productId]);
         $productSku = $skus[$productId];
 
-        $websiteCode = $this->resolveWebsiteCode($scopeId);
+        $websiteCode = $this->storeManager->getWebsite($scopeId)->getCode();
         $stock = $this->stockResolver->execute(SalesChannelInterface::TYPE_WEBSITE, $websiteCode);
         $stockId = $stock->getStockId();
 
@@ -162,26 +162,5 @@ class CheckQuoteItemQtyPlugin
         }
 
         return $qty;
-    }
-
-    /**
-     * Returns websiteCode for website assigned to store when scopeId is passed
-     * Returns websiteCode from default website if no scopeId is passed
-     * @param int $scopeId
-     * @return string
-     */
-    private function resolveWebsiteCode($scopeId = null) {
-        if($scopeId === null) {
-            return $this->storeManager->getWebsite()->getCode();
-        }
-
-        try {
-            $websiteId = $this->storeManager->getStore($scopeId)->getWebsiteId();
-
-            return $this->storeManager->getWebsite($websiteId)->getCode();
-        }
-        catch(NoSuchEntityException $exception) {
-            return $this->storeManager->getWebsite()->getCode();
-        }
     }
 }

--- a/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
+++ b/app/code/Magento/InventorySales/Plugin/StockState/CheckQuoteItemQtyPlugin.php
@@ -123,8 +123,7 @@ class CheckQuoteItemQtyPlugin
         $skus = $this->getSkusByProductIds->execute([$productId]);
         $productSku = $skus[$productId];
 
-        $websiteId = $this->resolveWebsiteId($scopeId);
-        $websiteCode = $this->storeManager->getWebsite($websiteId)->getCode();
+        $websiteCode = $this->resolveWebsiteCode($scopeId);
         $stock = $this->stockResolver->execute(SalesChannelInterface::TYPE_WEBSITE, $websiteCode);
         $stockId = $stock->getStockId();
 
@@ -166,23 +165,23 @@ class CheckQuoteItemQtyPlugin
     }
 
     /**
-     * Returns websiteId assigned to store when scopeId is passed
-     * Returns default websiteId if no scopeId is passed
+     * Returns websiteCode for website assigned to store when scopeId is passed
+     * Returns websiteCode from default website if no scopeId is passed
      * @param int $scopeId
      * @return string
      */
-    private function resolveWebsiteId($scopeId = null) {
-        if($scopeId == null) {
-            return $this->storeManager->getWebsite()->getId();
+    private function resolveWebsiteCode($scopeId = null) {
+        if($scopeId === null) {
+            return $this->storeManager->getWebsite()->getCode();
         }
 
         try {
-            return $this->storeManager
-                ->getStore($scopeId)
-                ->getWebsiteId();
+            $websiteId = $this->storeManager->getStore($scopeId)->getWebsiteId();
+
+            return $this->storeManager->getWebsite($websiteId)->getCode();
         }
         catch(NoSuchEntityException $exception) {
-            return $this->storeManager->getWebsite()->getId();
+            return $this->storeManager->getWebsite()->getCode();
         }
     }
 }


### PR DESCRIPTION
Passed correct websiteCode to check stock quantity when order is created using backoffice

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Default websiteCode was always passed when order was created in backoffice instead of websiteCode based on store view chosen by admin. This MR fixes that behaviour and passes correct websiteCode passed by admin.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#2108: MSI - Stock used from wrong source (multi store issue)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Setup a multistore setup with 4 websites
2. Setup 1 extra source
3. Setup 1 extra stock
4. Assign 2 websites to the default stock
5. Assign 2 websites to the extra stock
6. Assign a product to all websites and both sources and give 0 qty to default stock and 100 to the source.
7. Create an order through the admin for a website linked to the extra source /stock. Add a product with a qty higher then the default stock so higher then 0. Products will be assigned correctly to extra stock.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
