### PR TITLE
Travis integration tests maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ php:
 env:
   global:
     - COMPOSER_BIN_DIR=~/bin
-    - INTEGRATION_SETS=4
+    - INTEGRATION_SETS=6
     - NODE_JS_VERSION=8
     - MAGENTO_HOST_NAME="magento2.travis"
   matrix:
@@ -32,6 +32,8 @@ env:
     - TEST_SUITE=integration INTEGRATION_INDEX=2
     - TEST_SUITE=integration INTEGRATION_INDEX=3
     - TEST_SUITE=integration INTEGRATION_INDEX=4
+    - TEST_SUITE=integration INTEGRATION_INDEX=5
+    - TEST_SUITE=integration INTEGRATION_INDEX=6
     - TEST_SUITE=functional
     - TEST_SUITE=msi-api-functional
     - TEST_SUITE=graphql-api-functional

--- a/dev/tests/integration/testsuite/Magento/ImportExport/_files/import_data.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/_files/import_data.php
@@ -107,6 +107,8 @@ $importDataResource = \Magento\TestFramework\Helper\Bootstrap::getObjectManager(
     \Magento\ImportExport\Model\ResourceModel\Import\Data::class
 );
 
+/** @var $importDataResource Magento\ImportExport\Model\ResourceModel\Import\Data */
+$importDataResource->cleanBunches();
 foreach ($bunches as $bunch) {
     $importDataResource->saveBunch($bunch['entity'], $bunch['behavior'], $bunch['data']);
 }

--- a/dev/travis/before_script.sh
+++ b/dev/travis/before_script.sh
@@ -11,16 +11,18 @@ case $TEST_SUITE in
     integration)
         cd dev/tests/integration
 
-        tests_directory=$(find testsuite/* -maxdepth 1 -mindepth 1 -type d | sort)
-        module_directories=$(find ../../../app/code/*/*/Test/Integration -maxdepth 0 -mindepth 0 -type d | sort)
-        test_set_list=("${tests_directory[@]}" "${module_directories[@]}")
+        tests_directory=($(find testsuite/* -mindepth 1 -name "*Test.php" -type f | sort))
+        module_directories=($(find ../../../app/code/*/*/Test/Integration -mindepth 0 -type f -name "*Test.php" | sort))
+        test_set_list=(${tests_directory[@]} ${module_directories[@]})
 
-        test_set_count=$(printf "$test_set_list" | wc -l)
-        test_set_size[1]=$(printf "%.0f" $(echo "$test_set_count*0.13" | bc))
-        test_set_size[2]=$(printf "%.0f" $(echo "$test_set_count*0.31" | bc))
-        test_set_size[3]=$(printf "%.0f" $(echo "$test_set_count*0.48" | bc))
-        test_set_size[4]=$((test_set_count-test_set_size[1]-test_set_size[2]-test_set_size[3]))
-        echo "Total = ${test_set_count}; Batch #1 = ${test_set_size[1]}; Batch #2 = ${test_set_size[2]}; Batch #3 = ${test_set_size[3]}; Batch #4 = ${test_set_size[4]};";
+        test_set_count=${#test_set_list[@]}
+        test_set_size[1]=$(printf "%.0f" $(echo "$test_set_count*0.15" | bc))
+        test_set_size[2]=$(printf "%.0f" $(echo "$test_set_count*0.14" | bc))
+        test_set_size[3]=$(printf "%.0f" $(echo "$test_set_count*0.16" | bc))
+        test_set_size[4]=$(printf "%.0f" $(echo "$test_set_count*0.24" | bc))
+        test_set_size[5]=$(printf "%.0f" $(echo "$test_set_count*0.25" | bc))
+        test_set_size[6]=$((test_set_count-test_set_size[1]-test_set_size[2]-test_set_size[3]-test_set_size[4]-test_set_size[5]))
+        echo "Total = ${test_set_count}; Batch #1 = ${test_set_size[1]}; Batch #2 = ${test_set_size[2]}; Batch #3 = ${test_set_size[3]}; Batch #4 = ${test_set_size[4]}; Batch #5 = ${test_set_size[5]}; Batch #6 = ${test_set_size[6]};";
 
         echo "==> preparing integration testsuite on index $INTEGRATION_INDEX with set size of ${test_set_size[$INTEGRATION_INDEX]}"
         cp phpunit.xml.dist phpunit.xml
@@ -34,7 +36,7 @@ case $TEST_SUITE in
         # divide test sets up by indexed testsuites
         i=0; j=1; dirIndex=1; testIndex=1;
         for test_set in ${test_set_list[@]}; do
-            test_xml[j]+="            <directory suffix=\"Test.php\">$test_set</directory>\n"
+            test_xml[j]+="            <file>$test_set</file>\n"
 
             if [[ $j -eq $INTEGRATION_INDEX ]]; then
                 echo "$dirIndex: Batch #$j($testIndex of ${test_set_size[$j]}): + including $test_set"


### PR DESCRIPTION
### Description
As the number of integration tests for `Inventory` modules grow rapidly Travis CI test runner has to be once again optimized to accommodate larger computation time and memory requirements.

* Tests are now split into suites file-by-file instead of directory-by-directory
* Number of suites and weight coefficients updated to ensure none of the suites reaching time or memory limit. Fixed error with incorrect tests distribution.
* One of the core tests adjusted as it was failing due to dirty database state when splitting suites differently.
