### PR TITLE
MFTF fixes - DbRollback and Manage-Inventory suite configuration

### DIFF
--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/ActionGroup/AdminGoToProductGridFilterResultsByInputActionGroup.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/ActionGroup/AdminGoToProductGridFilterResultsByInputActionGroup.xml
@@ -53,7 +53,7 @@
 
         <conditionalClick selector="{{AdminGridFilterControls.clearAll}}" dependentSelector=".admin__data-grid-header[data-bind='afterRender: \$data.setToolbarNode'] .admin__data-grid-filters-current._show" visible="true" stepKey="clearTheFiltersIfPresent"/>
         <waitForPageLoad stepKey="waitForPageLoad" time="5"/>
-        <scrollTo selector="{{AdminGridFilterControls.filters}}" stepKey="scrollToGridFilterControls"/>
+        <scrollToTopOfPage  stepKey="scrollToGridFilterControls"/>
         <click selector="{{AdminGridFilterControls.filters}}" stepKey="clickOnFilters1"/>
         <fillField userInput="{{filter_value}}" selector="{{filter_selector}}" stepKey="fillCodeField2"/>
         <click selector="{{AdminGridFilterControls.applyFilters}}" stepKey="clickOnApplyFilters1"/>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Suite/msi-suite.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Suite/msi-suite.xml
@@ -24,7 +24,6 @@
             <group name="multi_mode"/>
         </exclude>
         <after>
-            <magentoCLI stepKey="dbRollback" command="setup:rollback" arguments="--db-file%3D%24%28ls%20..%2F..%2F..%2F..%2Fvar%2Fbackups%29%20-n" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
             <magentoCLI stepKey="disableBackup" command = "config:set system/backup/functionality_enabled 0" />
         </after>
@@ -44,7 +43,6 @@
             <group name="single_mode"/>
         </exclude>
         <after>
-            <magentoCLI stepKey="dbRollback" command="setup:rollback" arguments="--db-file%3D%24%28ls%20..%2F..%2F..%2F..%2Fvar%2Fbackups%29%20-n" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
             <magentoCLI stepKey="disableBackup" command = "config:set system/backup/functionality_enabled 0" />
         </after>
@@ -65,7 +63,6 @@
             <group name="multi_mode"/>
         </exclude>
         <after>
-            <magentoCLI stepKey="dbRollback" command="setup:rollback" arguments="--db-file%3D%24%28ls%20..%2F..%2F..%2F..%2Fvar%2Fbackups%29%20-n" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
             <magentoCLI stepKey="disableBackup" command = "config:set system/backup/functionality_enabled 0" />
         </after>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Suite/msi-suite.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Suite/msi-suite.xml
@@ -34,6 +34,7 @@
             <magentoCLI stepKey="dbBackup" command="setup:backup" arguments="--db" />
             <magentoCLI stepKey="maintenanceDisable" command="maintenance:disable"/>
             <magentoCLI stepKey="disableWYSYWYG" command="config:set cms/wysiwyg/enabled disabled"/>
+            <magentoCLI stepKey="enableStockManagement" command="config:set cataloginventory/item_options/manage_stock 1"/>
         </before>
         <include>
             <group name="multi_mode"/>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminConfigurableProductDisabledManageStockOnCustomStockTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminConfigurableProductDisabledManageStockOnCustomStockTest.xml
@@ -45,6 +45,7 @@
             <click selector="{{AdminGridMainControls.saveAndContinue}}" stepKey="saveCustomStock"/>
         </before>
         <after>
+            <magentoCLI command="config:set cataloginventory/item_options/manage_stock 1" stepKey="reenableManageStock"/>
             <deleteData createDataKey="category" stepKey="deleteCategory"/>
             <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
         </after>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminCreditMemoCreatedWithPartialRefundWithSimpleProductOnDefaultStockAfterFullInvoiceAndPartialShipment.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/AdminCreditMemoCreatedWithPartialRefundWithSimpleProductOnDefaultStockAfterFullInvoiceAndPartialShipment.xml
@@ -27,13 +27,26 @@
                 <requiredEntity createDataKey="createStock"/>
                 <requiredEntity createDataKey="createSource"/>
             </createData>
+
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+            <waitForPageLoad stepKey="waitForDashboardLoad"/>
+
+            <comment userInput="Assign main website to default stock" stepKey="assignChannelToStockComment"/>
+            <amOnPage url="{{AdminManageStockPage.url}}" stepKey="navigateToStockListPageToAssignMainWebsiteToDefaultStock"/>
+            <waitForPageLoad time="30" stepKey="waitForStockListPageLoad"/>
+            <actionGroup ref="searchAdminDataGridByKeyword" stepKey="searchDefaultStockByNameForAssignMainWebsiteChannel">
+                <argument name="keyword" value="_defaultStock.name"/>
+            </actionGroup>
+            <click selector="{{AdminGridRow.editByValue(_defaultStock.name)}}" stepKey="clickEditDefaultStock"/>
+            <waitForPageLoad time="30" stepKey="waitForDefaultStockPageLoaded"/>
+            <selectOption selector="{{AdminEditStockSalesChannelsSection.websites}}" userInput="Main Website" stepKey="selectDefaultWebsiteAsSalesChannelForDefaultStock"/>
+            <click selector="{{AdminGridMainControls.saveAndContinue}}" stepKey="saveDefaultStock"/>
+
             <createData entity="SimpleSubCategory" stepKey="simpleCategory"/>
             <createData entity="SimpleProduct" stepKey="simpleProduct">
                 <field key="qty">100.00</field>
                 <requiredEntity createDataKey="simpleCategory"/>
             </createData>
-            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-            <waitForPageLoad stepKey="waitForDashboardLoad"/>
         </before>
         <after>
             <actionGroup ref="logout" stepKey="logoutOfAdmin"/>

--- a/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/GuestCustomerOrderedDownloadableProductOnCustomStockFromHomepageTest.xml
+++ b/app/code/Magento/InventoryAdminUi/Test/Mftf/Test/GuestCustomerOrderedDownloadableProductOnCustomStockFromHomepageTest.xml
@@ -21,6 +21,7 @@
 
         <before>
             <magentoCLI stepKey="enableGuestCheckoutForDownloadable" command="config:set catalog/downloadable/disable_guest_checkout 0" />
+            <magentoCLI stepKey="enableStockManagement" command="config:set cataloginventory/item_options/manage_stock 1"/>
             <createData entity="FullSource1" stepKey="createSource"/>
             <createData entity="BasicMsiStockWithMainWebsite1" stepKey="createStock"/>
             <createData entity="SourceStockLinked1" stepKey="linkSourceStock">


### PR DESCRIPTION
Failures found sporadically in builds for MSI tests.
Changes made:
* Remove dbRollback functionality - not necessary with suite config
* Moved config set for "Manage Inventory" to suite level
* Explicitly setting MainWebsite for default stock where necessary
* Change some actions to ScrolltoTopOfPage from ScrollTo for stability