### PR TITLE
[TSG] MC-29851: Unexpected message appears if you try to add products to order via admin panel

### DIFF
--- a/InventorySalesAdminUi/Test/Mftf/Test/AdminAddSelectedProductToOrderTest.xml
+++ b/InventorySalesAdminUi/Test/Mftf/Test/AdminAddSelectedProductToOrderTest.xml
@@ -5,7 +5,6 @@
   * See COPYING.txt for license details.
   */
 -->
-
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAddSelectedProductToOrderTest">

--- a/InventorySalesAdminUi/Test/Mftf/Test/AdminAddSelectedProductToOrderTest.xml
+++ b/InventorySalesAdminUi/Test/Mftf/Test/AdminAddSelectedProductToOrderTest.xml
@@ -10,6 +10,7 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAddSelectedProductToOrderTest">
         <actionGroup ref="AssertAdminItemOrderedErrorActionGroup" stepKey="assertProductErrorRemains">
+            <argument name="productName" value="$simpleProduct.name$"/>
             <argument name="messageType" value="error"/>
         </actionGroup>
     </test>

--- a/InventorySalesAdminUi/Test/Mftf/Test/AdminAddSelectedProductToOrderTest.xml
+++ b/InventorySalesAdminUi/Test/Mftf/Test/AdminAddSelectedProductToOrderTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAddSelectedProductToOrderTest">
+        <actionGroup ref="AssertAdminItemOrderedErrorNotVisibleActionGroup" stepKey="assertErrorAbsent">
+            <argument name="messageType" value="error"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/InventorySalesAdminUi/Test/Mftf/Test/AdminAddSelectedProductToOrderTest.xml
+++ b/InventorySalesAdminUi/Test/Mftf/Test/AdminAddSelectedProductToOrderTest.xml
@@ -9,7 +9,7 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAddSelectedProductToOrderTest">
-        <actionGroup ref="AssertAdminItemOrderedErrorNotVisibleActionGroup" stepKey="assertErrorAbsent">
+        <actionGroup ref="AssertAdminItemOrderedErrorActionGroup" stepKey="assertProductErrorRemains">
             <argument name="messageType" value="error"/>
         </actionGroup>
     </test>


### PR DESCRIPTION
## Scope

### Bug - P1
* [MC-29851](https://jira.corp.magento.com/browse/MC-29851) Unexpected message appears if you try to add products to order via admin panel
* [#1637](https://github.com/magento/inventory/issues/1637) Unnecessary warning message during creating order with out-of-stock product

### Bamboo CI builds

* [x] [Performance Acceptance Test](https://bamboo.corp.magento.com/browse/MCCE23-PAT4383/latest)

### Related Pull Requests

- CE https://github.com/magento-tsg/magento2ce/pull/681
- EE https://github.com/magento-tsg/magento2ee/pull/434

### CE Checklist

- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Unit, Extended FAT CE, Extended FAT EE and Extended FAT B2B builds are green
