### PR TITLE
Fix MFTF - Source code column on product assign source removed

### DIFF
--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminManageStockOnConfigurationPageTurnedOffForSimpleProductTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminManageStockOnConfigurationPageTurnedOffForSimpleProductTest.xml
@@ -89,7 +89,6 @@
         <click selector="{{AdminAssignSourcesSlideOutGridSection.checkboxByCode($$customSource.source[source_code]$$)}}" stepKey="selectCreatedCustomSource"/>
         <click selector="{{AdminAssignSourcesSlideOutSection.done}}" stepKey="doneSelectSource"/>
 
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$customSource.source[source_code]$$" stepKey="checkSelectedSourceCodeInProductAssignedSourcesList"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$customSource.source[name]$$" stepKey="checkSelectedSourceNameInProductAssignedSourcesList"/>
 
         <fillField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="{{SimpleMsiProduct.quantity}}" stepKey="fillSourceQtyField"/>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminNotifyQuantityUseDefaultAppliedToSimpleProductOnConfigurationAdminPageTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminNotifyQuantityUseDefaultAppliedToSimpleProductOnConfigurationAdminPageTest.xml
@@ -100,7 +100,6 @@
         <click selector="{{AdminAssignSourcesSlideOutGridSection.checkboxByCode($$customSource.source[source_code]$$)}}" stepKey="assignCustomSourceToProduct"/>
         <click selector="{{AdminAssignSourcesSlideOutSection.done}}" stepKey="doneWithCustomSourceAssignment"/>
 
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$customSource.source[source_code]$$" stepKey="checkCustomSourceCode"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$customSource.source[name]$$" stepKey="checkCustomSourceName"/>
 
         <fillField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="{{SimpleMsiProduct.quantity}}" stepKey="fillSourceQty"/>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminNotifyQuantityUseDefaultAppliedToVirtualProductOnConfigurationAdminPageTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminNotifyQuantityUseDefaultAppliedToVirtualProductOnConfigurationAdminPageTest.xml
@@ -103,7 +103,6 @@
         <click selector="{{AdminAssignSourcesSlideOutGridSection.checkboxByCode($$createSource1.source[source_code]$$)}}" stepKey="assignCustomSourceToProduct1"/>
         <click selector="{{AdminAssignSourcesSlideOutSection.done}}" stepKey="doneWithCustomSourceAssignment1"/>
 
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$createSource1.source[source_code]$$" stepKey="checkCustomSourceCode1"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$createSource1.source[name]$$" stepKey="checkCustomSourceName1"/>
 
         <fillField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="{{VirtualMsiProduct.quantity}}" stepKey="fillSourceQty1"/>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminRemoveSourcesAssignedToProductTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminRemoveSourcesAssignedToProductTest.xml
@@ -58,29 +58,22 @@
         <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="default" stepKey="seeSourceIdInGrid1"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="Default Source" stepKey="seeSourceNameInGrid1"/>
 
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('1')}}" userInput="$$createSource1.source[source_code]$$" stepKey="seeSourceIdInGrid2"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('1')}}" userInput="$$createSource1.source[name]$$" stepKey="seeSourceNameInGrid2"/>
 
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('2')}}" userInput="$$createSource2.source[source_code]$$" stepKey="seeSourceIdInGrid3"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('2')}}" userInput="$$createSource2.source[name]$$" stepKey="seeSourceNameInGrid3"/>
 
         <click selector="{{AdminGridMainControls.saveAndContinue}}" stepKey="clickOnSaveAndContinue1"/>
 
         <click selector="{{AdminProductSourcesGrid.rowDelete('1')}}" stepKey="clickOnDelete1"/>
-        <dontSee selector="{{AdminProductSourcesGrid.rowByIndex('1')}}" userInput="$$createSource1.source[source_code]$$" stepKey="dontSeeSourceIdInGrid1"/>
         <dontSee selector="{{AdminProductSourcesGrid.rowByIndex('1')}}" userInput="$$createSource1.source[name]$$" stepKey="dontSeeSourceNameInGrid1"/>
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('1')}}" userInput="$$createSource2.source[source_code]$$" stepKey="seeSourceIdInGrid5"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('1')}}" userInput="$$createSource2.source[name]$$" stepKey="seeSourceNameInGrid5"/>
 
         <click selector="{{AdminProductSourcesGrid.rowDelete('1')}}" stepKey="clickOnDelete2"/>
-        <dontSee selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$createSource2.source[source_code]$$" stepKey="dontSeeSourceIdInGrid2"/>
         <dontSee selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$createSource2.source[name]$$" stepKey="dontSeeSourceNameInGrid2"/>
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="default" stepKey="seeSourceIdInGrid6"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="Default Source" stepKey="seeSourceNameInGrid6"/>
 
         <click selector="{{AdminGridMainControls.saveAndContinue}}" stepKey="clickOnSaveAndContinue2"/>
 
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="default" stepKey="seeSourceIdInGrid7"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="Default Source" stepKey="seeSourceNameInGrid7"/>
         <seeNumberOfElements selector=".data-row" userInput="1" stepKey="seeOneSourceRow1"/>
     </test>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminSourceForEachQuantityCanBeSetByAdminTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminSourceForEachQuantityCanBeSetByAdminTest.xml
@@ -43,7 +43,6 @@
 
         <fillField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="100" stepKey="fillDefaultQuantityField1"/>
 
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="{{_defaultSource.source_code}}" stepKey="seeSourceIdInGrid1"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="{{_defaultSource.name}}" stepKey="seeSourceNameInGrid1"/>
         <seeInField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="100" stepKey="seeSourceNameInGrid2"/>
 
@@ -54,7 +53,6 @@
 
         <fillField selector="{{AdminProductSourcesGrid.rowQty('1')}}" userInput="100" stepKey="fillDefaultQuantityField2"/>
 
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('1')}}" userInput="$$createSource1.source[source_code]$$" stepKey="seeSourceIdInGrid2"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('1')}}" userInput="$$createSource1.source[name]$$" stepKey="seeSourceNameInGrid3"/>
         <seeInField selector="{{AdminProductSourcesGrid.rowQty('1')}}" userInput="100" stepKey="seeSourceNameInGrid4"/>
 
@@ -65,7 +63,6 @@
 
         <fillField selector="{{AdminProductSourcesGrid.rowQty('2')}}" userInput="100" stepKey="fillDefaultQuantityField5"/>
 
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('2')}}" userInput="$$createSource2.source[source_code]$$" stepKey="seeSourceIdInGrid3"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('2')}}" userInput="$$createSource2.source[name]$$" stepKey="seeSourceNameInGrid6"/>
         <seeInField selector="{{AdminProductSourcesGrid.rowQty('2')}}" userInput="100" stepKey="seeSourceNameInGrid7"/>
 

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminSourcePrioritySelectionAlgorithmSimpleProductCustomStockTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminSourcePrioritySelectionAlgorithmSimpleProductCustomStockTest.xml
@@ -134,9 +134,7 @@
         <click selector="{{AdminAssignSourcesSlideOutGridSection.checkboxByCode($$highPrioritySource.source[source_code]$$)}}" stepKey="selectHighPrioritySource"/>
         <click selector="{{AdminAssignSourcesSlideOutSection.done}}" stepKey="doneSelectHighPrioritySource"/>
 
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$lowPrioritySource.source[source_code]$$" stepKey="checkLowPrioritySourceCode"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$lowPrioritySource.source[name]$$" stepKey="checkLowPrioritySourceName"/>
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('1')}}" userInput="$$highPrioritySource.source[source_code]$$" stepKey="checkHighPrioritySourceCode"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('1')}}" userInput="$$highPrioritySource.source[name]$$" stepKey="checkHighPrioritySourceName"/>
 
         <fillField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="{{SimpleProduct.quantity}}" stepKey="fillSourceQtyFieldForLowPrioritySource"/>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/StorefrontSimpleProductAssignedToNonDefaultSourceCreatedByAdminUserTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/StorefrontSimpleProductAssignedToNonDefaultSourceCreatedByAdminUserTest.xml
@@ -55,7 +55,6 @@
         </actionGroup>
         <click selector="{{AdminAssignSourcesSlideOutGridSection.checkboxByCode($$createCustomSource.source[source_code]$$)}}" stepKey="clickOnCheckboxOnProductPage"/>
         <click selector="{{AdminAssignSourcesSlideOutSection.done}}" stepKey="clickOnDoneOnProductPage"/>
-        <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$createCustomSource.source[source_code]$$" stepKey="seeSourceIdInGridOnProductPage"/>
         <see selector="{{AdminProductSourcesGrid.rowByIndex('0')}}" userInput="$$createCustomSource.source[name]$$" stepKey="seeSourceNameInGridOnProductPage"/>
 
         <fillField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="{{SimpleMsiProduct.quantity}}" stepKey="fillSourceQtyFieldOnProductPage"/>


### PR DESCRIPTION

Removed the see assertion for sourced_code on Product assign Source grid on Edit product page - this has been removed from MSI UI.

Tests modified:

* MSI-1126
* MSI-1617
* MSI-781
* MSI-937
* MSI-954
* MSI-955
* MSI-958
