### PR TITLE
MSI-2155: Zero qty for children products when save configurable product twice

### DIFF
--- a/app/code/Magento/InventoryConfigurableProductAdminUi/Observer/ProcessSourceItemsObserver.php
+++ b/app/code/Magento/InventoryConfigurableProductAdminUi/Observer/ProcessSourceItemsObserver.php
@@ -85,8 +85,9 @@ class ProcessSourceItemsObserver implements ObserverInterface
     private function processSourceItems(array $sourceItems, string $productSku)
     {
         foreach ($sourceItems as $key => $sourceItem) {
+            $sourceItems[$key][SourceItemInterface::QUANTITY] = $sourceItems[$key]['quantity_per_source'];
+
             if (!isset($sourceItem[SourceItemInterface::STATUS])) {
-                $sourceItems[$key][SourceItemInterface::QUANTITY] = $sourceItems[$key]['quantity_per_source'];
                 $sourceItems[$key][SourceItemInterface::STATUS]
                     = $sourceItems[$key][SourceItemInterface::QUANTITY] > 0 ? 1 : 0;
             }


### PR DESCRIPTION
### Description (*)
 Zero qty for children products when save configurable product twice

### Fixed Issues (if relevant)
#2155 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
