### PR TITLE
MC-23216: Unable to create Credit Memo

### DIFF
--- a/app/code/Magento/InventorySourceSelectionApi/Test/Integration/GetDefaultSortedSourcesResultTest.php
+++ b/app/code/Magento/InventorySourceSelectionApi/Test/Integration/GetDefaultSortedSourcesResultTest.php
@@ -160,10 +160,12 @@ class GetDefaultSortedSourcesResultTest extends TestCase
             $requestItems[] = $this->itemRequestFactory->create($requestItemData);
         }
 
-        $inventoryRequest = $this->inventoryRequestFactory->create([
-            'stockId' => $stockId,
-            'items'   => $requestItems
-        ]);
+        $inventoryRequest = $this->inventoryRequestFactory->create(
+            [
+                'stockId' => $stockId,
+                'items'   => $requestItems
+            ]
+        );
 
         $sortedSources = [];
         foreach ($sortedSourcesCodes as $sortedSourceCode) {
@@ -184,5 +186,29 @@ class GetDefaultSortedSourcesResultTest extends TestCase
             self::assertSame((float) $expected[$key]['deduct'], $selectionItem->getQtyToDeduct());
             self::assertSame((float) $expected[$key]['avail'], $selectionItem->getQtyAvailable());
         }
+    }
+
+    /**
+     * Check that "Undefined index" exception is not thrown when SKU case does not match
+     *
+     * SKU is not updated in source item table if the new SKU value is insensitively equal to the old value
+     *
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
+     */
+    public function testShouldNotThrowExceptionIfSkuCaseDoesNotMatch()
+    {
+        $requestItems[] = $this->itemRequestFactory->create(['sku' => 'sku-1', 'qty' => 15]);
+        $inventoryRequest = $this->inventoryRequestFactory->create(
+            [
+                'stockId' => 10,
+                'items'   => $requestItems
+            ]
+        );
+        $sortedSources = [];
+        $sortedSources[] = $this->sourceRepository->get('eu-1');
+        $this->assertNotNull($this->subject->execute($inventoryRequest, $sortedSources));
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
#### Unable to create Credit Memo

Problem: SKU is not updated in source item table if the new SKU value is insensitively equal to the old value (_e.g old value: Test, new value: TEST_). This is due to the collation of _sku_ column.

Solution: There are several ways to fix this issue. Here are some:

- Update existing source item record to match the actual value of SKU;
- Change the collation of the _sku_ column;
- Handle the issue where it appeared by performing case insensitive lookup

In this pull request, I chose to implement the third solution because it is the simplest and safest solution to fix the current issue. However the first solution could be the best, but it might be a bit complex and may lead to some backward incompatible changes.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

- Install MSI
- Create new product with SKU in lowercase, e.g "new test"
- Change SKU to the same but in upper case, e.g. "NEW TEST".
- Note that changed in catalog_product_entity table, but wrong in inventory_source_item
- Place order from the frontend
- Create Invoice and Shipping
- Try to create offline Credit Memo

EXPECTED RESULTS:
Credit Memo to be created

ACTUAL RESULTS:
Getting error "The credit memo couldn't be saved"

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
