### PR TITLE
#26989 MFTF: Use <magentoCron> for reindex

### DIFF
--- a/InventoryAdminUi/Test/Mftf/Test/AdminCancelOrderConfigurableProductWithDropDownAttributeAndCustomSourceTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCancelOrderConfigurableProductWithDropDownAttributeAndCustomSourceTest.xml
@@ -83,7 +83,7 @@
             <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <!--Add configurable product to cart.-->

--- a/InventoryAdminUi/Test/Mftf/Test/AdminCreateCreditMemoWholeOrderWithConfigurableProductFromCustomSourceTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCreateCreditMemoWholeOrderWithConfigurableProductFromCustomSourceTest.xml
@@ -86,7 +86,7 @@
             <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <!--Add configurable product to cart.-->

--- a/InventoryAdminUi/Test/Mftf/Test/AdminCreateScheduledPermanentUpdateConfigurableProductCustomStockTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCreateScheduledPermanentUpdateConfigurableProductCustomStockTest.xml
@@ -70,7 +70,7 @@
             <deleteData createDataKey="stock" stepKey="deleteStock" before="amOnLogoutPage"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <!--Assign source to configurable product.-->

--- a/InventoryAdminUi/Test/Mftf/Test/AdminCreateScheduledPermanentUpdateConfigurableProductDefaultStockTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCreateScheduledPermanentUpdateConfigurableProductDefaultStockTest.xml
@@ -66,7 +66,7 @@
             </actionGroup>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <!--Verify configurable product on storefront.-->

--- a/InventoryAdminUi/Test/Mftf/Test/AdminCreateShipmentForWholeOrderWithConfigurableProductFromCustomSourceTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCreateShipmentForWholeOrderWithConfigurableProductFromCustomSourceTest.xml
@@ -89,7 +89,7 @@
             <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <!--Add configurable product to cart.-->

--- a/InventoryAdminUi/Test/Mftf/Test/AdminCreateShipmentForWholeOrderWithConfigurableProductFromDefaultSourceTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCreateShipmentForWholeOrderWithConfigurableProductFromDefaultSourceTest.xml
@@ -66,7 +66,7 @@
             <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <!--Add configurable product to cart.-->

--- a/InventoryAdminUi/Test/Mftf/Test/AdminInvoiceCreatedForWholeOrderWithConfigurableProductTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminInvoiceCreatedForWholeOrderWithConfigurableProductTest.xml
@@ -73,7 +73,7 @@
             <deleteData createDataKey="customer" stepKey="deleteCustomer"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <actionGroup ref="AdminOpenProductIndexPageActionGroup" stepKey="openProductGrid"/>

--- a/InventoryAdminUi/Test/Mftf/Test/AdminReorderOfTheOrderWithConfigurableProductWithDropDownAttributeOnDefaultStockFromAdminTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminReorderOfTheOrderWithConfigurableProductWithDropDownAttributeOnDefaultStockFromAdminTest.xml
@@ -78,7 +78,7 @@
             <deleteData createDataKey="customer" stepKey="deleteCustomer"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <!-- Create a configurable product -->

--- a/InventoryAdminUi/Test/Mftf/Test/StorefrontBackordersEnabledOnConfigurationPageAndAppliedFromHomepageToWithConfigurableProductWithDropDownAttributeAndVariablesAssignedToNonDefaultSourceTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/StorefrontBackordersEnabledOnConfigurationPageAndAppliedFromHomepageToWithConfigurableProductWithDropDownAttributeAndVariablesAssignedToNonDefaultSourceTest.xml
@@ -80,7 +80,7 @@
             <deleteData createDataKey="customer" stepKey="deleteCustomer"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <actionGroup ref="AdminOpenProductIndexPageActionGroup" stepKey="openProductGrid"/>

--- a/InventoryAdminUi/Test/Mftf/Test/StorefrontButtonReorderForTheOrderWithConfigurableProductOnDefaultStockInCustomerCabinetOnHomepageIsNotPresentIfProductSoldOutTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/StorefrontButtonReorderForTheOrderWithConfigurableProductOnDefaultStockInCustomerCabinetOnHomepageIsNotPresentIfProductSoldOutTest.xml
@@ -75,7 +75,7 @@
             <deleteData createDataKey="customer" stepKey="deleteCustomer"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <!-- Create a configurable product -->

--- a/InventoryAdminUi/Test/Mftf/Test/StorefrontLoggedInCustomerOrderConfigurableProductWithDropDownAttributeAndCustomSourceTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/StorefrontLoggedInCustomerOrderConfigurableProductWithDropDownAttributeAndCustomSourceTest.xml
@@ -83,7 +83,7 @@
             <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <!--Add configurable product to cart.-->

--- a/InventoryAdminUi/Test/Mftf/Test/StorefrontLoggedInCustomerOrderConfigurableProductWithDropDownAttributeAndDefaultSourceTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/StorefrontLoggedInCustomerOrderConfigurableProductWithDropDownAttributeAndDefaultSourceTest.xml
@@ -72,7 +72,7 @@
             <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <!--Add configurable product to cart.-->

--- a/InventoryAdminUi/Test/Mftf/Test/StorefrontPartialInvoiceCreatedForOrderWithConfigurableProductInAdminTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/StorefrontPartialInvoiceCreatedForOrderWithConfigurableProductInAdminTest.xml
@@ -71,7 +71,7 @@
             <deleteData createDataKey="customer" stepKey="deleteCustomer"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <actionGroup ref="AdminOpenProductIndexPageActionGroup" stepKey="openProductGrid"/>

--- a/InventoryAdminUi/Test/Mftf/Test/StorefrontPriceOfConfigurableProductAssignedToTestStockAndTestWebsiteWhenOptionOfDisplayingOutOfStockProductsEnabledTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/StorefrontPriceOfConfigurableProductAssignedToTestStockAndTestWebsiteWhenOptionOfDisplayingOutOfStockProductsEnabledTest.xml
@@ -98,7 +98,7 @@
             <magentoCLI command="config:set {{StorefrontDisableAddStoreCodeToUrls.path}} {{StorefrontDisableAddStoreCodeToUrls.value}}" stepKey="addStoreCodeToUrlDisable"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <actionGroup ref="AdminOpenProductIndexPageActionGroup" stepKey="openProductGrid"/>

--- a/InventoryAdminUi/Test/Mftf/Test/StorefrontQuickOrderConfigurableProductsCustomStockTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/StorefrontQuickOrderConfigurableProductsCustomStockTest.xml
@@ -125,7 +125,7 @@
             <actionGroup ref="logout" stepKey="logout"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <remove keyForRemoval="quickOrderAddProductToCart"/>

--- a/InventoryAdminUi/Test/Mftf/Test/StorefrontSalableQuantityOnNonDefaultStockForConfigurableProductWithDropDownAttributeAfterPlacingOrderCountedCorrectlyTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/StorefrontSalableQuantityOnNonDefaultStockForConfigurableProductWithDropDownAttributeAfterPlacingOrderCountedCorrectlyTest.xml
@@ -76,7 +76,7 @@
             <deleteData createDataKey="customer" stepKey="deleteCustomer"/>
 
             <!-- Reindex invalidated indices after product attribute has been created/deleted -->
-            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
         </after>
 
         <actionGroup ref="AdminOpenProductIndexPageActionGroup" stepKey="openProductGrid"/>


### PR DESCRIPTION
### Description (*)
Optimize Functional Tests performance by using `<magentoCron groups="index">` where applicable.
Replace `cache:flush` with `cache:flush config` where applicable.,

### Similar Pull Requests
* https://github.com/magento/magento2/pull/26990
* https://github.com/magento/partners-magento2b2b/pull/53
<!-- similar pull request placeholder -->

### Fixed Issues (if relevant)
1. magento/magento2#26989

### Manual testing scenarios (*)
1. CI Functional Tests should pass in < 70 minutes

### Questions or comments
**Work In Progress** as I need to stabilise the CI.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
