### PR TITLE
MC-29177: Users can buy more products than available in stock

### DIFF
--- a/app/code/Magento/InventoryCatalog/Model/ResourceModel/SetDataToLegacyStockStatus.php
+++ b/app/code/Magento/InventoryCatalog/Model/ResourceModel/SetDataToLegacyStockStatus.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Model\ResourceModel;
+
+use Magento\CatalogInventory\Api\Data\StockStatusInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\InventoryCatalogApi\Model\GetProductIdsBySkusInterface;
+use Magento\CatalogInventory\Api\StockConfigurationInterface;
+
+/**
+ * Set data to legacy cataloginventory_stock_status table via plain MySql query.
+ */
+class SetDataToLegacyStockStatus
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var GetProductIdsBySkusInterface
+     */
+    private $getProductIdsBySkus;
+
+    /**
+     * @var StockConfigurationInterface
+     */
+    private $legaycStockConfiguration;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param GetProductIdsBySkusInterface $getProductIdsBySkus
+     * @param StockConfigurationInterface $legaycStockConfiguration
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        GetProductIdsBySkusInterface $getProductIdsBySkus,
+        StockConfigurationInterface $legaycStockConfiguration
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->getProductIdsBySkus = $getProductIdsBySkus;
+        $this->legaycStockConfiguration = $legaycStockConfiguration;
+    }
+
+    /**
+     * Updates status information in legacy index table.
+     *
+     * @param string $sku
+     * @param float $quantity
+     * @param int $status
+     * @return void
+     */
+    public function execute(string $sku, float $quantity, int $status): void
+    {
+        $productIds = $this->getProductIdsBySkus->execute([$sku]);
+
+        if (isset($productIds[$sku])) {
+            $productId = $productIds[$sku];
+
+            $connection = $this->resourceConnection->getConnection();
+            $connection->update(
+                $this->resourceConnection->getTableName('cataloginventory_stock_status'),
+                [
+                    StockStatusInterface::QTY => $quantity,
+                    StockStatusInterface::STOCK_STATUS => $status,
+                ],
+                [
+                    StockStatusInterface::PRODUCT_ID . ' = ?' => $productId,
+                    'website_id = ?' => $this->legaycStockConfiguration->getDefaultScopeId(),
+                ]
+            );
+        }
+    }
+}

--- a/app/code/Magento/InventoryCatalog/Model/SourceItemsSaveSynchronization/SetDataToLegacyCatalogInventory.php
+++ b/app/code/Magento/InventoryCatalog/Model/SourceItemsSaveSynchronization/SetDataToLegacyCatalogInventory.php
@@ -16,10 +16,11 @@ use Magento\CatalogInventory\Model\Stock;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventoryCatalogApi\Model\GetProductIdsBySkusInterface;
 use Magento\InventoryCatalog\Model\ResourceModel\SetDataToLegacyStockItem;
+use Magento\InventoryCatalog\Model\ResourceModel\SetDataToLegacyStockStatus;
 use Magento\InventoryCatalogApi\Model\SourceItemsSaveSynchronizationInterface;
 
 /**
- * Set Qty and status for legacy CatalogInventory Stock Item table
+ * Set Qty and status for legacy CatalogInventory Stock Information tables.
  */
 class SetDataToLegacyCatalogInventory
 {
@@ -27,6 +28,11 @@ class SetDataToLegacyCatalogInventory
      * @var SetDataToLegacyStockItem
      */
     private $setDataToLegacyStockItem;
+
+    /**
+     * @var SetDataToLegacyStockStatus
+     */
+    private $setDataToLegacyStockStatus;
 
     /**
      * @var StockItemCriteriaInterfaceFactory
@@ -60,6 +66,7 @@ class SetDataToLegacyCatalogInventory
      * @param GetProductIdsBySkusInterface $getProductIdsBySkus
      * @param StockStateProviderInterface $stockStateProvider
      * @param Processor $indexerProcessor
+     * @param SetDataToLegacyStockStatus $setDataToLegacyStockStatus
      */
     public function __construct(
         SetDataToLegacyStockItem $setDataToLegacyStockItem,
@@ -67,9 +74,11 @@ class SetDataToLegacyCatalogInventory
         StockItemRepositoryInterface $legacyStockItemRepository,
         GetProductIdsBySkusInterface $getProductIdsBySkus,
         StockStateProviderInterface $stockStateProvider,
-        Processor $indexerProcessor
+        Processor $indexerProcessor,
+        SetDataToLegacyStockStatus $setDataToLegacyStockStatus
     ) {
         $this->setDataToLegacyStockItem = $setDataToLegacyStockItem;
+        $this->setDataToLegacyStockStatus = $setDataToLegacyStockStatus;
         $this->legacyStockItemCriteriaFactory = $legacyStockItemCriteriaFactory;
         $this->legacyStockItemRepository = $legacyStockItemRepository;
         $this->getProductIdsBySkus = $getProductIdsBySkus;
@@ -78,6 +87,8 @@ class SetDataToLegacyCatalogInventory
     }
 
     /**
+     * Updates Stock information in legacy inventory.
+     *
      * @param array $sourceItems
      * @return void
      */
@@ -115,6 +126,11 @@ class SetDataToLegacyCatalogInventory
                 (float)$sourceItem->getQuantity(),
                 $isInStock
             );
+            $this->setDataToLegacyStockStatus->execute(
+                (string)$sourceItem->getSku(),
+                (float)$sourceItem->getQuantity(),
+                $isInStock
+            );
             $productIds[] = $productId;
         }
 
@@ -124,6 +140,8 @@ class SetDataToLegacyCatalogInventory
     }
 
     /**
+     * Returns StockItem from legacy inventory.
+     *
      * @param int $productId
      * @return null|StockItemInterface
      */


### PR DESCRIPTION
In the MSI implementation, while using Scheduled Update Indexing, after the order has been shipped data of a backend table (inventory_source_item) and an index table (inventory_stock_x) are updated.
If to use the default legacy stock the only the backend table is updated (catalog_inventory_stock_item). According to a formula which calculates a number of available products for sale until an order has been placed - the quantity of products is reduced; BUT after the order has been shipped the quantity returned to the original value.

### Description (*)
By the proposed changes, the legacy stock index table also updates information together with the backend table. 

### Fixed issues
* https://github.com/magento/inventory/issues/2754

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Configure Magento to Update By Schedule the indexes and turn off automatically running indexers (turn off the cron).
2. Create a product with quantity 10 in legacy stock. (now you can add to cart 10 products)
3. Place order with the product.
4. Make sure you can add to cart only 9 items of the product.
5. Ship the order.
6. Pay attention that you can add 10 items of the product to the cart. (Actual result)

Expected result: There are 9 salable items.

Repeat these steps with a product in the created stock to ensure that it is not the right behavior by the MSI implementation (after an order is shipped, qty are not turning back to the original value).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
