### PR TITLE
Fixed #876 Added name to the unique field list

### DIFF
--- a/app/code/Magento/Inventory/Model/ResourceModel/Stock.php
+++ b/app/code/Magento/Inventory/Model/ResourceModel/Stock.php
@@ -33,5 +33,11 @@ class Stock extends AbstractDb
     protected function _construct()
     {
         $this->_init(self::TABLE_NAME_STOCK, StockInterface::STOCK_ID);
+        $this->addUniqueField(
+            [
+                'field' => StockInterface::NAME,
+                'title' => 'Name'
+            ]
+        );
     }
 }


### PR DESCRIPTION
### Description
Added the stock name to the list of unique fields so its not possible to use the same name twice

### Fixed Issues
1. magento/inventory#876: Make Stock Name field unique.

### Manual testing scenarios
1. Got to the Backend and create a Stock
2. Create another Stock
3. **Result** Both are working
4. Edit one of the stocks for example assign it to a website
5. **Result** Editing works like expected
6. Create another Stock with the same name like in Step 1 or 2
7. **Result** An error appeare