### PR TITLE
Products created with WEBAPI without quantity are automatically assigned to default source.

### DIFF
--- a/InventoryAdminUi/Test/Mftf/Data/MsiProductData.xml
+++ b/InventoryAdminUi/Test/Mftf/Data/MsiProductData.xml
@@ -20,6 +20,7 @@
         <data key="notifyQuantity">1</data>
         <data key="attribute_set_id">4</data>
         <data key="visibility">4</data>
+        <requiredEntity type="product_extension_attribute">EavStock100</requiredEntity>
     </entity>
     <!--Notice: This product created for specific test. Has no unique suffix in sku.-->
     <entity name="SimpleMsiProductWithNumericSku" type="product">
@@ -35,6 +36,7 @@
         <data key="attribute_set_id">4</data>
         <data key="visibility">4</data>
         <requiredEntity type="custom_attribute_array">CustomAttributeCategoryIds</requiredEntity>
+        <requiredEntity type="product_extension_attribute">EavStock100</requiredEntity>
     </entity>
     <entity name="ConfigurableMsiProduct" type="product">
         <data key="name" unique="suffix">Configurable MSI Product </data>
@@ -47,6 +49,7 @@
         <data key="urlKey" unique="suffix">configurable-msi-product-</data>
         <data key="attribute_set_id">4</data>
         <data key="visibility">4</data>
+        <requiredEntity type="product_extension_attribute">EavStock100</requiredEntity>
     </entity>
     <entity name="VirtualMsiProduct" type="product">
         <data key="name" unique="suffix">Virtual MSI Product </data>
@@ -57,6 +60,7 @@
         <data key="urlKey" unique="suffix">Virtual-MSI-Product-</data>
         <data key="attribute_set_id">4</data>
         <data key="visibility">4</data>
+        <requiredEntity type="product_extension_attribute">EavStock100</requiredEntity>
     </entity>
     <entity name="DownloadableMsiProduct" type="product">
         <data key="name" unique="suffix">Downloadable MSI Product </data>
@@ -67,6 +71,7 @@
         <data key="urlKey" unique="suffix">Downloadable-MSI-Product-</data>
         <data key="attribute_set_id">4</data>
         <data key="visibility">4</data>
+        <requiredEntity type="product_extension_attribute">EavStock100</requiredEntity>
     </entity>
     <entity name="MsiDownloadableProduct" type="product">
         <data key="name" unique="suffix">Downloadable MSI Product </data>
@@ -78,5 +83,6 @@
         <data key="attribute_set_id">4</data>
         <data key="visibility">4</data>
         <requiredEntity type="custom_attribute_array">CustomAttributeCategoryIds</requiredEntity>
+        <requiredEntity type="product_extension_attribute">EavStock100</requiredEntity>
     </entity>
 </entities>

--- a/InventoryAdminUi/Test/Mftf/Test/AdminCreateCreditMemoTotalRefundFullInvoiceFullShipmentSimpleProductCustomOptionsDefaultStock.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCreateCreditMemoTotalRefundFullInvoiceFullShipmentSimpleProductCustomOptionsDefaultStock.xml
@@ -23,7 +23,7 @@
             <!--Create test data.-->
             <createData entity="FullSource1" stepKey="additionalSource"/>
             <createData entity="_defaultCategory" stepKey="category"/>
-            <createData entity="VirtualProduct" stepKey="product"/>
+            <createData entity="VirtualMsiProduct" stepKey="product"/>
             <!--Create customer.-->
             <createData entity="MsiCustomer1" stepKey="customer"/>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
@@ -61,7 +61,7 @@
             <argument name="Customer" value="$$customer$$"/>
         </actionGroup>
         <!--Add product to cart.-->
-        <amOnPage url="{{StorefrontProductPage.url($$product.name$$)}}" stepKey="navigateToPDP"/>
+        <amOnPage url="{{StorefrontProductPage.url($$product.custom_attributes[url_key]$$)}}" stepKey="navigateToPDP"/>
         <selectOption selector="//select[contains(@class,' required product-custom-option admin__control-select')]" userInput="{{ProductOptionValueDropdown1.title}} +${{ProductOptionValueDropdown1.price}}" stepKey="selectOption"/>
         <fillField selector="{{StorefrontProductPageSection.qtyInput}}" userInput="10" stepKey="fillProductQty"/>
         <click selector="{{StorefrontProductPageSection.addToCartBtn}}" stepKey="addToCart"/>

--- a/InventoryAdminUi/Test/Mftf/Test/AdminMassActionTransferInventoryToSourceForDifferentTypeOfProductsTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminMassActionTransferInventoryToSourceForDifferentTypeOfProductsTest.xml
@@ -40,15 +40,15 @@
             <conditionalClick selector="{{AdminGridConfirmActionSection.ok}}" dependentSelector="{{AdminGridConfirmActionSection.title}}" visible="true" stepKey="confirmProductsDelete"/>
 
             <comment userInput="Create products" stepKey="createProductsComment"/>
-            <createData entity="SimpleProduct" stepKey="createSimpleProduct">
+            <createData entity="SimpleMsiProduct" stepKey="createSimpleProduct">
                 <field key="price">10.00</field>
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
-            <createData entity="VirtualProduct" stepKey="createVirtualProduct">
+            <createData entity="VirtualMsiProduct" stepKey="createVirtualProduct">
                 <field key="price">10.00</field>
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
-            <createData entity="DownloadableProduct" stepKey="createDownloadableProduct">
+            <createData entity="DownloadableMsiProduct" stepKey="createDownloadableProduct">
                 <field key="price">10.00</field>
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
@@ -62,8 +62,6 @@
             <click selector="{{AdminGridRow.editByValue($$createDownloadableProduct.product[sku]$$)}}" stepKey="clickOnEditDownloadableProductForCheckInStock"/>
             <comment userInput="Assign category to product." stepKey="assignCategoryComment"/>
             <searchAndMultiSelectOption selector="{{AdminProductFormSection.categoriesDropdown}}" parameterArray="[$$createCategory.name$$]" requiredAction="true" stepKey="searchAndSelectCategory"/>
-            <selectOption selector="{{AdminProductSourcesGrid.rowStatus('0')}}" userInput="In Stock" stepKey="selectStockStatus" />
-            <fillField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="1000" stepKey="fillSourceQuantityField"/>
             <comment userInput="Add downloadable links to product." stepKey="addDownloadableLinks"/>
             <click selector="{{AdminProductDownloadableSection.sectionHeader}}" stepKey="openDownloadableSection"/>
             <checkOption selector="{{AdminProductDownloadableSection.isDownloadableProduct}}" stepKey="checkIsDownloadable"/>
@@ -133,11 +131,11 @@
         <conditionalClick selector="{{AdminDataGridHeaderSection.clearFilters}}" dependentSelector="{{AdminDataGridHeaderSection.clearFilters}}" visible="true" stepKey="clearAllFiltersForCheckDefaultSourceQty"/>
 
         <comment userInput="Check if that the default source assigned to created products." stepKey="checkDefaultSourceAssignedToCreatedProductsComment"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="1000" stepKey="checkSourceQtyForFirstCreatedProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="100" stepKey="checkSourceQtyForFirstCreatedProduct"/>
         <dontSee selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" stepKey="createdSourceIsNotAssignedToFirstProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="1000" stepKey="checkSourceQtyForVirtualCreatedProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="100" stepKey="checkSourceQtyForVirtualCreatedProduct"/>
         <dontSee selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" stepKey="createdSourceIsNotAssignedToVirtualProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="1000" stepKey="checkSourceQtyForDownloadableCreatedProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="100" stepKey="checkSourceQtyForDownloadableCreatedProduct"/>
         <dontSee selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" stepKey="createdSourceIsNotAssignedToDownloadableProduct"/>
 
         <comment userInput="Transfer inventory from default source to created source" stepKey="selectAllProductsForTransferInventoryComment"/>
@@ -155,16 +153,16 @@
 
         <comment userInput="Check that the default source inventory transfered to created source" stepKey="checkTheInventoryTransferedComment"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="0" stepKey="checkDefaultSourceQtyForFirstProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" userInput="1000" stepKey="checkCreatedSourceQtyForFirstProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" userInput="100" stepKey="checkCreatedSourceQtyForFirstProduct"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="0" stepKey="checkDefaultSourceQtyForVirtualProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" userInput="1000" stepKey="checkCreatedSourceQtyForVirtualProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" userInput="100" stepKey="checkCreatedSourceQtyForVirtualProduct"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="0" stepKey="checkDefaultSourceQtyForDownloadableProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" userInput="1000" stepKey="checkCreatedSourceQtyForDownloadableProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" userInput="100" stepKey="checkCreatedSourceQtyForDownloadableProduct"/>
 
-        <comment userInput="Verify that all created products got qty 1000 on created stock" stepKey="verifyThatCreatedSourceGotQtyComment"/>
-        <see selector="{{AdminProductGridSection.productSalableQty('1', $$createStock.stock[name]$$)}}" userInput="1000" stepKey="seeQtyOnCreatedStockForFirstProduct"/>
-        <see selector="{{AdminProductGridSection.productSalableQty('2', $$createStock.stock[name]$$)}}" userInput="1000" stepKey="seeQtyOnCreatedStockForVirtualProduct"/>
-        <see selector="{{AdminProductGridSection.productSalableQty('3', $$createStock.stock[name]$$)}}" userInput="1000" stepKey="seeQtyOnCreatedStockForDownloadableProduct"/>
+        <comment userInput="Verify that all created products got qty 100 on created stock" stepKey="verifyThatCreatedSourceGotQtyComment"/>
+        <see selector="{{AdminProductGridSection.productSalableQty('1', $$createStock.stock[name]$$)}}" userInput="100" stepKey="seeQtyOnCreatedStockForFirstProduct"/>
+        <see selector="{{AdminProductGridSection.productSalableQty('2', $$createStock.stock[name]$$)}}" userInput="100" stepKey="seeQtyOnCreatedStockForVirtualProduct"/>
+        <see selector="{{AdminProductGridSection.productSalableQty('3', $$createStock.stock[name]$$)}}" userInput="100" stepKey="seeQtyOnCreatedStockForDownloadableProduct"/>
 
         <comment userInput="Check that the all products in stock on created source." stepKey="checkAllProductsInStockOnCreatedSourceComment"/>
         <actionGroup ref="AdminGridFilterSearchResultsByInput" stepKey="findFirstSimpleProductBySku">
@@ -210,17 +208,17 @@
         <waitForPageLoad stepKey="waitForInventoryWillBeTransferToDefaultSource"/>
 
         <comment userInput="Check that the default source inventory transfered to created source" stepKey="checkTheInventoryTransferedFromCustomToDefaultSourceComment"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="1000" stepKey="checkDefaultSourceQtyForFirstProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="100" stepKey="checkDefaultSourceQtyForFirstProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" userInput="0" stepKey="checkCreatedSourceQtyForFirstProductAfterTransferFromCustomSource"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="1000" stepKey="checkDefaultSourceQtyForVirtualProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="100" stepKey="checkDefaultSourceQtyForVirtualProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" userInput="0" stepKey="checkCreatedSourceQtyForVirtualProductAfterTransferFromCustomSource"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="1000" stepKey="checkDefaultSourceQtyForDownloadableProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="100" stepKey="checkDefaultSourceQtyForDownloadableProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" userInput="0" stepKey="checkCreatedSourceQtyForDownloadableProductAfterTransferFromCustomSource"/>
 
-        <comment userInput="Verify that all created products got qty 1000 on created stock" stepKey="verifyThatCreatedSourceGotQtyAfterTransferFromCustomSourceComment"/>
-        <see selector="{{AdminProductGridSection.productSalableQty('1', _defaultStock.name)}}" userInput="1000" stepKey="seeQtyOnCreatedStockForFirstProductAfterTransferFromCustomSource"/>
-        <see selector="{{AdminProductGridSection.productSalableQty('2', _defaultStock.name)}}" userInput="1000" stepKey="seeQtyOnCreatedStockForVirtualProductAfterTransferFromCustomSource"/>
-        <see selector="{{AdminProductGridSection.productSalableQty('3', _defaultStock.name)}}" userInput="1000" stepKey="seeQtyOnCreatedStockForDownloadableProductAfterTransferFromCustomSource"/>
+        <comment userInput="Verify that all created products got qty 100 on created stock" stepKey="verifyThatCreatedSourceGotQtyAfterTransferFromCustomSourceComment"/>
+        <see selector="{{AdminProductGridSection.productSalableQty('1', _defaultStock.name)}}" userInput="100" stepKey="seeQtyOnCreatedStockForFirstProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productSalableQty('2', _defaultStock.name)}}" userInput="100" stepKey="seeQtyOnCreatedStockForVirtualProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productSalableQty('3', _defaultStock.name)}}" userInput="100" stepKey="seeQtyOnCreatedStockForDownloadableProductAfterTransferFromCustomSource"/>
 
         <comment userInput="Check that the all products in stock on created source." stepKey="checkAllProductsInStockOnDefaultSourceComment"/>
         <actionGroup ref="AdminGridFilterSearchResultsByInput" stepKey="findFirstSimpleProductBySkuForCheckInStock">

--- a/InventoryAdminUi/Test/Mftf/Test/AdminMassActionTransferInventoryToSourceForDifferentTypeOfProductsWithOutOfStockStatusOnSourceTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminMassActionTransferInventoryToSourceForDifferentTypeOfProductsWithOutOfStockStatusOnSourceTest.xml
@@ -40,15 +40,15 @@
             <conditionalClick selector="{{AdminGridConfirmActionSection.ok}}" dependentSelector="{{AdminGridConfirmActionSection.title}}" visible="true" stepKey="confirmProductsDelete"/>
 
             <comment userInput="Create products" stepKey="createProductsComment"/>
-            <createData entity="SimpleProduct" stepKey="createSimpleProduct">
+            <createData entity="SimpleMsiProduct" stepKey="createSimpleProduct">
                 <field key="price">10.00</field>
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
-            <createData entity="VirtualProduct" stepKey="createVirtualProduct">
+            <createData entity="VirtualMsiProduct" stepKey="createVirtualProduct">
                 <field key="price">10.00</field>
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
-            <createData entity="DownloadableProduct" stepKey="createDownloadableProduct">
+            <createData entity="DownloadableMsiProduct" stepKey="createDownloadableProduct">
                 <field key="price">10.00</field>
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
@@ -62,7 +62,6 @@
             <click selector="{{AdminGridRow.editByValue($$createDownloadableProduct.product[sku]$$)}}" stepKey="clickOnEditDownloadableProductForCheckInStock"/>
             <comment userInput="Assign category to product." stepKey="assignCategoryComment"/>
             <searchAndMultiSelectOption selector="{{AdminProductFormSection.categoriesDropdown}}" parameterArray="[$$createCategory.name$$]" requiredAction="true" stepKey="searchAndSelectCategory"/>
-            <fillField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="1000" stepKey="fillSourceQuantityField"/>
             <comment userInput="Add downloadable links to product." stepKey="addDownloadableLinks"/>
             <click selector="{{AdminProductDownloadableSection.sectionHeader}}" stepKey="openDownloadableSection"/>
             <checkOption selector="{{AdminProductDownloadableSection.isDownloadableProduct}}" stepKey="checkIsDownloadable"/>
@@ -161,11 +160,11 @@
         <conditionalClick selector="{{AdminDataGridHeaderSection.clearFilters}}" dependentSelector="{{AdminDataGridHeaderSection.clearFilters}}" visible="true" stepKey="clearAllFiltersForCheckDefaultSourcesAssignedToProducts"/>
 
         <comment userInput="Check if that the default source assigned to created products." stepKey="checkDefaultSourceAssignedToCreatedProductsComment"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="1000" stepKey="checkSourceQtyForFirstCreatedProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="100" stepKey="checkSourceQtyForFirstCreatedProduct"/>
         <dontSee selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" stepKey="createdSourceIsNotAssignedToFirstProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="1000" stepKey="checkSourceQtyForVirtualCreatedProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="100" stepKey="checkSourceQtyForVirtualCreatedProduct"/>
         <dontSee selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" stepKey="createdSourceIsNotAssignedToVirtualProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="1000" stepKey="checkSourceQtyForDownloadableCreatedProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="100" stepKey="checkSourceQtyForDownloadableCreatedProduct"/>
         <dontSee selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" stepKey="createdSourceIsNotAssignedToDownloadableProduct"/>
 
         <comment userInput="Transfer inventory from default source to created source" stepKey="selectAllProductsForTransferInventoryComment"/>
@@ -183,13 +182,13 @@
 
         <comment userInput="Check that the default source inventory transfered to created source" stepKey="checkTheInventoryTransferedComment"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="0" stepKey="checkDefaultSourceQtyForFirstProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" userInput="1000" stepKey="checkCreatedSourceQtyForFirstProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" userInput="100" stepKey="checkCreatedSourceQtyForFirstProduct"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="0" stepKey="checkDefaultSourceQtyForVirtualProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" userInput="1000" stepKey="checkCreatedSourceQtyForVirtualProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" userInput="100" stepKey="checkCreatedSourceQtyForVirtualProduct"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="0" stepKey="checkDefaultSourceQtyForDownloadableProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" userInput="1000" stepKey="checkCreatedSourceQtyForDownloadableProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" userInput="100" stepKey="checkCreatedSourceQtyForDownloadableProduct"/>
 
-        <comment userInput="Verify that all created products got qty 1000 on created stock" stepKey="verifyThatCreatedSourceGotQtyComment"/>
+        <comment userInput="Verify that all created products got qty 100 on created stock" stepKey="verifyThatCreatedSourceGotQtyComment"/>
         <see selector="{{AdminProductGridSection.productSalableQty('1', $$createStock.stock[name]$$)}}" userInput="0" stepKey="seeQtyOnCreatedStockForSimpleProduct"/>
         <see selector="{{AdminProductGridSection.productSalableQty('2', $$createStock.stock[name]$$)}}" userInput="0" stepKey="seeQtyOnCreatedStockForVirtualProduct"/>
         <see selector="{{AdminProductGridSection.productSalableQty('3', $$createStock.stock[name]$$)}}" userInput="0" stepKey="seeQtyOnCreatedStockForDownloadableProduct"/>
@@ -238,14 +237,14 @@
         <waitForPageLoad stepKey="waitForInventoryWillBeTransferToDefaultSource"/>
 
         <comment userInput="Check that the default source inventory transfered to created source" stepKey="checkTheInventoryTransferedFromCustomToDefaultSourceComment"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="1000" stepKey="checkDefaultSourceQtyForFirstProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="100" stepKey="checkDefaultSourceQtyForFirstProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" userInput="0" stepKey="checkCreatedSourceQtyForFirstProductAfterTransferFromCustomSource"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="1000" stepKey="checkDefaultSourceQtyForVirtualProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="100" stepKey="checkDefaultSourceQtyForVirtualProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" userInput="0" stepKey="checkCreatedSourceQtyForVirtualProductAfterTransferFromCustomSource"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="1000" stepKey="checkDefaultSourceQtyForDownloadableProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="100" stepKey="checkDefaultSourceQtyForDownloadableProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" userInput="0" stepKey="checkCreatedSourceQtyForDownloadableProductAfterTransferFromCustomSource"/>
 
-        <comment userInput="Verify that all created products got qty 1000 on created stock" stepKey="verifyThatCreatedSourceGotQtyAfterTransferFromCustomSourceComment"/>
+        <comment userInput="Verify that all created products got qty 100 on created stock" stepKey="verifyThatCreatedSourceGotQtyAfterTransferFromCustomSourceComment"/>
         <see selector="{{AdminProductGridSection.productSalableQty('1', _defaultStock.name)}}" userInput="0" stepKey="seeQtyOnCreatedStockForFirstProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productSalableQty('2', _defaultStock.name)}}" userInput="0" stepKey="seeQtyOnCreatedStockForVirtualProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productSalableQty('3', _defaultStock.name)}}" userInput="0" stepKey="seeQtyOnCreatedStockForDownloadableProductAfterTransferFromCustomSource"/>

--- a/InventoryAdminUi/Test/Mftf/Test/AdminMassActionTransferInventoryToSourceTransferringNotifyQuantityForDifferentTypesOfProductsTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminMassActionTransferInventoryToSourceTransferringNotifyQuantityForDifferentTypesOfProductsTest.xml
@@ -40,15 +40,15 @@
             <conditionalClick selector="{{AdminGridConfirmActionSection.ok}}" dependentSelector="{{AdminGridConfirmActionSection.title}}" visible="true" stepKey="confirmProductsDelete"/>
 
             <comment userInput="Create products" stepKey="createProductsComment"/>
-            <createData entity="SimpleProduct" stepKey="createSimpleProduct">
+            <createData entity="SimpleMsiProduct" stepKey="createSimpleProduct">
                 <field key="price">10.00</field>
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
-            <createData entity="VirtualProduct" stepKey="createVirtualProduct">
+            <createData entity="VirtualMsiProduct" stepKey="createVirtualProduct">
                 <field key="price">10.00</field>
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
-            <createData entity="DownloadableProduct" stepKey="createDownloadableProduct">
+            <createData entity="DownloadableMsiProduct" stepKey="createDownloadableProduct">
                 <field key="price">10.00</field>
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
@@ -62,7 +62,6 @@
             <click selector="{{AdminGridRow.editByValue($$createDownloadableProduct.product[sku]$$)}}" stepKey="clickOnEditDownloadableProductForCheckInStock"/>
             <comment userInput="Assign category to product." stepKey="assignCategoryComment"/>
             <searchAndMultiSelectOption selector="{{AdminProductFormSection.categoriesDropdown}}" parameterArray="[$$createCategory.name$$]" requiredAction="true" stepKey="searchAndSelectCategory"/>
-            <fillField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="1000" stepKey="fillSourceQuantityField"/>
             <comment userInput="Add downloadable links to product." stepKey="addDownloadableLinks"/>
             <click selector="{{AdminProductDownloadableSection.sectionHeader}}" stepKey="openDownloadableSection"/>
             <checkOption selector="{{AdminProductDownloadableSection.isDownloadableProduct}}" stepKey="checkIsDownloadable"/>
@@ -164,11 +163,11 @@
         <conditionalClick selector="{{AdminDataGridHeaderSection.clearFilters}}" dependentSelector="{{AdminDataGridHeaderSection.clearFilters}}" visible="true" stepKey="clearAllFiltersForCheckDefaultSourcesAssignedToProducts"/>
 
         <comment userInput="Check if that the default source assigned to created products." stepKey="checkDefaultSourceAssignedToCreatedProductsComment"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="1000" stepKey="checkSourceQtyForFirstCreatedProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="100" stepKey="checkSourceQtyForFirstCreatedProduct"/>
         <dontSee selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" stepKey="createdSourceIsNotAssignedToFirstProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="1000" stepKey="checkSourceQtyForVirtualCreatedProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="100" stepKey="checkSourceQtyForVirtualCreatedProduct"/>
         <dontSee selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" stepKey="createdSourceIsNotAssignedToVirtualProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="1000" stepKey="checkSourceQtyForDownloadableCreatedProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="100" stepKey="checkSourceQtyForDownloadableCreatedProduct"/>
         <dontSee selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" stepKey="createdSourceIsNotAssignedToDownloadableProduct"/>
 
         <comment userInput="Transfer inventory from default source to created source" stepKey="selectAllProductsForTransferInventoryComment"/>
@@ -186,11 +185,11 @@
 
         <comment userInput="Check that the default source inventory transfered to created source" stepKey="checkTheInventoryTransferedComment"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="0" stepKey="checkDefaultSourceQtyForFirstProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" userInput="1000" stepKey="checkCreatedSourceQtyForFirstProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" userInput="100" stepKey="checkCreatedSourceQtyForFirstProduct"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="0" stepKey="checkDefaultSourceQtyForVirtualProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" userInput="1000" stepKey="checkCreatedSourceQtyForVirtualProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" userInput="100" stepKey="checkCreatedSourceQtyForVirtualProduct"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="0" stepKey="checkDefaultSourceQtyForDownloadableProduct"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" userInput="1000" stepKey="checkCreatedSourceQtyForDownloadableProduct"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" userInput="100" stepKey="checkCreatedSourceQtyForDownloadableProduct"/>
 
         <comment userInput="Check notify quantity for all products on created source." stepKey="checkNotifyQuantityForAllProductsOnCreatedSourceComment"/>
         <actionGroup ref="AdminGridFilterSearchResultsByInput" stepKey="findSimpleProductBySku">
@@ -239,11 +238,11 @@
         <waitForPageLoad stepKey="waitForInventoryWillBeTransferToDefaultSource"/>
 
         <comment userInput="Check that the default source inventory transfered to created source" stepKey="checkTheInventoryTransferedFromCustomToDefaultSourceComment"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="1000" stepKey="checkDefaultSourceQtyForFirstProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('1', _defaultSource.name)}}" userInput="100" stepKey="checkDefaultSourceQtyForFirstProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('1', $$createSource.source[name]$$)}}" userInput="0" stepKey="checkCreatedSourceQtyForFirstProductAfterTransferFromCustomSource"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="1000" stepKey="checkDefaultSourceQtyForVirtualProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('2', _defaultSource.name)}}" userInput="100" stepKey="checkDefaultSourceQtyForVirtualProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('2', $$createSource.source[name]$$)}}" userInput="0" stepKey="checkCreatedSourceQtyForVirtualProductAfterTransferFromCustomSource"/>
-        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="1000" stepKey="checkDefaultSourceQtyForDownloadableProductAfterTransferFromCustomSource"/>
+        <see selector="{{AdminProductGridSection.productQtyPerSource('3', _defaultSource.name)}}" userInput="100" stepKey="checkDefaultSourceQtyForDownloadableProductAfterTransferFromCustomSource"/>
         <see selector="{{AdminProductGridSection.productQtyPerSource('3', $$createSource.source[name]$$)}}" userInput="0" stepKey="checkCreatedSourceQtyForDownloadableProductAfterTransferFromCustomSource"/>
 
         <comment userInput="Check notify quantity for all products on default source." stepKey="checkNotifyQuantityForAllProductsOnDefaultSourceComment"/>

--- a/InventoryAdminUi/Test/Mftf/Test/CatalogPriceRuleDownloadableProductAdditionalStockTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/CatalogPriceRuleDownloadableProductAdditionalStockTest.xml
@@ -22,7 +22,7 @@
         <before>
             <!--Replace simple product with downloadable.-->
             <remove keyForRemoval="createProduct"/>
-            <createData entity="DownloadableProduct" stepKey="createProduct" after="createCategory"/>
+            <createData entity="DownloadableMsiProduct" stepKey="createProduct" after="createCategory"/>
             <!--Create additional source and stock.-->
             <createData entity="_minimalSource" stepKey="additionalSource" after="createProduct"/>
             <createData entity="BasicMsiStockWithMainWebsite1" stepKey="additionalStock" after="additionalSource"/>
@@ -33,16 +33,16 @@
             </createData>
             <!--Assign created product to additional stock and set product qty.'.-->
             <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="openProductEditPageToSetQty" after="loginAsAdmin"/>
-            <actionGroup ref="AssignSourceToProductActionGroup" stepKey="assignAdditionalSourceToProduct" after="openProductEditPageToSetQty">
+            <waitForPageLoad stepKey="waitForProductEditPageLoad" after="openProductEditPageToSetQty"/>
+            <!--Assign product to category.-->
+            <actionGroup ref="AdminAssignCategoryToProductAndSaveActionGroup" stepKey="assignCategoryToDownloadableProduct" after="waitForProductEditPageLoad">
+                <argument name="categoryName" value="$$createCategory.name$$"/>
+            </actionGroup>
+            <actionGroup ref="AssignSourceToProductActionGroup" stepKey="assignAdditionalSourceToProduct" after="assignCategoryToDownloadableProduct">
                 <argument name="sourceCode" value="$$additionalSource.source[source_code]$$"/>
             </actionGroup>
             <fillField selector="{{AdminProductFormSection.productPrice}}" userInput="123.00" stepKey="fillProductPrice" after="assignAdditionalSourceToProduct"/>
-            <fillField selector="{{AdminProductSourcesGrid.rowQty('1')}}" userInput="100" stepKey="setProductQuantity" after="fillProductPrice"/>
-            <scrollToTopOfPage stepKey="scrollToTheTopOfProductEditPage" after="setProductQuantity"/>
-            <!--Assign product to category.-->
-            <actionGroup ref="AdminAssignCategoryToProductAndSaveActionGroup" stepKey="assignCategoryToDownloadableProduct" after="scrollToTheTopOfProductEditPage">
-                <argument name="categoryName" value="$$createCategory.name$$"/>
-            </actionGroup>
+            <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct" after="fillProductPrice"/>
         </before>
         <after>
             <!--Assign Default Stock to Default Website.-->

--- a/InventoryAdvancedCheckout/Test/Mftf/Test/AddSimpleOutOfStockProductBySkuFromCustomerAccountAdditionalStockTest.xml
+++ b/InventoryAdvancedCheckout/Test/Mftf/Test/AddSimpleOutOfStockProductBySkuFromCustomerAccountAdditionalStockTest.xml
@@ -27,7 +27,10 @@
             <!--Assign create product to additional stock and set qty.-->
             <actionGroup ref="LoginAsAdmin" stepKey="loginToAdminPanel" after="createSimpleProduct"/>
             <amOnPage url="{{AdminProductEditPage.url($$createSimpleProduct.id$$)}}" stepKey="openProductEditPageToSetQty" after="loginToAdminPanel"/>
-            <actionGroup ref="AssignSourceToProductActionGroup" stepKey="assignSourceToCreatedProduct" after="openProductEditPageToSetQty">
+            <actionGroup ref="AssignSourceToProductActionGroup" stepKey="assignDefaultSourceToCreatedProduct" after="openProductEditPageToSetQty">
+                <argument name="sourceCode" value="{{_defaultSource.source_code}}"/>
+            </actionGroup>
+            <actionGroup ref="AssignSourceToProductActionGroup" stepKey="assignSourceToCreatedProduct" after="assignDefaultSourceToCreatedProduct">
                 <argument name="sourceCode" value="$$additionalSource.source[source_code]$$"/>
             </actionGroup>
             <fillField selector="{{AdminProductSourcesGrid.rowQty('1')}}" userInput="0" stepKey="setProductQuantity" after="assignSourceToCreatedProduct"/>

--- a/InventoryCatalog/Test/Api/ProductRepositoryInterfaceTest.php
+++ b/InventoryCatalog/Test/Api/ProductRepositoryInterfaceTest.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Test\Api\Catalog;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\CatalogInventory\Api\Data\StockItemInterface;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SortOrder;
+use Magento\Framework\Webapi\Rest\Request;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\TestFramework\TestCase\WebapiAbstract;
+
+/**
+ * Test product management api with source items
+ */
+class ProductRepositoryInterfaceTest extends WebapiAbstract
+{
+    private const SERVICE_NAME = 'catalogProductRepositoryV1';
+    private const SERVICE_VERSION = 'V1';
+    private const RESOURCE_PATH = '/V1/products';
+    private const SOURCE_ITEMS_SERVICE_NAME = 'inventoryApiSourceItemRepositoryV1';
+    private const SOURCE_ITEMS_SERVICE_VERSION = 'V1';
+    private const SOURCE_ITEMS_RESOURCE_PATH = '/V1/inventory/source-items';
+
+    /**
+     * Test that product created without quantity should not be automatically assigned to default source
+     */
+    public function testCreateWithoutQty(): void
+    {
+        $data = $this->getProductSampleData();
+        $this->saveProduct($data);
+        $sourceItems = $this->getSourceItems($data[ProductInterface::SKU]);
+        $this->assertEmpty($sourceItems);
+        $this->deleteProduct($data[ProductInterface::SKU]);
+    }
+
+    /**
+     * Test that product created with quantity should be automatically assigned to default source
+     */
+    public function testCreateWithQty(): void
+    {
+        $data = $this->getProductSampleData();
+        $data[ProductInterface::EXTENSION_ATTRIBUTES_KEY] = [
+            'stock_item' => [
+                StockItemInterface::QTY => 100,
+            ]
+        ];
+        $this->saveProduct($data);
+        $sourceItems = $this->getSourceItems($data[ProductInterface::SKU]);
+        $this->assertCount(1, $sourceItems);
+        $this->assertEquals('default', $sourceItems[0][SourceItemInterface::SOURCE_CODE]);
+        $this->deleteProduct($data[ProductInterface::SKU]);
+    }
+
+    /**
+     * Save Product
+     *
+     * @param $product
+     * @param string|null $storeCode
+     * @param string|null $token
+     * @return mixed
+     */
+    private function saveProduct($product, $storeCode = null, ?string $token = null)
+    {
+        if (isset($product['custom_attributes'])) {
+            foreach ($product['custom_attributes'] as &$attribute) {
+                if ($attribute['attribute_code'] == 'category_ids'
+                    && !is_array($attribute['value'])
+                ) {
+                    $attribute['value'] = [""];
+                }
+            }
+        }
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH,
+                'httpMethod' => Request::HTTP_METHOD_POST,
+            ],
+            'soap' => [
+                'service' => self::SERVICE_NAME,
+                'serviceVersion' => self::SERVICE_VERSION,
+                'operation' => self::SERVICE_NAME . 'Save',
+            ],
+        ];
+        if ($token) {
+            $serviceInfo['rest']['token'] = $serviceInfo['soap']['token'] = $token;
+        }
+        $requestData = ['product' => $product];
+
+        return $this->_webApiCall($serviceInfo, $requestData, null, $storeCode);
+    }
+
+    /**
+     * Delete Product
+     *
+     * @param string $sku
+     * @return void
+     */
+    private function deleteProduct(string $sku): void
+    {
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH . '/' . $sku,
+                'httpMethod' => Request::HTTP_METHOD_DELETE,
+            ],
+            'soap' => [
+                'service' => self::SERVICE_NAME,
+                'serviceVersion' => self::SERVICE_VERSION,
+                'operation' => self::SERVICE_NAME . 'DeleteById',
+            ],
+        ];
+        (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST)
+            ? $this->_webApiCall($serviceInfo)
+            : $this->_webApiCall($serviceInfo, ['sku' => $sku]);
+    }
+
+    /**
+     * Get Product
+     *
+     * @param string $sku
+     * @return array
+     */
+    private function getSourceItems(string $sku): array
+    {
+        $requestData = [
+            'searchCriteria' => [
+                SearchCriteria::FILTER_GROUPS => [
+                    [
+                        'filters' => [
+                            [
+                                'field' => SourceItemInterface::SKU,
+                                'value' => $sku,
+                                'condition_type' => 'eq',
+                            ],
+                        ],
+                    ],
+                ],
+                SearchCriteria::SORT_ORDERS => [
+                    [
+                        'field' => SourceItemInterface::SOURCE_CODE,
+                        'direction' => SortOrder::SORT_DESC,
+                    ],
+                ],
+                SearchCriteria::CURRENT_PAGE => 1,
+                SearchCriteria::PAGE_SIZE => 1000,
+            ],
+        ];
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::SOURCE_ITEMS_RESOURCE_PATH . '?' . http_build_query($requestData),
+                'httpMethod' => Request::HTTP_METHOD_GET,
+            ],
+            'soap' => [
+                'service' => self::SOURCE_ITEMS_SERVICE_NAME,
+                'serviceVersion' => self::SOURCE_ITEMS_SERVICE_VERSION,
+                'operation' => self::SOURCE_ITEMS_SERVICE_NAME . 'Save',
+            ],
+        ];
+        $response = (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST)
+            ? $this->_webApiCall($serviceInfo)
+            : $this->_webApiCall($serviceInfo, $requestData);
+
+        return $response['items'];
+    }
+
+    /**
+     * Get necessary sample data to create a product
+     *
+     * @return array
+     */
+    private function getProductSampleData(): array
+    {
+        $name = uniqid('simple-product-');
+        return [
+            ProductInterface::SKU => $name,
+            ProductInterface::NAME => $name,
+            ProductInterface::TYPE_ID => 'simple',
+            ProductInterface::PRICE => 100,
+            ProductInterface::ATTRIBUTE_SET_ID => 4,
+        ];
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
- Source Items and Source Item Configurations are not removed when product is deleted, therefore a new product with same SKU will inherit previously deleted product source items data (Fixed in  #2795 )
- Products created with webapi without stock data are assigned to default source.

### Manual testing scenarios (*)
- Install Magento with MSI
- Create new Source Stores->Inventory->Sources (Name: Second, code: second), specify the address, Save.
- Create a new product through the backend. Name: Simple Product1, sku: test111, price: 100, assign sources: second, qty: 100. Save
- Go back to the product grid. Note the quantity per source: "Second: 100".
- Mark the product in the grid and delete it.
- Create a new integration: System -> Extensions -> Integrations. Enter the name, your password, and all privileges. Save. Activate. Copy the Access token.
- Go to the Swagger: http://site.local/swagger/ . Specify the token, apply it.
Select catalogProductRepositoryV1 -> POST - > /V1/products, Try it out.
Specify the request body: 
```json
{
 "product": {
    "sku": "test111",
    "name": "Simple Product2",
    "attribute_set_id": 4,
    "price": 100,
    "type_id": "simple"
 }
```

- Note that the sku is the same as in #3. Click Execute. The product must be successfully created (code 200)
- Go back to the backend in the product grid.

EXPECTED RESULTS

The new product is not assigned to sources and has no quantity.

ACTUAL RESULTS

The new product is assigned with two sources - the default with qty 0 and the second with qty 100 from the deleted product.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
This is issue is not reproducible if the product is created on backend. However the source items data are not removed until a new product is created that match the  previously deleted product's SKU, then old source items data are removed on fly.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
