### PR TITLE
Disable fields in Mass action -> Update attributes -> Advanced invent…

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Inventory.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Inventory.php
@@ -28,22 +28,37 @@ class Inventory extends \Magento\Backend\Block\Widget implements \Magento\Backen
      * @since 101.0.0
      */
     protected $disabledFields = [];
+    /**
+     * @var \Magento\InventoryCatalogApi\Model\IsSingleSourceModeInterface
+     */
+    private $singleSourceMode;
 
     /**
-     * @param \Magento\Backend\Block\Template\Context $context
-     * @param \Magento\CatalogInventory\Model\Source\Backorders $backorders
-     * @param \Magento\CatalogInventory\Api\StockConfigurationInterface $stockConfiguration
-     * @param array $data
+     * @param \Magento\Backend\Block\Template\Context                        $context
+     * @param \Magento\CatalogInventory\Model\Source\Backorders              $backorders
+     * @param \Magento\CatalogInventory\Api\StockConfigurationInterface      $stockConfiguration
+     * @param \Magento\InventoryCatalogApi\Model\IsSingleSourceModeInterface $singleSourceMode
+     * @param array                                                          $data
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\CatalogInventory\Model\Source\Backorders $backorders,
         \Magento\CatalogInventory\Api\StockConfigurationInterface $stockConfiguration,
+        \Magento\InventoryCatalogApi\Model\IsSingleSourceModeInterface $singleSourceMode,
         array $data = []
     ) {
         $this->_backorders = $backorders;
         $this->stockConfiguration = $stockConfiguration;
+        $this->singleSourceMode = $singleSourceMode;
         parent::__construct($context, $data);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSingleSourceMode(): bool
+    {
+        return $this->singleSourceMode->execute();
     }
 
     /**

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml
@@ -36,6 +36,7 @@ if (!is_numeric($defaultMinSaleQty)) {
     $defaultMinSaleQty = json_decode($defaultMinSaleQty, true);
     $defaultMinSaleQty = (float) $defaultMinSaleQty[\Magento\Customer\Api\Data\GroupInterface::CUST_GROUP_ALL] ?? 1;
 }
+$isSingleSourceMode = $block->isSingleSourceMode();
 ?>
 <div class="fieldset-wrapper form-inline advanced-inventory-edit">
     <div class="fieldset-wrapper-title">
@@ -77,27 +78,29 @@ if (!is_numeric($defaultMinSaleQty)) {
             <div class="field-service" value-scope="<?= /* @escapeNotVerified */ __('[GLOBAL]') ?>"></div>
         </div>
 
-        <div class="field required">
-            <label class="label" for="inventory_qty">
-                <span><?= /* @escapeNotVerified */ __('Qty') ?></span>
-            </label>
+        <?php if($isSingleSourceMode): ?>
+            <div class="field required">
+                <label class="label" for="inventory_qty">
+                    <span><?= /* @escapeNotVerified */ __('Qty') ?></span>
+                </label>
 
-            <div class="control">
-                <div class="fields-group-2">
-                    <div class="field">
-                        <input type="text" class="input-text required-entry validate-number" id="inventory_qty"
-                               name="<?= /* @escapeNotVerified */ $block->getFieldSuffix() ?>[qty]"
-                               value="<?= /* @escapeNotVerified */ $block->getDefaultConfigValue('qty') * 1 ?>" disabled="disabled"/>
-                    </div>
-                    <div class="field choice">
-                        <input type="checkbox" id="inventory_qty_checkbox" data-role="toggle-editability-all"/>
-                        <label for="inventory_qty_checkbox"
-                               class="label"><span><?= /* @escapeNotVerified */ __('Change') ?></span></label>
+                <div class="control">
+                    <div class="fields-group-2">
+                        <div class="field">
+                            <input type="text" class="input-text required-entry validate-number" id="inventory_qty"
+                                   name="<?= /* @escapeNotVerified */ $block->getFieldSuffix() ?>[qty]"
+                                   value="<?= /* @escapeNotVerified */ $block->getDefaultConfigValue('qty') * 1 ?>" disabled="disabled"/>
+                        </div>
+                        <div class="field choice">
+                            <input type="checkbox" id="inventory_qty_checkbox" data-role="toggle-editability-all"/>
+                            <label for="inventory_qty_checkbox"
+                                   class="label"><span><?= /* @escapeNotVerified */ __('Change') ?></span></label>
+                        </div>
                     </div>
                 </div>
+                <div class="field-service" value-scope="<?= /* @escapeNotVerified */ __('[GLOBAL]') ?>"></div>
             </div>
-            <div class="field-service" value-scope="<?= /* @escapeNotVerified */ __('[GLOBAL]') ?>"></div>
-        </div>
+        <?php endif; ?>
 
         <div class="field with-addon">
             <label class="label" for="inventory_min_qty">
@@ -246,34 +249,36 @@ if (!is_numeric($defaultMinSaleQty)) {
             <div class="field-service" value-scope="<?= /* @escapeNotVerified */ __('[GLOBAL]') ?>"></div>
         </div>
 
-        <div class="field">
-            <label class="label" for="inventory_notify_stock_qty">
-                <span><?= /* @escapeNotVerified */ __('Notify for Quantity Below') ?></span>
-            </label>
+        <?php if($isSingleSourceMode): ?>
+            <div class="field">
+                <label class="label" for="inventory_notify_stock_qty">
+                    <span><?= /* @escapeNotVerified */ __('Notify for Quantity Below') ?></span>
+                </label>
 
-            <div class="control">
-                <div class="fields-group-2">
-                    <div class="field">
-                        <input type="text" class="input-text validate-number" id="inventory_notify_stock_qty"
-                               name="<?= /* @escapeNotVerified */ $block->getFieldSuffix() ?>[notify_stock_qty]"
-                               value="<?= /* @escapeNotVerified */ $block->getDefaultConfigValue('notify_stock_qty') * 1 ?>"
-                               disabled="disabled"/>
-                    </div>
-                    <div class="field choice">
-                        <input type="checkbox" id="inventory_use_config_notify_stock_qty"
-                               name="<?= /* @escapeNotVerified */ $block->getFieldSuffix() ?>[use_config_notify_stock_qty]" value="1" data-role="toggle-editability" checked="checked" disabled="disabled"/>
-                        <label for="inventory_use_config_notify_stock_qty"
-                               class="label"><span><?= /* @escapeNotVerified */ __('Use Config Settings') ?></span></label>
-                    </div>
-                    <div class="field choice">
-                        <input type="checkbox" id="inventory_notify_stock_qty_checkbox" data-role="toggle-editability-all"/>
-                        <label for="inventory_notify_stock_qty_checkbox"
-                               class="label"><span><?= /* @escapeNotVerified */ __('Change') ?></span></label>
+                <div class="control">
+                    <div class="fields-group-2">
+                        <div class="field">
+                            <input type="text" class="input-text validate-number" id="inventory_notify_stock_qty"
+                                   name="<?= /* @escapeNotVerified */ $block->getFieldSuffix() ?>[notify_stock_qty]"
+                                   value="<?= /* @escapeNotVerified */ $block->getDefaultConfigValue('notify_stock_qty') * 1 ?>"
+                                   disabled="disabled"/>
+                        </div>
+                        <div class="field choice">
+                            <input type="checkbox" id="inventory_use_config_notify_stock_qty"
+                                   name="<?= /* @escapeNotVerified */ $block->getFieldSuffix() ?>[use_config_notify_stock_qty]" value="1" data-role="toggle-editability" checked="checked" disabled="disabled"/>
+                            <label for="inventory_use_config_notify_stock_qty"
+                                   class="label"><span><?= /* @escapeNotVerified */ __('Use Config Settings') ?></span></label>
+                        </div>
+                        <div class="field choice">
+                            <input type="checkbox" id="inventory_notify_stock_qty_checkbox" data-role="toggle-editability-all"/>
+                            <label for="inventory_notify_stock_qty_checkbox"
+                                   class="label"><span><?= /* @escapeNotVerified */ __('Change') ?></span></label>
+                        </div>
                     </div>
                 </div>
+                <div class="field-service" value-scope="<?= /* @escapeNotVerified */ __('[GLOBAL]') ?>"></div>
             </div>
-            <div class="field-service" value-scope="<?= /* @escapeNotVerified */ __('[GLOBAL]') ?>"></div>
-        </div>
+        <?php endif; ?>
 
         <div class="field">
             <label class="label" for="inventory_enable_qty_increments">
@@ -336,31 +341,33 @@ if (!is_numeric($defaultMinSaleQty)) {
             <div class="field-service" value-scope="<?= /* @escapeNotVerified */ __('[GLOBAL]') ?>"></div>
         </div>
 
-        <div class="field">
-            <label class="label" for="inventory_stock_availability">
-                <span><?= /* @escapeNotVerified */ __('Stock Availability') ?></span>
-            </label>
+        <?php if($isSingleSourceMode): ?>
+            <div class="field">
+                <label class="label" for="inventory_stock_availability">
+                    <span><?= /* @escapeNotVerified */ __('Stock Availability') ?></span>
+                </label>
 
-            <div class="control">
-                <div class="fields-group-2">
-                    <div class="field">
-                        <select id="inventory_stock_availability"
-                                name="<?= /* @escapeNotVerified */ $block->getFieldSuffix() ?>[is_in_stock]" class="select"
-                                disabled="disabled">
-                            <option value="1"><?= /* @escapeNotVerified */ __('In Stock') ?></option>
-                            <option
-                                value="0"<?php if ($block->getDefaultConfigValue('is_in_stock') == 0): ?> selected<?php endif; ?>><?= /* @escapeNotVerified */ __('Out of Stock') ?></option>
-                        </select>
-                    </div>
-                    <div class="field choice">
-                        <input type="checkbox" id="inventory_stock_availability_checkbox" data-role="toggle-editability-all"/>
-                        <label for="inventory_stock_availability_checkbox"
-                               class="label"><span><?= /* @escapeNotVerified */ __('Change') ?></span></label>
+                <div class="control">
+                    <div class="fields-group-2">
+                        <div class="field">
+                            <select id="inventory_stock_availability"
+                                    name="<?= /* @escapeNotVerified */ $block->getFieldSuffix() ?>[is_in_stock]" class="select"
+                                    disabled="disabled">
+                                <option value="1"><?= /* @escapeNotVerified */ __('In Stock') ?></option>
+                                <option
+                                    value="0"<?php if ($block->getDefaultConfigValue('is_in_stock') == 0): ?> selected<?php endif; ?>><?= /* @escapeNotVerified */ __('Out of Stock') ?></option>
+                            </select>
+                        </div>
+                        <div class="field choice">
+                            <input type="checkbox" id="inventory_stock_availability_checkbox" data-role="toggle-editability-all"/>
+                            <label for="inventory_stock_availability_checkbox"
+                                   class="label"><span><?= /* @escapeNotVerified */ __('Change') ?></span></label>
+                        </div>
                     </div>
                 </div>
+                <div class="field-service" value-scope="<?= /* @escapeNotVerified */ __('[GLOBAL]') ?>"></div>
             </div>
-            <div class="field-service" value-scope="<?= /* @escapeNotVerified */ __('[GLOBAL]') ?>"></div>
-        </div>
+        <?php endif; ?>
         </fieldset>
     </div>
 </div>


### PR DESCRIPTION
Refer to issue: #2138

### Description

When multi sources enabled, on Products grid in Mass action -> Update attributes -> Advanced inventory fields like qty, stock availability etc. need to be hide

### Fixed Issues

magento-engcom/msi#2138: Disable fields in Mass action -> Update attributes -> Advanced inventory