### PR TITLE
Filter out of stock products from search even if Elasticsearch is disabled

### DIFF
--- a/app/code/Magento/InventoryElasticsearch/composer.json
+++ b/app/code/Magento/InventoryElasticsearch/composer.json
@@ -6,7 +6,6 @@
         "magento/framework": "*",
         "magento/module-catalog-inventory": "*",
         "magento/module-catalog-search": "*",
-        "magento/module-elasticsearch": "*",
         "magento/module-inventory-catalog-api": "*",
         "magento/module-inventory-indexer": "*",
         "magento/module-inventory-sales-api": "*",


### PR DESCRIPTION
### Description (*)
Performance optimization done in the Magento core with the commit 9ab466d8569ea556cb01393989579c3aac53d9a3 did not account for Magento Inventory. Core plugin was adjusted to filter out of stock products for MySql search engine same as it was done for Elasticsearch.

Same inventory plugin `StockedProductFilterByInventoryStock` needed same type of maintenance to produce correct results.

