### PR TITLE
Correctly load order using increment_id while running reservation compensation from argument

### DIFF
--- a/app/code/Magento/InventoryReservationCli/Command/Input/GetReservationFromCompensationArgument.php
+++ b/app/code/Magento/InventoryReservationCli/Command/Input/GetReservationFromCompensationArgument.php
@@ -61,6 +61,8 @@ class GetReservationFromCompensationArgument
     }
 
     /**
+     * Parse CLI argument into order and order item information. 
+     *
      * @param string $argument
      * @return array
      * @throws InvalidArgumentException
@@ -76,6 +78,8 @@ class GetReservationFromCompensationArgument
     }
 
     /**
+     * Builds reservation model from given compensation input argument.
+     *
      * @param string $argument
      * @return ReservationInterface
      * @throws InvalidArgumentException
@@ -93,11 +97,15 @@ class GetReservationFromCompensationArgument
             ->setSku((string)$argumentParts['sku'])
             ->setQuantity((float)$argumentParts['quantity'])
             ->setStockId((int)$argumentParts['stock_id'])
-            ->setMetadata($this->serializer->serialize([
-                'event_type' => 'manual_compensation',
-                'object_type' => 'order',
-                'object_id' => $order->getEntityId(),
-            ]))
+            ->setMetadata(
+                $this->serializer->serialize(
+                    [
+                        'event_type' => 'manual_compensation',
+                        'object_type' => 'order',
+                        'object_id' => $order->getEntityId(),
+                    ]
+                )
+            )
             ->build();
     }
 }

--- a/app/code/Magento/InventoryReservationCli/Command/Input/GetReservationFromCompensationArgument.php
+++ b/app/code/Magento/InventoryReservationCli/Command/Input/GetReservationFromCompensationArgument.php
@@ -61,7 +61,7 @@ class GetReservationFromCompensationArgument
     }
 
     /**
-     * Parse CLI argument into order and order item information. 
+     * Parse CLI argument into order and order item information.
      *
      * @param string $argument
      * @return array

--- a/app/code/Magento/InventoryReservationCli/Command/Input/GetReservationFromCompensationArgument.php
+++ b/app/code/Magento/InventoryReservationCli/Command/Input/GetReservationFromCompensationArgument.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace Magento\InventoryReservationCli\Command\Input;
 
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\Validation\ValidationException;
 use Magento\InventoryReservationsApi\Model\ReservationBuilderInterface;
@@ -35,18 +37,27 @@ class GetReservationFromCompensationArgument
     private $serializer;
 
     /**
-     * @param OrderRepositoryInterface $orderRepository
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @param OrderRepositoryInterface    $orderRepository
      * @param ReservationBuilderInterface $reservationBuilder
-     * @param SerializerInterface $serializer
+     * @param SerializerInterface         $serializer
+     * @param SearchCriteriaBuilder|null  $searchCriteriaBuilder
      */
     public function __construct(
         OrderRepositoryInterface $orderRepository,
         ReservationBuilderInterface $reservationBuilder,
-        SerializerInterface $serializer
+        SerializerInterface $serializer,
+        SearchCriteriaBuilder $searchCriteriaBuilder = null
     ) {
         $this->orderRepository = $orderRepository;
         $this->reservationBuilder = $reservationBuilder;
         $this->serializer = $serializer;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder
+            ?: ObjectManager::getInstance()->get(SearchCriteriaBuilder::class);
     }
 
     /**
@@ -73,7 +84,10 @@ class GetReservationFromCompensationArgument
     public function execute(string $argument): ReservationInterface
     {
         $argumentParts = $this->parseArgument($argument);
-        $order = $this->orderRepository->get($argumentParts['increment_id']);
+        $results = $this->orderRepository->getList(
+            $this->searchCriteriaBuilder->addFilter('increment_id', $argumentParts['increment_id'], 'eq')->create()
+        );
+        $order = current($results->getItems());
 
         return $this->reservationBuilder
             ->setSku((string)$argumentParts['sku'])


### PR DESCRIPTION
### Description (*)
Load order using increment_id instead of entity_id when creating reservation compensation from argument.

### Fixed Issues (if relevant)
1. magento/inventory#2203: Reservations can not be compensated for the configurable product using CLI

### Manual testing scenarios (*)
1. Place order.
2. Delete reservation from the DB.
3. Run `bin/magento inventory:reservation:list-inconsistencies -r | bin/magento inventory:reservation:create-compensations`


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
