### PR TITLE
MC-30456: Test ProductAlertTest is failing

### DIFF
--- a/app/code/Magento/InventoryProductAlert/Test/Integration/ProductAlertTest.php
+++ b/app/code/Magento/InventoryProductAlert/Test/Integration/ProductAlertTest.php
@@ -105,7 +105,7 @@ class ProductAlertTest extends TestCase
      * @magentoDataFixture ../../../../app/code/Magento/InventoryProductAlert/Test/_files/product_alert_eu_website_customer.php
      * @magentoConfigFixture default_store catalog/productalert/allow_stock 1
      * @magentoConfigFixture store_for_eu_website_store catalog/productalert/allow_stock 1
-     *
+     * @magentoAppArea frontend
      * @magentoDbIsolation disabled
      */
     public function testAlertsOneSourceItemInStock()
@@ -147,7 +147,7 @@ class ProductAlertTest extends TestCase
      * @magentoDataFixture ../../../../app/code/Magento/InventoryProductAlert/Test/_files/product_alert_eu_website_customer.php
      * @magentoConfigFixture default_store catalog/productalert/allow_stock 1
      * @magentoConfigFixture store_for_eu_website_store catalog/productalert/allow_stock 1
-     *
+     * @magentoAppArea frontend
      * @magentoDbIsolation disabled
      */
     public function testAlertsBothSourceItemsInStock()


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fix of the Test ProductAlertTest is failing

Reason is that the Test is supposed to work in Frontend area that was not added into the test. Previously the scenario that was tested included starting and stopping environment emulation. In scope of the bug-fix MC-30091 emulation starting and stopping environment emulation was removed because emulation is started on the upper level and supposed to be stopped on upper level
### Fixed Issues (if relevant)


<!--- ### Manual testing scenarios (*) -->
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Is tested in scope of the original ticket

<!--- ### Questions or comments -->
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
