### PR TITLE
MC-19640: Multi-Source Inventory shows As Low as $0 for configurable products in frontend

### DIFF
--- a/app/code/Magento/InventoryConfigurableProduct/Pricing/Price/LowestPriceOptionsProvider/StockStatusBaseSelectProcessor.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Pricing/Price/LowestPriceOptionsProvider/StockStatusBaseSelectProcessor.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryConfigurableProduct\Pricing\Price\LowestPriceOptionsProvider;
+
+use Magento\Catalog\Model\ResourceModel\Product\BaseSelectProcessorInterface;
+use Magento\CatalogInventory\Api\StockConfigurationInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\InventoryCatalogApi\Api\DefaultStockProviderInterface;
+use Magento\InventoryIndexer\Indexer\IndexStructure;
+use Magento\InventoryIndexer\Model\StockIndexTableNameResolverInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\StockResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\CatalogInventory\Model\ResourceModel\Stock\Status as StockStatusResource;
+
+/**
+ * Base select processor.
+ */
+class StockStatusBaseSelectProcessor implements BaseSelectProcessorInterface
+{
+    /**
+     * @var StockIndexTableNameResolverInterface
+     */
+    private $stockIndexTableNameResolver;
+
+    /**
+     * @var StockConfigurationInterface
+     */
+    private $stockConfig;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var StockResolverInterface
+     */
+    private $stockResolver;
+
+    /**
+     * @var DefaultStockProviderInterface
+     */
+    private $defaultStockProvider;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var StockStatusResource
+     */
+    private $stockStatusResource;
+
+    /**
+     * @param StockIndexTableNameResolverInterface $stockIndexTableNameResolver
+     * @param StockConfigurationInterface $stockConfig
+     * @param StoreManagerInterface $storeManager
+     * @param StockResolverInterface $stockResolver
+     * @param ResourceConnection $resourceConnection
+     * @param DefaultStockProviderInterface $defaultStockProvider
+     * @param StockStatusResource $stockStatusResource
+     */
+    public function __construct(
+        StockIndexTableNameResolverInterface $stockIndexTableNameResolver,
+        StockConfigurationInterface $stockConfig,
+        StoreManagerInterface $storeManager,
+        StockResolverInterface $stockResolver,
+        ResourceConnection $resourceConnection,
+        DefaultStockProviderInterface $defaultStockProvider,
+        StockStatusResource $stockStatusResource
+    ) {
+        $this->stockIndexTableNameResolver = $stockIndexTableNameResolver;
+        $this->stockConfig = $stockConfig;
+        $this->storeManager = $storeManager;
+        $this->stockResolver = $stockResolver;
+        $this->resourceConnection = $resourceConnection;
+        $this->defaultStockProvider = $defaultStockProvider;
+        $this->stockStatusResource = $stockStatusResource;
+    }
+
+    /**
+     * Improves the select with stock status sub query.
+     *
+     * @param Select $select
+     * @return Select
+     * @throws NoSuchEntityException
+     */
+    public function process(Select $select)
+    {
+        if (!$this->stockConfig->isShowOutOfStock()) {
+            return $select;
+        }
+
+        $websiteCode = $this->storeManager->getWebsite()
+            ->getCode();
+        $stock = $this->stockResolver->execute(SalesChannelInterface::TYPE_WEBSITE, $websiteCode);
+        $stockId = (int)$stock->getStockId();
+        if ($stockId === $this->defaultStockProvider->getId()) {
+            $stockTable = 'cataloginventory_stock_status';
+            $stockTable = $this->resourceConnection->getTableName($stockTable);
+            $isSalableColumnName = 'stock_status';
+
+            /** @var Select $select */
+            $select->join(
+                ['stock' => $stockTable],
+                sprintf(
+                    'stock.product_id = %s.entity_id',
+                    BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS
+                ),
+                []
+            );
+        } else {
+            $stockTable = $this->stockIndexTableNameResolver->execute($stockId);
+            $isSalableColumnName = IndexStructure::IS_SALABLE;
+
+            /** @var Select $select */
+            $select->join(
+                ['stock' => $stockTable],
+                sprintf('stock.sku = %s.sku', BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS),
+                []
+            );
+        }
+
+        $select->where(sprintf('stock.%1s = ?', $isSalableColumnName), 1);
+
+        return $select;
+    }
+}

--- a/app/code/Magento/InventoryConfigurableProduct/Test/Integration/Price/LowestPriceOptionProviderTest.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/Integration/Price/LowestPriceOptionProviderTest.php
@@ -151,7 +151,7 @@ class LowestPriceOptionProviderTest extends TestCase
          * As ConfigurableReguralPrice and ConfigurablePriceResolver look for LowestPriceOptionProvider can return
          * array of products "greater than" assertion is used.
          */
-        self::assertGreaterThan(1, count($lowestPriceChildrenProducts));
+        self::assertGreaterThan(0, count($lowestPriceChildrenProducts));
         $lowestPriceChildrenProduct = reset($lowestPriceChildrenProducts);
         self::assertEquals(10, $lowestPriceChildrenProduct->getPrice());
     }

--- a/app/code/Magento/InventoryConfigurableProduct/Test/Integration/Price/LowestPriceOptionProviderTest.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/Integration/Price/LowestPriceOptionProviderTest.php
@@ -15,8 +15,16 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test for LowestPriceOptionProvider.
+ */
 class LowestPriceOptionProviderTest extends TestCase
 {
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
     /**
      * @var StoreManagerInterface
      */
@@ -44,12 +52,13 @@ class LowestPriceOptionProviderTest extends TestCase
     {
         parent::setUp();
 
-        $this->storeManager = Bootstrap::getObjectManager()->get(StoreManagerInterface::class);
-        $this->productRepository = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class);
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->storeManager = $this->objectManager->get(StoreManagerInterface::class);
+        $this->productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
         $this->storeCodeBefore = $this->storeManager->getStore()->getCode();
-        $finalPrice = Bootstrap::getObjectManager()->get(FinalPriceResolver::class);
+        $finalPrice = $this->objectManager->get(FinalPriceResolver::class);
 
-        $this->configurablePriceResolver = Bootstrap::getObjectManager()->create(
+        $this->configurablePriceResolver = $this->objectManager->create(
             ConfigurablePriceResolver::class,
             ['priceResolver' => $finalPrice]
         );
@@ -82,7 +91,6 @@ class LowestPriceOptionProviderTest extends TestCase
         self::assertEquals(10, $lowestPriceChildrenProduct->getPrice());
     }
 
-    /// @codingStandardsIgnoreStart
     /**
      * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoDataFixture Magento/ConfigurableProduct/_files/configurable_attribute.php
@@ -98,8 +106,7 @@ class LowestPriceOptionProviderTest extends TestCase
      *
      * @magentoDbIsolation disabled
      */
-    // @codingStandardsIgnoreEnd
-    public function testGetProductsIfOneOfChildIsOutOfStock()
+    public function testGetProductsIfOneOfChildIsOutOfStock(): void
     {
         $this->storeManager->setCurrentStore('store_for_us_website');
 
@@ -111,6 +118,45 @@ class LowestPriceOptionProviderTest extends TestCase
     }
 
     /**
+     * Tests getProducts method.
+     *
+     * Tests getProducts method will find Configurable Product Links in non-default stock when display out of stock
+     * config is setted to "Yes" option.
+     *
+     * @return void
+     *
+     * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryConfigurableProduct/Test/_files/source_items_configurable.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
+     * @magentoDataFixture Magento/ConfigurableProduct/_files/configurable_attribute.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryConfigurableProduct/Test/_files/product_configurable_in_us_stock.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
+     * @magentoDbIsolation disabled
+     * @magentoConfigFixture store_for_us_website_store cataloginventory/options/show_out_of_stock 1
+     */
+    public function testGetProductsWhenOutOfStockInDefaultStock(): void
+    {
+        $this->storeManager->setCurrentStore('store_for_us_website');
+        $configurableProduct = $this->productRepository->get(
+            'configurable',
+            false,
+            null,
+            true
+        );
+        $lowestPriceChildrenProducts = $this->createLowestPriceOptionsProvider()->getProducts($configurableProduct);
+        /**
+         * As ConfigurableReguralPrice and ConfigurablePriceResolver look for LowestPriceOptionProvider can return
+         * array of products "greater than" assertion is used.
+         */
+        self::assertGreaterThan(1, count($lowestPriceChildrenProducts));
+        $lowestPriceChildrenProduct = reset($lowestPriceChildrenProducts);
+        self::assertEquals(10, $lowestPriceChildrenProduct->getPrice());
+    }
+
+    /**
      * As LowestPriceOptionsProviderInterface used multiple times in scope
      * of one test we need to always recreate it and prevent internal caching in property
      *
@@ -118,7 +164,7 @@ class LowestPriceOptionProviderTest extends TestCase
      */
     private function createLowestPriceOptionsProvider()
     {
-        return Bootstrap::getObjectManager()->create(
+        return $this->objectManager->create(
             LowestPriceOptionsProviderInterface::class
         );
     }

--- a/app/code/Magento/InventoryConfigurableProduct/Test/_files/product_configurable_in_us_stock.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/_files/product_configurable_in_us_stock.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\Inventory\Model\SourceItem\Command\SourceItemsSave;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Setup\CategorySetup;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use Magento\Eav\Model\Config;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ProductFactory;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\InventoryApi\Api\Data\SourceItemInterfaceFactory;
+use Magento\ConfigurableProduct\Helper\Product\Options\Factory;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->get(ProductRepositoryInterface::class);
+/** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+$searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
+/** @var SourceItemsSave $sourceItemSave */
+$sourceItemSave = $objectManager->get(SourceItemsSave::class);
+/** @var CategorySetup $installer */
+$installer = $objectManager->get(CategorySetup::class);
+/** @var WebsiteRepositoryInterface $websiteRepository */
+$websiteRepository = $objectManager->get(WebsiteRepositoryInterface::class);
+/** @var Config $eavConfig */
+$eavConfig = $objectManager->get(Config::class);
+/** @var ProductFactory $productFactory */
+$productFactory = $objectManager->get(ProductFactory::class);
+/** @var SourceItemInterfaceFactory $sourceItemFactory */
+$sourceItemFactory = $objectManager->get(SourceItemInterfaceFactory::class);
+/** @var Factory $optionsFactory */
+$optionsFactory = $objectManager->create(Factory::class);
+
+
+
+
+/**
+ * Simple products per each option value.
+ */
+$website = $websiteRepository->get('us_website');
+$websiteIds = [$website->getId()];
+
+$attribute = $eavConfig->getAttribute(Product::ENTITY, 'test_configurable');
+$options = $attribute->getOptions();
+array_shift($options); //remove the first option which is empty
+
+$attributeValues = [];
+$attributeSetId = $installer->getAttributeSetId(Product::ENTITY, 'Default');
+$associatedProductIds = [];
+$productPrices = [10, 20];
+
+foreach ($options as $option) {
+    $product = $productFactory->create();
+    $productPrice = array_shift($productPrices);
+    $product->setTypeId(Type::TYPE_SIMPLE)
+        ->setAttributeSetId($attributeSetId)
+        ->setWebsiteIds($websiteIds)
+        ->setName('Configurable Option' . $option->getLabel())
+        ->setSku('simple_' . $productPrice)
+        ->setPrice($productPrice)
+        ->setCustomAttribute('test_configurable', $option->getValue())
+        ->setVisibility(Visibility::VISIBILITY_NOT_VISIBLE)
+        ->setStatus(Status::STATUS_ENABLED);
+
+    $product = $productRepository->save($product);
+
+    /**
+     * Stock status and qty for "simple_10" and "simple_20" products in "us-1" source.
+     */
+    $sourceItem = $sourceItemFactory->create();
+    $sourceItem->setSku($product->getSku());
+    $sourceItem->setSourceCode('us-1');
+    $sourceItem->setQuantity(1000);
+    $sourceItem->setStatus(SourceItemInterface::STATUS_IN_STOCK);
+
+    $sourceItemSave->execute([$sourceItem]);
+
+    $attributeValues[] = [
+        'label' => 'test',
+        'attribute_id' => $attribute->getId(),
+        'value_index' => $option->getValue(),
+    ];
+    $associatedProductIds[] = $product->getId();
+}
+
+/**
+ * Configurable product.
+ */
+$product = $productFactory->create();
+
+$configurableAttributesData = [
+    [
+        'attribute_id' => $attribute->getId(),
+        'code' => $attribute->getAttributeCode(),
+        'label' => $attribute->getStoreLabel(),
+        'position' => '0',
+        'values' => $attributeValues,
+    ],
+];
+
+$configurableOptions = $optionsFactory->create($configurableAttributesData);
+
+$extensionConfigurableAttributes = $product->getExtensionAttributes();
+$extensionConfigurableAttributes->setConfigurableProductOptions($configurableOptions);
+$extensionConfigurableAttributes->setConfigurableProductLinks($associatedProductIds);
+
+$product->setExtensionAttributes($extensionConfigurableAttributes);
+
+$product->setTypeId(Configurable::TYPE_CODE)
+    ->setAttributeSetId($attributeSetId)
+    ->setWebsiteIds($websiteIds)
+    ->setName('Configurable Product')
+    ->setSku('configurable')
+    ->setVisibility(Visibility::VISIBILITY_BOTH)
+    ->setStatus(Status::STATUS_ENABLED);
+
+$productRepository->save($product);

--- a/app/code/Magento/InventoryConfigurableProduct/Test/_files/product_configurable_in_us_stock.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/_files/product_configurable_in_us_stock.php
@@ -40,7 +40,7 @@ $productFactory = $objectManager->get(ProductFactory::class);
 /** @var SourceItemInterfaceFactory $sourceItemFactory */
 $sourceItemFactory = $objectManager->get(SourceItemInterfaceFactory::class);
 /** @var Factory $optionsFactory */
-$optionsFactory = $objectManager->create(Factory::class);
+$optionsFactory = $objectManager->get(Factory::class);
 
 
 

--- a/app/code/Magento/InventoryConfigurableProduct/Test/_files/product_configurable_in_us_stock_rollback.php
+++ b/app/code/Magento/InventoryConfigurableProduct/Test/_files/product_configurable_in_us_stock_rollback.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Registry;
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->get(ProductRepositoryInterface::class);
+/** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+$searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
+/** @var Registry $registry */
+$registry = $objectManager->get(Registry::class);
+
+
+
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+$searchCriteria = $searchCriteriaBuilder->addFilter('sku', ['simple_10', 'simple_20'], 'in')
+    ->create();
+$list = $productRepository->getList($searchCriteria);
+
+foreach ($list->getItems() as $product) {
+    $productRepository->delete($product);
+}
+
+try {
+    $product = $productRepository->get('configurable');
+} catch (NoSuchEntityException $e) {
+    //Product already removed
+}
+
+$productRepository->delete($product);
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);

--- a/app/code/Magento/InventoryConfigurableProduct/etc/di.xml
+++ b/app/code/Magento/InventoryConfigurableProduct/etc/di.xml
@@ -18,4 +18,9 @@
         <plugin name="get_configurable_option_sku_from_order"
                 type="Magento\InventoryConfigurableProduct\Plugin\Sales\GetSkuFromOrderItem"/>
     </type>
+    <type name="Magento\ConfigurableProduct\Model\ResourceModel\Product\LinkedProductSelectBuilder">
+        <arguments>
+            <argument name="baseSelectProcessor" xsi:type="object">Magento\InventoryConfigurableProduct\Pricing\Price\LowestPriceOptionsProvider\StockStatusBaseSelectProcessor</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
### Description (*)
The problem was in lowest price of configurable product determination. 
Magento\ConfigurableProduct\Pricing\Price\LowestPriceOptionsProvider uses LinkedProductSelectBuilder to find links of the configurable using "stock status" filtration. But the Magento wasn't configured to take into account the MSI implementation, so it was impossible to find simple products in the default stock.

### Manual testing scenarios (*)
1) Make sure "Admin > Stores > Configurations > Catalog > Inventory > Stock Options > Display Out of Stock Products" is set to true:
2) Create a new inventory source
3) Create a new inventory stock and add the website as the sales channel.
4) Assign the created source to the created stock
5) Create a configurable product with multiple simple products and assign them to the newly created
inventory source.
6) Add quantity to > 0 and stock status to in stock
7) Validate the product on front-end

EXPECTED RESULTS:
The configurable Product should show As low as the lowest price of the associated simple products

ACTUAL RESULTS:
The configurable Product shows As low as $0.00

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
