### PR TITLE
MSI-2062: Inventory Stock Export. Fix table name used without resource connection getTableName

### DIFF
--- a/app/code/Magento/InventoryExportStock/Model/ResourceModel/StockIndexDumpProcessor.php
+++ b/app/code/Magento/InventoryExportStock/Model/ResourceModel/StockIndexDumpProcessor.php
@@ -180,6 +180,8 @@ class StockIndexDumpProcessor
             ->getTableName('cataloginventory_stock_item');
         $productEntityTable = $this->resourceConnection
             ->getTableName('catalog_product_entity');
+        $productWebsiteTable = $this->resourceConnection
+            ->getTableName('catalog_product_website');
         $select = $this->connection->select();
         $getQtyForNotManageStock = $this->getQtyForNotManageStock->execute();
         if ($getQtyForNotManageStock === null) {
@@ -203,7 +205,7 @@ class StockIndexDumpProcessor
             'legacy_stock_item.product_id = product_entity.entity_id',
             ['sku']
         )->join(
-            ['pr_web' => 'catalog_product_website'],
+            ['pr_web' => $productWebsiteTable],
             'legacy_stock_item.product_id = pr_web.product_id',
             ''
         )->where(


### PR DESCRIPTION


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
catalog_product_website table name was used as a string instead of getting this from resource connection using method getTableName for adding table prefix if it used

### Manual testing scenarios (*)
1. Create new Magento instance with table prefixes
2. Run Stock dump inventory export

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
