### PR TITLE
fix-skiped-test for magento-engcom/msi#1562

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/ShipOrderTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/ShipOrderTest.php
@@ -37,7 +37,6 @@ class ShipOrderTest extends \Magento\TestFramework\TestCase\WebapiAbstract
      */
     public function testConfigurableShipOrder()
     {
-        $this->markTestIncomplete('https://github.com/magento-engcom/msi/issues/1335');
         $productsQuantity = 1;
 
         /** @var \Magento\Sales\Model\Order $existingOrder */

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_configurable_product.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_configurable_product.php
@@ -51,6 +51,9 @@ $order->setIncrementId('100000001')
 $order->save();
 
 $qtyOrdered = 2;
+$simpleProductId = current($configurableProduct->getExtensionAttributes()->getConfigurableProductLinks());
+/** @var \Magento\Catalog\Api\Data\ProductInterface $simpleProduct */
+$simpleProduct = $productRepository->getById($simpleProductId);
 /** @var \Magento\Sales\Model\Order\Item $orderItem */
 $orderConfigurableItem = $objectManager->create(\Magento\Sales\Model\Order\Item::class);
 $orderConfigurableItem->setProductId($configurableProduct->getId())->setQtyOrdered($qtyOrdered);
@@ -60,6 +63,9 @@ $orderConfigurableItem->setRowTotal($configurableProduct->getPrice());
 $orderConfigurableItem->setParentItemId(null);
 $orderConfigurableItem->setProductType('configurable');
 $orderConfigurableItem->setOrder($order);
+$orderConfigurableItem->setProductOptions([
+    'simple_sku' => $simpleProduct->getSku()
+]);
 /** @var \Magento\Sales\Api\OrderItemRepositoryInterface $orderItemsRepository */
 $orderItemsRepository = $objectManager->create(\Magento\Sales\Api\OrderItemRepositoryInterface::class);
 // Configurable item must be present in database to have its real ID to set parent id of simple product.


### PR DESCRIPTION
### Description (*)
This test was failing with error 

> ] main.CRITICAL: The shipment couldn't be saved. {"exception":"[object] (Magento\\Framework\\Exception\\CouldNotSaveException(code: 0): The shipment couldn't be saved. at /home/nazar/sites/magento/msi/app/code/Magento/Sales/Model/Order/ShipmentRepository.php:150, Exception(code: 0): Notice: Undefined index: simple_sku in /home/nazar/sites/magento/msi/app/code/Magento/InventoryConfigurableProduct/Plugin/Sales/GetSkuFromOrderItem.php on line 36 at /home/nazar/sites/magento/msi/lib/internal/Magento/Framework/App/ErrorHandler.php:61)"} []


### Fixed Issues (if relevant)

1. magento-engcom/msi#1562: Magento.Sales.Service.V1.ShipOrderTest.testConfigurableShipOrder Web API test failure 
2. magento-engcom/msi#1603 Unskip Magento\Sales\Service\V1\ShipOrderTest::testConfigurableShipOrder test

### Manual testing scenarios (*)
Run WebAPI tests for Magento.Sales.Service.V1.ShipOrderTest.testConfigurableShipOrder (both, SOAP and REST)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
