### PR TITLE
Load default pickup locations list with empty search query

### DIFF
--- a/InventoryInStorePickupFrontend/view/frontend/web/js/view/store-selector.js
+++ b/InventoryInStorePickupFrontend/view/frontend/web/js/view/store-selector.js
@@ -15,7 +15,8 @@ define([
     'Magento_Checkout/js/model/address-converter',
     'Magento_Checkout/js/action/set-shipping-information',
     'Magento_InventoryInStorePickupFrontend/js/model/pickup-locations-service',
-    'Magento_Checkout/js/checkout-data'
+    'Magento_Checkout/js/checkout-data',
+    'Magento_InventoryInStorePickupFrontend/js/view/store-pickup'
 ], function (
     $,
     _,
@@ -74,6 +75,7 @@ define([
                 this.updateNearbyLocations(searchQuery + this.delimiter + country);
             }, this.searchDebounceTimeout).bind(this);
             this.searchQuery.subscribe(updateNearbyLocations);
+            this.searchQuery.notifySubscribers('');
 
             return this;
         },


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The pickup locations list was empty until uses try to search them.
Now it is not

### Manual testing scenarios (*)
1. Go to 'Pick in Store' checkout step
2. Click 'Select Store'
3. Make sure it is not empty: Pickup locations for the store default country are loaded


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
