### PR TITLE
Avoid querying inventory default stock view in storefront operations

### DIFF
--- a/app/code/Magento/InventoryIndexer/Model/ResourceModel/GetStockItemData.php
+++ b/app/code/Magento/InventoryIndexer/Model/ResourceModel/GetStockItemData.php
@@ -43,6 +43,8 @@ class GetStockItemData implements GetStockItemDataInterface
     /**
      * @param ResourceConnection $resource
      * @param StockIndexTableNameResolverInterface $stockIndexTableNameResolver
+     * @param DefaultStockProviderInterface $defaultStockProvider
+     * @param GetProductIdsBySkusInterface $getProductIdsBySkus
      */
     public function __construct(
         ResourceConnection $resource,

--- a/app/code/Magento/InventoryIndexer/Model/ResourceModel/GetStockItemData.php
+++ b/app/code/Magento/InventoryIndexer/Model/ResourceModel/GetStockItemData.php
@@ -75,7 +75,7 @@ class GetStockItemData implements GetStockItemDataInterface
                     GetStockItemDataInterface::QUANTITY => 'qty',
                     GetStockItemDataInterface::IS_SALABLE => 'stock_status',
                 ]
-            )->where('product_id' . ' = ?', $productId);
+            )->where('product_id = ?', $productId);
         } else {
             $stockItemTableName = $this->stockIndexTableNameResolver->execute($stockId);
             $select->from(

--- a/app/code/Magento/InventoryIndexer/Model/ResourceModel/GetStockItemData.php
+++ b/app/code/Magento/InventoryIndexer/Model/ResourceModel/GetStockItemData.php
@@ -12,6 +12,8 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\InventoryIndexer\Model\StockIndexTableNameResolverInterface;
 use Magento\InventorySalesApi\Model\GetStockItemDataInterface;
 use Magento\InventoryIndexer\Indexer\IndexStructure;
+use Magento\InventoryCatalogApi\Api\DefaultStockProviderInterface;
+use Magento\InventoryCatalogApi\Model\GetProductIdsBySkusInterface;
 
 /**
  * @inheritdoc
@@ -29,15 +31,29 @@ class GetStockItemData implements GetStockItemDataInterface
     private $stockIndexTableNameResolver;
 
     /**
+     * @var DefaultStockProviderInterface
+     */
+    private $defaultStockProvider;
+
+    /**
+     * @var GetProductIdsBySkusInterface
+     */
+    private $getProductIdsBySkus;
+
+    /**
      * @param ResourceConnection $resource
      * @param StockIndexTableNameResolverInterface $stockIndexTableNameResolver
      */
     public function __construct(
         ResourceConnection $resource,
-        StockIndexTableNameResolverInterface $stockIndexTableNameResolver
+        StockIndexTableNameResolverInterface $stockIndexTableNameResolver,
+        DefaultStockProviderInterface $defaultStockProvider,
+        GetProductIdsBySkusInterface $getProductIdsBySkus
     ) {
         $this->resource = $resource;
         $this->stockIndexTableNameResolver = $stockIndexTableNameResolver;
+        $this->defaultStockProvider = $defaultStockProvider;
+        $this->getProductIdsBySkus = $getProductIdsBySkus;
     }
 
     /**
@@ -45,18 +61,29 @@ class GetStockItemData implements GetStockItemDataInterface
      */
     public function execute(string $sku, int $stockId): ?array
     {
-        $stockItemTableName = $this->stockIndexTableNameResolver->execute($stockId);
-
         $connection = $this->resource->getConnection();
-        $select = $connection->select()
-            ->from(
+        $select = $connection->select();
+
+        if ($this->defaultStockProvider->getId() === $stockId) {
+            $productId = current($this->getProductIdsBySkus->execute([$sku]));
+            $stockItemTableName = $this->resource->getTableName('cataloginventory_stock_status');
+            $select->from(
+                $stockItemTableName,
+                [
+                    GetStockItemDataInterface::QUANTITY => 'qty',
+                    GetStockItemDataInterface::IS_SALABLE => 'stock_status',
+                ]
+            )->where('product_id' . ' = ?', $productId);
+        } else {
+            $stockItemTableName = $this->stockIndexTableNameResolver->execute($stockId);
+            $select->from(
                 $stockItemTableName,
                 [
                     GetStockItemDataInterface::QUANTITY => IndexStructure::QUANTITY,
                     GetStockItemDataInterface::IS_SALABLE => IndexStructure::IS_SALABLE,
                 ]
-            )
-            ->where(IndexStructure::SKU . ' = ?', $sku);
+            )->where(IndexStructure::SKU . ' = ?', $sku);
+        }
 
         try {
             if ($connection->isTableExists($stockItemTableName)) {


### PR DESCRIPTION
### Description (*)
This Pull Request is supposed to reduce the usage of `inventory_stock_1` database view in frontend operations. 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
