### PR TITLE
Eliminate group concat from source item indexer

### DIFF
--- a/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SourceItem/SiblingSkuListInStockProvider.php
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/Indexer/SourceItem/SiblingSkuListInStockProvider.php
@@ -32,10 +32,6 @@ class SiblingSkuListInStockProvider
     private $skuListInStockFactory;
 
     /**
-     * @var int
-     */
-    private $groupConcatMaxLen;
-    /**
      * @var MetadataPool
      */
     private $metadataPool;
@@ -56,7 +52,6 @@ class SiblingSkuListInStockProvider
      * @param ResourceConnection $resourceConnection
      * @param SkuListInStockFactory $skuListInStockFactory
      * @param MetadataPool $metadataPool
-     * @param int $groupConcatMaxLen
      * @param string $tableNameSourceItem
      * @param string $tableNameStockSourceLink
      */
@@ -64,13 +59,11 @@ class SiblingSkuListInStockProvider
         ResourceConnection $resourceConnection,
         SkuListInStockFactory $skuListInStockFactory,
         MetadataPool $metadataPool,
-        int $groupConcatMaxLen,
         $tableNameSourceItem,
         $tableNameStockSourceLink
     ) {
         $this->resourceConnection = $resourceConnection;
         $this->skuListInStockFactory = $skuListInStockFactory;
-        $this->groupConcatMaxLen = $groupConcatMaxLen;
         $this->metadataPool = $metadataPool;
         $this->tableNameSourceItem = $tableNameSourceItem;
         $this->tableNameStockSourceLink = $tableNameStockSourceLink;
@@ -91,15 +84,13 @@ class SiblingSkuListInStockProvider
 
         $metadata = $this->metadataPool->getMetadata(ProductInterface::class);
         $linkField = $metadata->getIdentifierField();
+        $items = [];
 
         $select = $connection
             ->select()
             ->from(
                 ['source_item' => $sourceItemTable],
-                [
-                    SourceItemInterface::SKU =>
-                        "GROUP_CONCAT(DISTINCT sibling_product_entity." . SourceItemInterface::SKU . " SEPARATOR ',')"
-                ]
+                [SourceItemInterface::SKU => 'sibling_product_entity.' . SourceItemInterface::SKU]
             )->joinInner(
                 ['stock_source_link' => $sourceStockLinkTable],
                 sprintf(
@@ -124,11 +115,17 @@ class SiblingSkuListInStockProvider
                 ['sibling_product_entity' => $this->resourceConnection->getTableName('catalog_product_entity')],
                 'sibling_product_entity.' . $linkField . ' = sibling_link.product_id',
                 []
-            )->where('source_item.source_item_id IN (?)', $sourceItemIds)
-            ->group(['stock_source_link.' . StockSourceLinkInterface::STOCK_ID]);
+            )->where(
+                'source_item.source_item_id IN (?)',
+                $sourceItemIds
+            );
 
-        $connection->query('SET group_concat_max_len = ' . $this->groupConcatMaxLen);
-        $items = $connection->fetchAll($select);
+        $dbStatement = $connection->query($select);
+        while ($item = $dbStatement->fetch()) {
+            $items[$item[StockSourceLinkInterface::STOCK_ID]][$item[SourceItemInterface::SKU]] =
+                $item[SourceItemInterface::SKU];
+        }
+
         return $this->getStockIdToSkuList($items);
     }
 
@@ -141,11 +138,11 @@ class SiblingSkuListInStockProvider
     private function getStockIdToSkuList(array $items): array
     {
         $skuListInStockList = [];
-        foreach ($items as $item) {
+        foreach ($items as $stockId => $skuList) {
             /** @var SkuListInStock $skuListInStock */
             $skuListInStock = $this->skuListInStockFactory->create();
-            $skuListInStock->setStockId((int)$item[StockSourceLinkInterface::STOCK_ID]);
-            $skuListInStock->setSkuList(explode(',', $item[SourceItemInterface::SKU]));
+            $skuListInStock->setStockId((int)$stockId);
+            $skuListInStock->setSkuList($skuList);
             $skuListInStockList[] = $skuListInStock;
         }
         return $skuListInStockList;

--- a/app/code/Magento/InventoryConfigurableProductIndexer/etc/di.xml
+++ b/app/code/Magento/InventoryConfigurableProductIndexer/etc/di.xml
@@ -27,7 +27,6 @@
     </type>
     <type name="Magento\InventoryConfigurableProductIndexer\Indexer\SourceItem\SiblingSkuListInStockProvider">
         <arguments>
-            <argument name="groupConcatMaxLen" xsi:type="number">2000</argument>
             <argument name="tableNameSourceItem" xsi:type="const">Magento\Inventory\Model\ResourceModel\SourceItem::TABLE_NAME_SOURCE_ITEM</argument>
             <argument name="tableNameStockSourceLink" xsi:type="const">Magento\Inventory\Model\ResourceModel\StockSourceLink::TABLE_NAME_STOCK_SOURCE_LINK</argument>
         </arguments>

--- a/app/code/Magento/InventoryGroupedProductIndexer/Indexer/SourceItem/SiblingSkuListInStockProvider.php
+++ b/app/code/Magento/InventoryGroupedProductIndexer/Indexer/SourceItem/SiblingSkuListInStockProvider.php
@@ -33,10 +33,6 @@ class SiblingSkuListInStockProvider
     private $skuListInStockFactory;
 
     /**
-     * @var int
-     */
-    private $groupConcatMaxLen;
-    /**
      * @var MetadataPool
      */
     private $metadataPool;
@@ -52,12 +48,9 @@ class SiblingSkuListInStockProvider
     private $tableNameStockSourceLink;
 
     /**
-     * GetSkuListInStock constructor.
-     *
      * @param ResourceConnection $resourceConnection
      * @param SkuListInStockFactory $skuListInStockFactory
      * @param MetadataPool $metadataPool
-     * @param int $groupConcatMaxLen
      * @param string $tableNameSourceItem
      * @param string $tableNameStockSourceLink
      */
@@ -65,13 +58,11 @@ class SiblingSkuListInStockProvider
         ResourceConnection $resourceConnection,
         SkuListInStockFactory $skuListInStockFactory,
         MetadataPool $metadataPool,
-        int $groupConcatMaxLen,
         $tableNameSourceItem,
         $tableNameStockSourceLink
     ) {
         $this->resourceConnection = $resourceConnection;
         $this->skuListInStockFactory = $skuListInStockFactory;
-        $this->groupConcatMaxLen = $groupConcatMaxLen;
         $this->metadataPool = $metadataPool;
         $this->tableNameSourceItem = $tableNameSourceItem;
         $this->tableNameStockSourceLink = $tableNameStockSourceLink;
@@ -92,15 +83,13 @@ class SiblingSkuListInStockProvider
 
         $metadata = $this->metadataPool->getMetadata(ProductInterface::class);
         $linkField = $metadata->getIdentifierField();
+        $items = [];
 
         $select = $connection
             ->select()
             ->from(
                 ['source_item' => $sourceItemTable],
-                [
-                    SourceItemInterface::SKU =>
-                        "GROUP_CONCAT(DISTINCT sibling_product_entity." . SourceItemInterface::SKU . " SEPARATOR ',')"
-                ]
+                [SourceItemInterface::SKU => 'sibling_product_entity.' . SourceItemInterface::SKU]
             )->joinInner(
                 ['stock_source_link' => $sourceStockLinkTable],
                 sprintf(
@@ -127,11 +116,16 @@ class SiblingSkuListInStockProvider
                 ['sibling_product_entity' => $this->resourceConnection->getTableName('catalog_product_entity')],
                 'sibling_product_entity.' . $linkField . ' = sibling_link.linked_product_id',
                 []
-            )->where('source_item.source_item_id IN (?)', $sourceItemIds)
-            ->group(['stock_source_link.' . StockSourceLinkInterface::STOCK_ID]);
+            )->where(
+                'source_item.source_item_id IN (?)',
+                $sourceItemIds
+            );
 
-        $connection->query('SET group_concat_max_len = ' . $this->groupConcatMaxLen);
-        $items = $connection->fetchAll($select);
+        $dbStatement = $connection->query($select);
+        while ($item = $dbStatement->fetch()) {
+            $items[$item[StockSourceLinkInterface::STOCK_ID]][$item[SourceItemInterface::SKU]] =
+                $item[SourceItemInterface::SKU];
+        }
 
         return $this->getStockIdToSkuList($items);
     }
@@ -145,11 +139,11 @@ class SiblingSkuListInStockProvider
     private function getStockIdToSkuList(array $items): array
     {
         $skuListInStockList = [];
-        foreach ($items as $item) {
+        foreach ($items as $stockId => $skuList) {
             /** @var SkuListInStock $skuListInStock */
             $skuListInStock = $this->skuListInStockFactory->create();
-            $skuListInStock->setStockId((int)$item[StockSourceLinkInterface::STOCK_ID]);
-            $skuListInStock->setSkuList(explode(',', $item[SourceItemInterface::SKU]));
+            $skuListInStock->setStockId((int)$stockId);
+            $skuListInStock->setSkuList($skuList);
             $skuListInStockList[] = $skuListInStock;
         }
         return $skuListInStockList;

--- a/app/code/Magento/InventoryGroupedProductIndexer/etc/di.xml
+++ b/app/code/Magento/InventoryGroupedProductIndexer/etc/di.xml
@@ -27,7 +27,6 @@
     </type>
     <type name="Magento\InventoryGroupedProductIndexer\Indexer\SourceItem\SiblingSkuListInStockProvider">
         <arguments>
-            <argument name="groupConcatMaxLen" xsi:type="number">2000</argument>
             <argument name="tableNameSourceItem" xsi:type="const">Magento\Inventory\Model\ResourceModel\SourceItem::TABLE_NAME_SOURCE_ITEM</argument>
             <argument name="tableNameStockSourceLink" xsi:type="const">Magento\Inventory\Model\ResourceModel\StockSourceLink::TABLE_NAME_STOCK_SOURCE_LINK</argument>
         </arguments>

--- a/app/code/Magento/InventoryIndexer/Indexer/SourceItem/GetSkuListInStock.php
+++ b/app/code/Magento/InventoryIndexer/Indexer/SourceItem/GetSkuListInStock.php
@@ -29,25 +29,15 @@ class GetSkuListInStock
     private $skuListInStockFactory;
 
     /**
-     * @var int
-     */
-    private $groupConcatMaxLen;
-
-    /**
-     * GetSkuListInStock constructor.
-     *
      * @param ResourceConnection $resourceConnection
      * @param SkuListInStockFactory $skuListInStockFactory
-     * @param int $groupConcatMaxLen
      */
     public function __construct(
         ResourceConnection $resourceConnection,
-        SkuListInStockFactory $skuListInStockFactory,
-        int $groupConcatMaxLen
+        SkuListInStockFactory $skuListInStockFactory
     ) {
         $this->resourceConnection = $resourceConnection;
         $this->skuListInStockFactory = $skuListInStockFactory;
-        $this->groupConcatMaxLen = $groupConcatMaxLen;
     }
 
     /**
@@ -65,15 +55,13 @@ class GetSkuListInStock
         $sourceItemTable = $this->resourceConnection->getTableName(
             SourceItemResourceModel::TABLE_NAME_SOURCE_ITEM
         );
+        $items = [];
 
         $select = $connection
             ->select()
             ->from(
                 ['source_item' => $sourceItemTable],
-                [
-                    SourceItemInterface::SKU =>
-                        sprintf("GROUP_CONCAT(DISTINCT %s SEPARATOR ',')", 'source_item.' . SourceItemInterface::SKU)
-                ]
+                [SourceItemInterface::SKU => 'source_item.' . SourceItemInterface::SKU]
             )->joinInner(
                 ['stock_source_link' => $sourceStockLinkTable],
                 sprintf(
@@ -82,11 +70,16 @@ class GetSkuListInStock
                     StockSourceLink::SOURCE_CODE
                 ),
                 [StockSourceLink::STOCK_ID]
-            )->where('source_item.source_item_id IN (?)', $sourceItemIds)
-            ->group(['stock_source_link.' . StockSourceLink::STOCK_ID]);
+            )->where(
+                'source_item.source_item_id IN (?)',
+                $sourceItemIds
+            );
 
-        $connection->query('SET group_concat_max_len = ' . $this->groupConcatMaxLen);
-        $items = $connection->fetchAll($select);
+        $dbStatement = $connection->query($select);
+        while ($item = $dbStatement->fetch()) {
+            $items[$item[StockSourceLink::STOCK_ID]][$item[SourceItemInterface::SKU]] = $item[SourceItemInterface::SKU];
+        }
+
         return $this->getStockIdToSkuList($items);
     }
 
@@ -99,11 +92,11 @@ class GetSkuListInStock
     private function getStockIdToSkuList(array $items): array
     {
         $skuListInStockList = [];
-        foreach ($items as $item) {
+        foreach ($items as $stockId => $skuList) {
             /** @var SkuListInStock $skuListInStock */
             $skuListInStock = $this->skuListInStockFactory->create();
-            $skuListInStock->setStockId((int)$item[StockSourceLink::STOCK_ID]);
-            $skuListInStock->setSkuList(explode(',', $item[SourceItemInterface::SKU]));
+            $skuListInStock->setStockId((int)$stockId);
+            $skuListInStock->setSkuList($skuList);
             $skuListInStockList[] = $skuListInStock;
         }
         return $skuListInStockList;

--- a/app/code/Magento/InventoryIndexer/etc/di.xml
+++ b/app/code/Magento/InventoryIndexer/etc/di.xml
@@ -25,11 +25,6 @@
             <argument name="indexHandler" xsi:type="object">Magento\InventoryIndexer\Indexer\IndexHandler</argument>
         </arguments>
     </type>
-    <type name="Magento\InventoryIndexer\Indexer\SourceItem\GetSkuListInStock">
-        <arguments>
-            <argument name="groupConcatMaxLen" xsi:type="number">2000</argument>
-        </arguments>
-    </type>
     <type name="Magento\InventoryIndexer\Model\ResourceModel\GetProductIdsBySourceItemIds">
         <arguments>
             <argument name="productTableName" xsi:type="string">catalog_product_entity</argument>

--- a/app/code/Magento/InventoryReservations/etc/di.xml
+++ b/app/code/Magento/InventoryReservations/etc/di.xml
@@ -13,7 +13,7 @@
     <preference for="Magento\InventoryReservationsApi\Model\GetReservationsQuantityInterface" type="Magento\InventoryReservations\Model\ResourceModel\GetReservationsQuantity"/>
     <type name="Magento\InventoryReservations\Model\ResourceModel\CleanupReservations">
         <arguments>
-            <argument name="groupConcatMaxLen" xsi:type="number">2000</argument>
+            <argument name="groupConcatMaxLen" xsi:type="number">32768</argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
### Description (*)
Using GROUP CONCAT with predefined maximum length may cause intermittent issues with building source item index. Longer skus may cause limit to be exceeded causing errors in index data.

This pull request eliminates this logic and replaces it with grouping on the php side instead of database side. 

