### PR TITLE
Assign all generated websites to default stock

### DIFF
--- a/app/code/Magento/InventorySetupFixtureGenerator/Plugin/Setup/Fixtures/StoresFixturePlugin.php
+++ b/app/code/Magento/InventorySetupFixtureGenerator/Plugin/Setup/Fixtures/StoresFixturePlugin.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventorySetupFixtureGenerator\Plugin\Setup\Fixtures;
+
+use Magento\InventoryCatalogApi\Api\DefaultStockProviderInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;
+use Magento\InventorySalesApi\Model\ReplaceSalesChannelsForStockInterface;
+use Magento\Setup\Fixtures\StoresFixture;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Assign all websites to default stock after generating website fixtures.
+ */
+class StoresFixturePlugin
+{
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var ReplaceSalesChannelsForStockInterface
+     */
+    private $replaceSalesChannelsForStock;
+
+    /**
+     * @var SalesChannelInterfaceFactory
+     */
+    private $salesChannelInterfaceFactory;
+
+    /**
+     * @var DefaultStockProviderInterface
+     */
+    private $defaultStockProvider;
+
+    /**
+     * @param StoreManagerInterface $storeManager
+     * @param ReplaceSalesChannelsForStockInterface $replaceSalesChannelsForStock
+     * @param SalesChannelInterfaceFactory $salesChannelInterfaceFactory
+     * @param DefaultStockProviderInterface $defaultStockProvider
+     */
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        ReplaceSalesChannelsForStockInterface $replaceSalesChannelsForStock,
+        SalesChannelInterfaceFactory $salesChannelInterfaceFactory,
+        DefaultStockProviderInterface $defaultStockProvider
+    ) {
+        $this->storeManager = $storeManager;
+        $this->replaceSalesChannelsForStock = $replaceSalesChannelsForStock;
+        $this->salesChannelInterfaceFactory = $salesChannelInterfaceFactory;
+        $this->defaultStockProvider = $defaultStockProvider;
+    }
+
+    /**
+     * Assign all websites to default stock after generating website fixtures.
+     *
+     * @param StoresFixture $subject
+     * @return void
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function afterExecute(StoresFixture $subject)
+    {
+        $salesChannels = [];
+        $websites = $this->storeManager->getWebsites();
+        foreach ($websites as $website) {
+            $salesChannels[] = $this->salesChannelInterfaceFactory->create(
+                [
+                    'data' => [
+                        SalesChannelInterface::TYPE => SalesChannelInterface::TYPE_WEBSITE,
+                        SalesChannelInterface::CODE => $website->getCode()
+                    ]
+                ]
+            );
+        }
+
+        $this->replaceSalesChannelsForStock->execute($salesChannels, $this->defaultStockProvider->getId());
+    }
+}

--- a/app/code/Magento/InventorySetupFixtureGenerator/composer.json
+++ b/app/code/Magento/InventorySetupFixtureGenerator/composer.json
@@ -3,7 +3,10 @@
   "description": "N/A",
   "require": {
     "php": "~7.1.3||~7.2.0||~7.3.0",
-    "magento/framework": "*"
+    "magento/framework": "*",
+    "magento/module-store": "*",
+    "magento/module-inventory-catalog-api": "*",
+    "magento/module-inventory-sales-api": "*"
   },
   "type": "magento2-module",
   "license": [

--- a/app/code/Magento/InventorySetupFixtureGenerator/etc/di.xml
+++ b/app/code/Magento/InventorySetupFixtureGenerator/etc/di.xml
@@ -9,4 +9,7 @@
     <type name="Magento\Setup\Model\FixtureGenerator\EntityGeneratorFactory">
         <plugin name="update_custom_table_map" type="Magento\InventorySetupFixtureGenerator\Plugin\Setup\Model\FixtureGenerator\EntityGeneratorFactory\UpdateCustomTableMapPlugin"/>
     </type>
+    <type name="Magento\Setup\Fixtures\StoresFixture">
+        <plugin name="assign_all_websites_to_default_stock_fixture_generation" type="Magento\InventorySetupFixtureGenerator\Plugin\Setup\Fixtures\StoresFixturePlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
### Description (*)
This Pull Request fixes the issue with the performance fixture generator which does not allow to generate additional websites.

Assigning default stock to all of the generated websites fixes the issue.

### Manual testing scenarios (*)
1. `bin/magento setup:performance:generate-fixtures setup/performance-toolkit/profiles/ce/medium.xml`

### Related Pull Requests
* https://github.com/magento/magento2-infrastructure/pull/1067
