### PR TITLE
[UI Love for Assigned Sources] Source code #2134 

### DIFF
--- a/app/code/Magento/InventoryCatalogAdminUi/i18n/en_US.csv
+++ b/app/code/Magento/InventoryCatalogAdminUi/i18n/en_US.csv
@@ -48,3 +48,4 @@ Done,Done
 "Are you sure you want to unassign one or more sources from the selected items?","Are you sure you want to unassign one or more sources from the selected items?"
 "Transfer Inventory To Source","Transfer Inventory To Source"
 "Are you sure you want to transfer the inventory of the selected items?","Are you sure you want to transfer the inventory of the selected items?"
+"Source code: ", "Source code: "

--- a/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/ui_component/product_form.xml
@@ -98,17 +98,8 @@
                         <item name="dataScope" xsi:type="string"/>
                     </item>
                 </argument>
-                <field name="source_code" formElement="input" sortOrder="10">
+                <field name="name" formElement="input" sortOrder="20" template="Magento_InventoryCatalogAdminUi/dynamic-rows/cells/text">
                     <settings>
-                        <elementTmpl>ui/dynamic-rows/cells/text</elementTmpl>
-                        <dataType>text</dataType>
-                        <dataScope>source_code</dataScope>
-                        <label translate="true">Source Code</label>
-                    </settings>
-                </field>
-                <field name="name" formElement="input" sortOrder="20">
-                    <settings>
-                        <elementTmpl>ui/dynamic-rows/cells/text</elementTmpl>
                         <dataType>text</dataType>
                         <dataScope>name</dataScope>
                         <label translate="true">Name</label>

--- a/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/web/template/dynamic-rows/cells/text.html
+++ b/app/code/Magento/InventoryCatalogAdminUi/view/adminhtml/web/template/dynamic-rows/cells/text.html
@@ -1,0 +1,13 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<div class="control-table-text">
+    <span attr="'data-index': index, 'title': $t('Source code: ')+$record().data().source_code" data-bind="
+        text: value,
+        css: {_disabled: disabled}
+    ">
+    </span>
+</div>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
fix: remove Source Code column and add tooltip to the Name Column

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Removed the Source Code column and added tooltip with source code to the Name column.
This is the new output after making the requested changes:
![image](https://user-images.githubusercontent.com/39999239/55669762-83fb0a80-587b-11e9-9859-86b31112c694.png)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#2134: [UI Love for Assigned Sources] Source code

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add or edit a Product in the Magento Backend
2. In the Sources section, click "Assign Sources" to add one or more sources to the product
3. The changes will be displayed in "Assigned Sourced" table

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

