### PR TITLE
Pluginization of isSaleable method on product model

### DIFF
--- a/app/code/Magento/InventoryCatalog/Plugin/Catalog/Model/Product.php
+++ b/app/code/Magento/InventoryCatalog/Plugin/Catalog/Model/Product.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Plugin\Catalog\Model;
+
+class Product
+{
+    /**
+     * @var \Magento\InventorySalesApi\Model\GetAssignedStockIdForWebsiteInterface
+     */
+    protected $getAssignedStockIdForWebsite;
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    protected $storeManager;
+    /**
+     * @var \Magento\InventorySalesApi\Api\IsProductSalableInterface
+     */
+    protected $isProductSalable;
+
+    /**
+     * Product constructor.
+     * @param \Magento\InventorySalesApi\Model\GetAssignedStockIdForWebsiteInterface $getAssignedStockIdForWebsite
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\InventorySalesApi\Api\IsProductSalableInterface $isProductSalable
+     */
+    public function __construct(
+        \Magento\InventorySalesApi\Model\GetAssignedStockIdForWebsiteInterface $getAssignedStockIdForWebsite,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\InventorySalesApi\Api\IsProductSalableInterface $isProductSalable
+    ){
+        $this->getAssignedStockIdForWebsite = $getAssignedStockIdForWebsite;
+        $this->storeManager                 = $storeManager;
+        $this->isProductSalable             = $isProductSalable;
+    }
+    /**
+     * @param \Magento\Catalog\Model\Product $subject
+     * @param bool $result
+     */
+    public function afterIsSalable(
+        \Magento\Catalog\Model\Product $subject,
+        bool $result
+    ){
+        $currentWebsite = $this->storeManager->getWebsite();
+        if($currentWebsite){
+            $result = $this->isProductSalable->execute(
+                $subject->getSku(),
+                $this->getAssignedStockIdForWebsite->execute($currentWebsite->getCode())
+            );
+        }
+
+        return $result;
+    }
+}

--- a/app/code/Magento/InventoryCatalog/etc/di.xml
+++ b/app/code/Magento/InventoryCatalog/etc/di.xml
@@ -140,4 +140,8 @@
         <plugin name="adapt_verify_stock_to_negative_min_qty"
                 type="Magento\InventoryCatalog\Plugin\CatalogInventory\Model\Spi\StockStateProvider\AdaptVerifyStockToNegativeMinQtyPlugin"/>
     </type>
+    <type name="Magento\Catalog\Model\Product">
+        <plugin name="is_salable_product_multistock"
+                type="Magento\InventoryCatalog\Plugin\Catalog\Model\Product"/>
+    </type>
 </config>


### PR DESCRIPTION
Discover pluginization of isSaleable method on product model in Magento #2213

### Description (*)
Method isSalable of Magento\Catalog\Model\Product has tens of usages across Magento Core files and possibly multitude of other usages in existing third-party customization.

Currently, MSI does not introduce any plugin or other logic which would return correct value from this method given environment with multiple source setup.

### Fixed Issues (if relevant)
isSaleable returns true when ProductSalableQty is 0

### Manual testing scenarios (*)
For determining whether or not to show the add to cart buttons. However, we've found if we have 10 of an item and a customer orders 10 (a stock reservation is made making the salable quantity 0) but isSaleable still returns true.
