### PR TITLE
MSI-2131 Incorrect processing of products with non-manageable stock a…

### DIFF
--- a/app/code/Magento/InventoryCatalog/Plugin/CatalogInventory/Model/Indexer/ModifySelectInProductPriceIndexFilter.php
+++ b/app/code/Magento/InventoryCatalog/Plugin/CatalogInventory/Model/Indexer/ModifySelectInProductPriceIndexFilter.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventoryCatalog\Plugin\CatalogInventory\Model\Indexer;
 
-use Magento\Catalog\Model\ResourceModel\Product\Collection;
+//use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\Indexer\Price\IndexTableStructure;
 use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\CatalogInventory\Model\Indexer\ProductPriceIndexFilter;
@@ -95,7 +95,7 @@ class ModifySelectInProductPriceIndexFilter
                     ['inventory_stock' => $stockTable],
                     'inventory_stock.sku = product_entity.sku',
                     []
-                )->join(
+                )->joinLeft(
                     ['legacy_stock_item' => $this->resourceConnection->getTableName('cataloginventory_stock_item')],
                     'product_entity.entity_id = legacy_stock_item.product_id',
                     ['use_config_manage_stock', 'manage_stock']
@@ -104,7 +104,7 @@ class ModifySelectInProductPriceIndexFilter
                 if (1 === $globalManageStock) {
                     $stockSettingsCondition .= ' OR legacy_stock_item.use_config_manage_stock = 1';
                 }
-                $select->where('(inventory_stock.is_salable = 0 OR inventory_stock.is_salable IS NULL) AND '.$stockSettingsCondition);
+                $select->where('(inventory_stock.is_salable = 0 OR inventory_stock.is_salable IS NULL) AND (' . $stockSettingsCondition . ')');
             }
 
             $select->where('price_index.website_id = ?', $websiteId);

--- a/app/code/Magento/InventoryCatalogSearch/etc/module.xml
+++ b/app/code/Magento/InventoryCatalogSearch/etc/module.xml
@@ -10,6 +10,7 @@
         <sequence>
             <module name="Magento_CatalogSearch"/>
             <module name="Magento_InventoryCatalog"/>
+            <module name="Magento_CatalogInventory"/>
         </sequence>
     </module>
 </config>

--- a/app/code/Magento/InventoryConfiguration/Model/GetStockItemConfiguration.php
+++ b/app/code/Magento/InventoryConfiguration/Model/GetStockItemConfiguration.php
@@ -67,20 +67,27 @@ class GetStockItemConfiguration implements GetStockItemConfigurationInterface
 
     /**
      * @inheritdoc
+     * @todo Need to make Manage_to_stock setting as catalog attribute
      */
     public function execute(string $sku, int $stockId): StockItemConfigurationInterface
     {
+        $result = true;
         if ($this->defaultStockProvider->getId() !== $stockId
             && true === $this->isSourceItemManagementAllowedForSku->execute($sku)
             && false === $this->isProductAssignedToStock->execute($sku, $stockId)) {
-            throw new SkuIsNotAssignedToStockException(
-                __('The requested sku is not assigned to given stock.')
-            );
+            $result = false;
         }
-
+        $stockItem = $this->getLegacyStockItem->execute($sku);
+        if(!$result){
+            if($stockItem->getManageStock() !== 0){
+                throw new SkuIsNotAssignedToStockException(
+                    __('The requested sku is not assigned to given stock.')
+                );
+            }
+        }
         return $this->stockItemConfigurationFactory->create(
             [
-                'stockItem' => $this->getLegacyStockItem->execute($sku)
+                'stockItem' => $stockItem
             ]
         );
     }


### PR DESCRIPTION
…bsent in stock index
Fixed issue when product that have "Manage Stock" = No is not visible on frontend.
Was added checking for this param to indexation processed and product collection obtaining.



### Description (*)
Changed filters to product collection
Changed price index modification plugin

### Fixed Issues (if relevant)
In case where a new Product was created with no source/stock assignment (or assignment to a non-default source/stock) and has Manage Stock = false in its Advanced Inventory settings it would not show up in the frontend.

Currently, a set of plugins in the InventoryCatalog module are responsible for adapting catalog inventory stock status to use indexes provided by MSI. These plugins are joining stock index and products for the frontend product collection. Product, with combination of settings described above, never gets into the stock index and therefore is absent in the product collections


### Manual testing scenarios (*)
1. Create product with "Manage stock" = No and do not assign any source 
2. Check that product is available on frontend


