### PR TITLE
2169: Implement reservations CLI for incomplete orders

### DIFF
--- a/app/code/Magento/InventoryReservationCli/Command/ShowInconsistenciesForIncompleteOrders.php
+++ b/app/code/Magento/InventoryReservationCli/Command/ShowInconsistenciesForIncompleteOrders.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryReservationCli\Command;
+
+use Magento\InventoryReservationCli\Model\GetOrdersInNotFinalState;
+use Magento\InventoryReservationCli\Model\GetOrdersWithMissingInitialReservations;
+use Magento\InventoryReservationCli\Model\GetOrdersWithNotCompensatedReservations;
+use Magento\Sales\Model\Order;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Outputs a list of incomplete orders, which have not a initial reservation.
+ *
+ * This command may be used to simplify migrations from Magento versions without new Inventory or to track down
+ * incorrect behavior of customizations.
+ */
+class ShowInconsistenciesForIncompleteOrders extends Command
+{
+    /**
+     * @var GetOrdersInNotFinalState
+     */
+    private $getOrdersInNotFinalState;
+
+    /**
+     * @var GetOrdersWithMissingInitialReservations
+     */
+    private $getOrdersWithMissingInitialReservations;
+
+    /**
+     * @param GetOrdersWithMissingInitialReservations $getOrdersWithMissingInitialReservations
+     * @param GetOrdersInNotFinalState $getOrdersInNotFinalState
+     */
+    public function __construct(
+        GetOrdersWithMissingInitialReservations $getOrdersWithMissingInitialReservations,
+        GetOrdersInNotFinalState $getOrdersInNotFinalState
+    ) {
+        $this->getOrdersWithMissingInitialReservations = $getOrdersWithMissingInitialReservations;
+        $this->getOrdersInNotFinalState = $getOrdersInNotFinalState;
+        parent::__construct();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('inventory:reservation:list-missing-reservation')
+            ->setDescription('Show all orders and products without initial reservation')
+            ->addOption('raw', 'r', InputOption::VALUE_NONE, 'Raw output');
+
+        parent::configure();
+    }
+
+    /**
+     * Format output
+     *
+     * @param OutputInterface $output
+     * @param array $inconsistentData
+     */
+    private function prettyOutput(OutputInterface $output, array $inconsistentData): void
+    {
+        $output->writeln('<comment>Inconsistencies found on following entries:</comment>');
+
+        /** @var Order $order */
+        foreach ($inconsistentData as $inconsistentOrder) {
+            $inconsistentSkus = $inconsistentOrder['skus'];
+            $incrementId = $inconsistentOrder['increment_id'];
+
+            $output->writeln(sprintf('Order <comment>%s</comment>:', $incrementId));
+
+            foreach ($inconsistentSkus as $inconsistentSku => $qty) {
+                $output->writeln(
+                    sprintf(
+                        '  - Product <comment>%s</comment> should be compensated by <comment>%+f</comment>',
+                        $inconsistentSku,
+                        -$qty
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Output without formatting
+     *
+     * @param OutputInterface $output
+     * @param array $inconsistentData
+     */
+    private function rawOutput(OutputInterface $output, array $inconsistentData): void
+    {
+        /** @var Order $order */
+        foreach ($inconsistentData as $inconsistentOrder) {
+            $inconsistentSkus = $inconsistentOrder['skus'];
+            $incrementId = $inconsistentOrder['increment_id'];
+
+            foreach ($inconsistentSkus as $inconsistentSku => $qty) {
+                $output->writeln(
+                    sprintf('%s:%s:%f', $incrementId, $inconsistentSku, -$qty)
+                );
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $incompleteOrders = $this->getOrdersInNotFinalState->execute();
+        $inconsistentData = $this->getOrdersWithMissingInitialReservations->execute($incompleteOrders);
+
+        if (empty($inconsistentData)) {
+            $output->writeln('<info>No order inconsistencies were found</info>');
+            return 0;
+        }
+
+        if ($input->getOption('raw')) {
+            $this->rawOutput($output, $inconsistentData);
+        } else {
+            $this->prettyOutput($output, $inconsistentData);
+        }
+        return -1;
+    }
+}

--- a/app/code/Magento/InventoryReservationCli/Model/GetOrdersInNotFinalState.php
+++ b/app/code/Magento/InventoryReservationCli/Model/GetOrdersInNotFinalState.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryReservationCli\Model;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+
+/**
+ * Get list of orders, which are not in any of the final states (Complete, Closed, Canceled).
+ */
+class GetOrdersInNotFinalState
+{
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @param OrderRepositoryInterface $orderRepository
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     */
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+    }
+
+    /**
+     * Get list of orders
+     *
+     * @return OrderInterface[]
+     */
+    public function execute(): array
+    {
+        /** @var SearchCriteriaInterface $filter */
+        $filter = $this->searchCriteriaBuilder
+            ->addFilter('state', [
+                Order::STATE_COMPLETE,
+                Order::STATE_CLOSED,
+                Order::STATE_CANCELED
+            ], 'nin')
+            ->create();
+
+        $orderSearchResult = $this->orderRepository->getList($filter);
+        return $orderSearchResult->getItems();
+    }
+}

--- a/app/code/Magento/InventoryReservationCli/Model/GetOrdersWithMissingInitialReservations.php
+++ b/app/code/Magento/InventoryReservationCli/Model/GetOrdersWithMissingInitialReservations.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryReservationCli\Model;
+
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\InventoryReservationCli\Model\ResourceModel\GetReservationsList;
+use Magento\Sales\Api\Data\OrderInterface;
+
+/**
+ * Filter orders for missing initial reservation
+ */
+class GetOrdersWithMissingInitialReservations
+{
+    /**
+     * @var GetReservationsList
+     */
+    private $getReservationsList;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serialize;
+
+    /**
+     * @param GetReservationsList $getReservationsList
+     * @param SerializerInterface $serialize
+     */
+    public function __construct(
+        GetReservationsList $getReservationsList,
+        SerializerInterface $serialize
+    ) {
+        $this->getReservationsList = $getReservationsList;
+        $this->serialize = $serialize;
+    }
+
+    /**
+     * Get list of reservations for Order entity.
+     *
+     * @param OrderInterface[] $orders
+     * @return array
+     */
+    public function execute(array $orders): array
+    {
+        $entityIdAndSkuList = $this->getEntityIdAndSkuList($orders);
+
+        $reservationList = $this->getReservationsList->execute();
+        foreach ($reservationList as $reservation) {
+            $metadata = $this->serialize->unserialize($reservation['metadata']);
+            $objectId = $metadata['object_id'];
+            $eventType = $metadata['event_type'];
+
+            if ($eventType == 'order_placed' && in_array($objectId, array_keys($entityIdAndSkuList))) {
+                unset($entityIdAndSkuList[$objectId]);
+            }
+        }
+
+        return $entityIdAndSkuList;
+    }
+
+    /**
+     * @param OrderInterface[] $orders
+     * @return array
+     */
+    private function getEntityIdAndSkuList(array $orders): array
+    {
+        $list = [];
+        foreach ($orders as $order) {
+            $entityId = $order->getEntityId();
+            $list[$entityId] = [
+                'increment_id' => $order->getIncrementId(),
+                'skus' => []
+            ];
+            foreach ($order->getItems() as $item) {
+                $list[$entityId]['skus'][$item->getSku()] = (float)$item->getQtyOrdered();
+            }
+        }
+        return $list;
+    }
+}

--- a/app/code/Magento/InventoryReservationCli/Test/Integration/Model/GetListMissingReservationsForIncompleteOrdersTest.php
+++ b/app/code/Magento/InventoryReservationCli/Test/Integration/Model/GetListMissingReservationsForIncompleteOrdersTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryReservationCli\Test\Integration\Model;
+
+use Magento\InventoryReservationCli\Model\GetOrdersInNotFinalState;
+use Magento\InventoryReservationCli\Model\GetOrdersWithMissingInitialReservations;
+use PHPUnit\Framework\TestCase;
+use Magento\TestFramework\Helper\Bootstrap;
+
+class GetListMissingReservationsForIncompleteOrdersTest extends TestCase
+{
+    /**
+     * @var GetOrdersWithMissingInitialReservations
+     */
+    private $getOrdersWithMissingInitialReservations;
+
+    /**
+     * @var GetOrdersInNotFinalState
+     */
+    private $getOrdersInNotFinalState;
+
+    /**
+     * Initialize test dependencies
+     */
+    protected function setUp()
+    {
+        $this->getOrdersWithMissingInitialReservations
+            = Bootstrap::getObjectManager()->get(GetOrdersWithMissingInitialReservations::class);
+        $this->getOrdersInNotFinalState
+            = Bootstrap::getObjectManager()->get(GetOrdersInNotFinalState::class);
+    }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryReservationCli/Test/Integration/_fixtures/create_incomplete_order_with_reservation.php
+     */
+    public function testShouldNotFindAnyInconsistency(): void
+    {
+        $incompleteOrders = $this->getOrdersInNotFinalState->execute();
+        $missingReservations = $this->getOrdersWithMissingInitialReservations->execute($incompleteOrders);
+        self::assertSame([], $missingReservations);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testShouldFindOneInconsistency(): void
+    {
+        $incompleteOrders = $this->getOrdersInNotFinalState->execute();
+        $missingReservations = $this->getOrdersWithMissingInitialReservations->execute($incompleteOrders);
+        self::assertCount(1, $missingReservations);
+    }
+}

--- a/app/code/Magento/InventoryReservationCli/Test/Integration/_fixtures/create_incomplete_order_with_reservation.php
+++ b/app/code/Magento/InventoryReservationCli/Test/Integration/_fixtures/create_incomplete_order_with_reservation.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Address as OrderAddress;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Sales\Model\Order\Payment;
+use Magento\Store\Model\StoreManagerInterface;
+
+require __DIR__ . '/../../../../../../../dev/tests/integration/testsuite/Magento/Sales/_files/default_rollback.php';
+require __DIR__ . '/../../../../../../../dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple.php';
+/** @var \Magento\Catalog\Model\Product $product */
+
+$addressData = include __DIR__ . '/../../../../../../../dev/tests/integration/testsuite/Magento/Sales/_files/address_data.php';
+
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+$billingAddress = $objectManager->create(OrderAddress::class, ['data' => $addressData]);
+$billingAddress->setAddressType('billing');
+
+$shippingAddress = clone $billingAddress;
+$shippingAddress->setId(null)->setAddressType('shipping');
+
+/** @var Payment $payment */
+$payment = $objectManager->create(Payment::class);
+$payment->setMethod('checkmo')
+    ->setAdditionalInformation('last_trans_id', '11122')
+    ->setAdditionalInformation(
+        'metadata',
+        [
+            'type' => 'free',
+            'fraudulent' => false,
+        ]
+    );
+
+/** @var OrderItem $orderItem */
+$orderItem = $objectManager->create(OrderItem::class);
+$orderItem->setProductId($product->getId())
+    ->setQtyOrdered(2)
+    ->setSku($product->getSku())
+    ->setBasePrice($product->getPrice())
+    ->setPrice($product->getPrice())
+    ->setRowTotal($product->getPrice())
+    ->setProductType('simple')
+    ->setName($product->getName());
+
+/** @var Order $order */
+$order = $objectManager->create(Order::class);
+$order->setIncrementId('100000001')
+    ->setState(Order::STATE_PROCESSING)
+    ->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING))
+    ->setSubtotal(100)
+    ->setGrandTotal(100)
+    ->setBaseSubtotal(100)
+    ->setBaseGrandTotal(100)
+    ->setCustomerIsGuest(true)
+    ->setCustomerEmail('customer@null.com')
+    ->setBillingAddress($billingAddress)
+    ->setShippingAddress($shippingAddress)
+    ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
+    ->addItem($orderItem)
+    ->setPayment($payment);
+
+/** @var \Magento\Sales\Api\OrderManagementInterface $orderManagement */
+$orderManagement = $objectManager->create(\Magento\Sales\Api\OrderManagementInterface::class);
+
+$orderManagement->place($order);
+
+/** @var \Magento\Framework\DB\Transaction $transaction */
+$transaction = $objectManager->create(\Magento\Framework\DB\Transaction::class);
+$transaction->addObject($order)->save();

--- a/app/code/Magento/InventoryReservationCli/etc/di.xml
+++ b/app/code/Magento/InventoryReservationCli/etc/di.xml
@@ -12,6 +12,9 @@
                 <item name="inventory_complete_order_inconsistency" xsi:type="object">
                     Magento\InventoryReservationCli\Command\ShowInconsistenciesInCompletedOrders
                 </item>
+                <item name="inventory_incomplete_order_inconsistency" xsi:type="object">
+                    Magento\InventoryReservationCli\Command\ShowInconsistenciesForIncompleteOrders
+                </item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
- added CLI command `inventory:reservation:list-missing-reservation`
- added integration tests

### Description (*)
Implements CLI command, which detects orders with missing reservations. This command may be used to simplify migrations from Magento versions without new Inventory or to track down incorrect behavior of customizations.

### Fixed Issues (if relevant)
1. magento-engcom/msi#2169: Reservations CLI for incomplete orders

### Manual testing scenarios (*)
1. Create new order
2. Remove the reservation from database for created order
3. Run `bin/magento inventory:reservation:list-missing-reservation`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
