### PR TITLE
MSI-2428: Incorrect output for compensation amount.

### DIFF
--- a/app/code/Magento/InventoryReservationCli/Command/CreateCompensations.php
+++ b/app/code/Magento/InventoryReservationCli/Command/CreateCompensations.php
@@ -125,7 +125,7 @@ class CreateCompensations extends Command
                         '  - Product <comment>%s</comment> was compensated by '
                         . '<comment>%+f</comment> for stock <comment>%s</comment>',
                         $compensation->getSku(),
-                        -$compensation->getQuantity(),
+                        $compensation->getQuantity(),
                         $compensation->getStockId()
                     )
                 );

--- a/app/code/Magento/InventoryReservationCli/Command/CreateCompensations.php
+++ b/app/code/Magento/InventoryReservationCli/Command/CreateCompensations.php
@@ -83,6 +83,8 @@ class CreateCompensations extends Command
     }
 
     /**
+     * Get list of compensation arguments from command input
+     *
      * @param InputInterface $input
      * @return array
      * @throws InvalidArgumentException
@@ -103,7 +105,7 @@ class CreateCompensations extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      *
      * @param InputInterface $input
      * @param OutputInterface $output
@@ -134,17 +136,21 @@ class CreateCompensations extends Command
                 $output->writeln(sprintf(' - <error>%s</error>', $exception->getMessage()));
             } catch (InvalidArgumentException $exception) {
                 $hasErrors = true;
-                $output->writeln(sprintf(
-                    '  - <error>Error while parsing argument "%s". %s</error>',
-                    $compensationsArgument,
-                    $exception->getMessage()
-                ));
+                $output->writeln(
+                    sprintf(
+                        '  - <error>Error while parsing argument "%s". %s</error>',
+                        $compensationsArgument,
+                        $exception->getMessage()
+                    )
+                );
             } catch (\Exception $exception) {
-                $output->writeln(sprintf(
-                    '  - <error>Argument "%s" caused exception "%s"</error>',
-                    $compensationsArgument,
-                    $exception->getMessage()
-                ));
+                $output->writeln(
+                    sprintf(
+                        '  - <error>Argument "%s" caused exception "%s"</error>',
+                        $compensationsArgument,
+                        $exception->getMessage()
+                    )
+                );
             }
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fix incorrect "+" sign before qty number.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/inventory#2482: Incorrect output for compensation amount

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See steps from magento/inventory#2482: Incorrect output for compensation amount

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
