### PR TITLE
Optimize GetStockItemData service to avoid repeating SHOW TABLE queries

### DIFF
--- a/app/code/Magento/InventoryIndexer/Model/ResourceModel/GetStockItemData.php
+++ b/app/code/Magento/InventoryIndexer/Model/ResourceModel/GetStockItemData.php
@@ -76,6 +76,8 @@ class GetStockItemData implements GetStockItemDataInterface
                     GetStockItemDataInterface::IS_SALABLE => 'stock_status',
                 ]
             )->where('product_id = ?', $productId);
+
+            return $connection->fetchRow($select) ?: null;
         } else {
             $stockItemTableName = $this->stockIndexTableNameResolver->execute($stockId);
             $select->from(
@@ -85,18 +87,16 @@ class GetStockItemData implements GetStockItemDataInterface
                     GetStockItemDataInterface::IS_SALABLE => IndexStructure::IS_SALABLE,
                 ]
             )->where(IndexStructure::SKU . ' = ?', $sku);
-        }
 
-        try {
-            if ($connection->isTableExists($stockItemTableName)) {
-                return $connection->fetchRow($select) ?: null;
+            try {
+                if ($connection->isTableExists($stockItemTableName)) {
+                    return $connection->fetchRow($select) ?: null;
+                }
+
+                return null;
+            } catch (\Exception $e) {
+                throw new LocalizedException(__('Could not receive Stock Item data'), $e);
             }
-
-            return null;
-        } catch (\Exception $e) {
-            throw new LocalizedException(__(
-                'Could not receive Stock Item data'
-            ), $e);
         }
     }
 }


### PR DESCRIPTION
### Description (*)
Service `\Magento\InventoryIndexer\Model\ResourceModel\GetStockItemData` makes redundant `SHOW TABLE` queries in situation where Magento is working in single stock mode. This does not make any sense and may be safely refactored to execute this check only on custom stocks.

### Fixed Issues (if relevant)
* Not reported

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
