### PR TITLE
magento-engcom/msi#2156: fixed issue with incorrect product stock status

### DIFF
--- a/app/code/Magento/InventorySales/Model/IsProductSalableCondition/IsSetInStockStatusForCompositeProductCondition.php
+++ b/app/code/Magento/InventorySales/Model/IsProductSalableCondition/IsSetInStockStatusForCompositeProductCondition.php
@@ -43,7 +43,7 @@ class IsSetInStockStatusForCompositeProductCondition implements IsProductSalable
      */
     public function execute(string $sku, int $stockId): bool
     {
-        if ($this->isSourceItemManagementAllowedForSku->execute($sku)) {
+        if (!$this->isSourceItemManagementAllowedForSku->execute($sku)) {
             return true;
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#2156: Issue Product status is 'In Stock' on storefront even it is Out of Stock in all Sources

### Manual testing scenarios (*)
Steps to reproduce (*)
Go to create product page
Fill all required data
Assign a few sources
Switch Source Item Status to Out of Stock on each source
Switch Backorders to Allow Qty Below 0 on Advanced Inventory page
Save product
Open product on storefront
Expected result (*)
Product isn't salable and status is Out of Stock

Actual result (*)
Product is salable and status is In Stock

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
