### PR TITLE
[UI Love for Assigned Sources] Notify Quantity #2132

### DIFF
--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/i18n/en_US.csv
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/i18n/en_US.csv
@@ -9,3 +9,5 @@ Quantity,Quantity
 "Source Code","Source Code"
 "Notify Quantity","Notify Quantity"
 "Notify Quantity Use Default","Notify Quantity Use Default"
+"Notify Qty","Notify Qty"
+"Use Default","Use Default"

--- a/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/InventoryLowQuantityNotificationAdminUi/view/adminhtml/ui_component/product_form.xml
@@ -6,7 +6,7 @@
  */
 -->
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
-    <fieldset name="sources">
+    <container name="sources">
         <dynamicRows name="assigned_sources" component="Magento_Ui/js/dynamic-rows/dynamic-rows-grid">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
@@ -18,47 +18,57 @@
                 </item>
             </argument>
             <container name="record" component="Magento_Ui/js/dynamic-rows/record">
-                <field name="notify_stock_qty" formElement="input" sortOrder="60" component="Magento_InventoryLowQuantityNotificationAdminUi/js/components/notify-stock-qty">
-                    <settings>
-                        <dataType>text</dataType>
-                        <dataScope>notify_stock_qty</dataScope>
-                        <label translate="true">Notify Quantity</label>
-                        <imports>
-                            <link name="notifyStockQtyUseDefault">${$.parentName}.notify_stock_qty_use_default:checked</link>
-                            <link name="manageStock">!${ $.provider }:data.product.stock_data.manage_stock</link>
-                        </imports>
-                    </settings>
-                </field>
-                <field name="notify_stock_qty_use_default" component="Magento_InventoryLowQuantityNotificationAdminUi/js/components/use-config-settings" formElement="checkbox" sortOrder="70">
+                <container component="Magento_Ui/js/form/components/group" sortOrder="60">
                     <argument name="data" xsi:type="array">
                         <item name="config" xsi:type="array">
-                            <item name="valueFromConfig" xsi:type="object">Magento\CatalogInventory\Model\Source\StockConfiguration</item>
-                            <item name="keyInConfiguration" xsi:type="string">notify_stock_qty</item>
-                            <item name="default" xsi:type="number">1</item>
+                            <item name="label" xsi:type="string" translate="true">Notify Qty</item>
+                            <item name="showLabel" xsi:type="boolean">false</item>
                         </item>
                     </argument>
-                    <settings>
-                        <dataScope>notify_stock_qty_use_default</dataScope>
-                        <label translate="true">Notify Quantity Use Default</label>
-                        <links>
-                            <link name="linkedValue">${$.provider}:${$.parentScope}.notify_stock_qty</link>
-                        </links>
-                        <imports>
-                            <link name="disabled">!${ $.provider }:data.product.stock_data.manage_stock</link>
-                        </imports>
-                    </settings>
-                    <formElements>
-                        <checkbox class="Magento\InventoryLowQuantityNotificationAdminUi\Ui\Component\Product\Form\Element\UseConfigSettings">
-                            <settings>
-                                <valueMap>
-                                    <map name="false" xsi:type="string">0</map>
-                                    <map name="true" xsi:type="string">1</map>
-                                </valueMap>
-                            </settings>
-                        </checkbox>
-                    </formElements>
-                </field>
+                    <field name="notify_stock_qty" formElement="input" sortOrder="60"
+                           component="Magento_InventoryLowQuantityNotificationAdminUi/js/components/notify-stock-qty">
+                        <settings>
+                            <labelVisible>false</labelVisible>
+                            <dataType>text</dataType>
+                            <dataScope>notify_stock_qty</dataScope>
+                            <imports>
+                                <link name="notifyStockQtyUseDefault">${$.parentName}.notify_stock_qty_use_default:checked</link>
+                                <link name="manageStock">!${ $.provider }:data.product.stock_data.manage_stock</link>
+                            </imports>
+                        </settings>
+                    </field>
+                    <field name="notify_stock_qty_use_default" component="Magento_InventoryLowQuantityNotificationAdminUi/js/components/use-config-settings" formElement="checkbox" sortOrder="70">
+                        <argument name="data" xsi:type="array">
+                            <item name="config" xsi:type="array">
+                                <item name="valueFromConfig" xsi:type="object">Magento\CatalogInventory\Model\Source\StockConfiguration</item>
+                                <item name="keyInConfiguration" xsi:type="string">notify_stock_qty</item>
+                                <item name="default" xsi:type="number">1</item>
+                            </item>
+                        </argument>
+                        <settings>
+                            <labelVisible>false</labelVisible>
+                            <dataScope>notify_stock_qty_use_default</dataScope>
+                            <links>
+                                <link name="linkedValue">${$.provider}:${$.parentScope}.notify_stock_qty</link>
+                            </links>
+                            <imports>
+                                <link name="disabled">!${ $.provider }:data.product.stock_data.manage_stock</link>
+                            </imports>
+                        </settings>
+                        <formElements>
+                            <checkbox class="Magento\InventoryLowQuantityNotificationAdminUi\Ui\Component\Product\Form\Element\UseConfigSettings">
+                                <settings>
+                                    <description translate="true">Use Default</description>
+                                    <valueMap>
+                                        <map name="false" xsi:type="string">0</map>
+                                        <map name="true" xsi:type="string">1</map>
+                                    </valueMap>
+                                </settings>
+                            </checkbox>
+                        </formElements>
+                    </field>
+                </container>
             </container>
         </dynamicRows>
-    </fieldset>
+    </container>
 </form>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
fix: elimate column Notify Quantity Use Default and move checkbox to Notify Qty column

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In Assigned Sources panel, located on the Product Edit page the
following edits were made:
  1. Eliminated column "Notify Quantity Use Default"
  2. Moved checkbox which was in column "Notify Quantity Use Default" to "Notifiy Qty" column below the number input
  3. Added "Use Default" description to the checkbox

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#2132: [UI Love for Assigned Sources] Notify Quantity

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add or edit a Product in the Magento Backend
2. In the Sources section, click "Assign Sources" to add one or more sources to the product
3. The changes will be displayed in "Assigned Sourced" table

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
