### PR TITLE
Fixed #2579 removed previouse region from region text field on countr…

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -199,6 +199,7 @@ define([
                 label.attr('for', regionList.attr('id'));
             } else {
                 this._removeSelectOptions(regionList);
+                $(this.options.regionInputId).val('');
 
                 if (this.options.isRegionRequired) {
                     regionInput.addClass('required-entry').removeAttr('disabled');


### PR DESCRIPTION
### Description
The previouse region should be cleand if an country with no region will be selected.

### Fixed Issues
1. magento/inventory#2579: Customer address get the region of the previouse country when no region available

### Manual testing scenarios
1. Create a customer with an address in United States and a region
2. Go to the customer and change the address to a country without region
3. **Result** The region should be an empty text field
