### PR TITLE
Msi 2825 hide store pickup on the checkout if one of the products in cart is not available for pickup

### DIFF
--- a/InventoryInStorePickup/Model/ProductInfo.php
+++ b/InventoryInStorePickup/Model/ProductInfo.php
@@ -15,6 +15,8 @@ use Magento\InventoryInStorePickupApi\Api\Data\SearchRequest\ProductInfoInterfac
  */
 class ProductInfo implements ProductInfoInterface
 {
+    public const SKU = 'sku';
+
     /**
      * @var string
      */

--- a/InventoryInStorePickup/Model/ProductInfo.php
+++ b/InventoryInStorePickup/Model/ProductInfo.php
@@ -15,8 +15,6 @@ use Magento\InventoryInStorePickupApi\Api\Data\SearchRequest\ProductInfoInterfac
  */
 class ProductInfo implements ProductInfoInterface
 {
-    public const SKU = 'sku';
-
     /**
      * @var string
      */

--- a/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
+++ b/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
@@ -18,17 +18,6 @@ $sourceItemFactory = Bootstrap::getObjectManager()->get(SourceItemInterfaceFacto
 /** @var  SourceItemsSaveInterface $sourceItemsSave */
 $sourceItemsSave = Bootstrap::getObjectManager()->get(SourceItemsSaveInterface::class);
 
-/**
- * SKU-1 - EU-source-1(id:10) - 5.5qty
- * SKU-1 - EU-source-2(id:20) - 3qty
- * SKU-1 - EU-source-3(id:30) - 10qty
- * SKU-1 - EU-source-4(id:40) - 10qty (disabled source)
- *
- * SKU-2 - US-source-1(id:30) - 5qty
- * SKU-2 - EU-source-2(id:20) - 3qty
- *
- * SKU-3 - EU-source-2(id:20) - 6qty
- */
 $sourcesItemsData = [
     [
         SourceItemInterface::SOURCE_CODE => 'eu-1',
@@ -39,26 +28,14 @@ $sourcesItemsData = [
     [
         SourceItemInterface::SOURCE_CODE => 'eu-2',
         SourceItemInterface::SKU => 'SKU-1',
-        SourceItemInterface::QUANTITY => 3.5,
-        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
+        SourceItemInterface::QUANTITY => 0,
+        SourceItemInterface::STATUS => SourceItemInterface::STATUS_OUT_OF_STOCK,
     ],
     [
         SourceItemInterface::SOURCE_CODE => 'eu-3',
         SourceItemInterface::SKU => 'SKU-1',
-        SourceItemInterface::QUANTITY => 10,
-        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
-    ],
-    [
-        SourceItemInterface::SOURCE_CODE => 'eu-disabled',
-        SourceItemInterface::SKU => 'SKU-1',
-        SourceItemInterface::QUANTITY => 10,
-        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
-    ],
-    [
-        SourceItemInterface::SOURCE_CODE => 'us-1',
-        SourceItemInterface::SKU => 'SKU-2',
-        SourceItemInterface::QUANTITY => 5,
-        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
+        SourceItemInterface::QUANTITY => 0,
+        SourceItemInterface::STATUS => SourceItemInterface::STATUS_OUT_OF_STOCK,
     ],
     [
         SourceItemInterface::SOURCE_CODE => 'eu-1',
@@ -79,28 +56,22 @@ $sourcesItemsData = [
         SourceItemInterface::STATUS => SourceItemInterface::STATUS_OUT_OF_STOCK,
     ],
     [
-        SourceItemInterface::SOURCE_CODE => 'eu-disabled',
-        SourceItemInterface::SKU => 'SKU-2',
+        SourceItemInterface::SOURCE_CODE => 'eu-1',
+        SourceItemInterface::SKU => 'SKU-3',
         SourceItemInterface::QUANTITY => 0,
         SourceItemInterface::STATUS => SourceItemInterface::STATUS_OUT_OF_STOCK,
     ],
     [
+        SourceItemInterface::SOURCE_CODE => 'eu-3',
+        SourceItemInterface::SKU => 'SKU-3',
+        SourceItemInterface::QUANTITY => 10,
+        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
+    ],
+    [
         SourceItemInterface::SOURCE_CODE => 'eu-2',
         SourceItemInterface::SKU => 'SKU-3',
-        SourceItemInterface::QUANTITY => 6,
-        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
-    ],
-    [
-        SourceItemInterface::SOURCE_CODE => 'eu-2',
-        SourceItemInterface::SKU => 'SKU-4',
-        SourceItemInterface::QUANTITY => 6,
-        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
-    ],
-    [
-        SourceItemInterface::SOURCE_CODE => 'eu-1',
-        SourceItemInterface::SKU => 'SKU-6',
-        SourceItemInterface::QUANTITY => 666,
-        SourceItemInterface::STATUS => SourceItemInterface::STATUS_IN_STOCK,
+        SourceItemInterface::QUANTITY => 0,
+        SourceItemInterface::STATUS => SourceItemInterface::STATUS_OUT_OF_STOCK,
     ],
 ];
 

--- a/InventoryInStorePickupQuoteGraphQl/Test/Api/Customer/PickupLocationForShippingTest.php
+++ b/InventoryInStorePickupQuoteGraphQl/Test/Api/Customer/PickupLocationForShippingTest.php
@@ -64,7 +64,7 @@ class PickupLocationForShippingTest extends GraphQlAbstract
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/create_in_store_pickup_quote_on_eu_website_customer.php
      *
@@ -174,7 +174,7 @@ QUERY;
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/create_in_store_pickup_quote_on_eu_website_customer.php
      *

--- a/InventoryInStorePickupQuoteGraphQl/Test/Api/Guest/PickupLocationForShippingTest.php
+++ b/InventoryInStorePickupQuoteGraphQl/Test/Api/Guest/PickupLocationForShippingTest.php
@@ -54,7 +54,7 @@ class PickupLocationForShippingTest extends GraphQlAbstract
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/create_in_store_pickup_quote_on_eu_website_guest.php
      *

--- a/InventoryInStorePickupSales/Test/Integration/Extension/OrderExtensionTest.php
+++ b/InventoryInStorePickupSales/Test/Integration/Extension/OrderExtensionTest.php
@@ -50,7 +50,7 @@ class OrderExtensionTest extends TestCase
      * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/create_in_store_pickup_quote_on_eu_website_guest.php
      * @magentoDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/place_order.php

--- a/InventoryInStorePickupSalesApi/Test/Api/OrderCreateTest.php
+++ b/InventoryInStorePickupSalesApi/Test/Api/OrderCreateTest.php
@@ -23,7 +23,7 @@ class OrderCreateTest extends OrderPlacementBase
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      *
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -59,7 +59,7 @@ class OrderCreateTest extends OrderPlacementBase
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      *
      * @return void
@@ -94,7 +94,7 @@ class OrderCreateTest extends OrderPlacementBase
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      *
      * @return void
@@ -130,7 +130,7 @@ class OrderCreateTest extends OrderPlacementBase
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      *
      * @return void
@@ -163,7 +163,7 @@ class OrderCreateTest extends OrderPlacementBase
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      *
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -213,7 +213,7 @@ class OrderCreateTest extends OrderPlacementBase
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      *
      * @return void

--- a/InventoryInStorePickupSalesApi/Test/Api/PlaceOrderTest.php
+++ b/InventoryInStorePickupSalesApi/Test/Api/PlaceOrderTest.php
@@ -77,11 +77,12 @@ class PlaceOrderTest extends GraphQlAbstract
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/create_in_store_pickup_quote_on_eu_website_guest.php
      *
      * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testPlaceOrderWithStorePickupDeliveryMethodGuestCustomer(): void
     {
@@ -120,12 +121,14 @@ QUERY;
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/create_in_store_pickup_quote_on_eu_website_customer.php
      * @magentoConfigFixture store_for_eu_website_store customer/account_share/scope 0
      *
      * @return void
+     * @throws \Magento\Framework\Exception\AuthenticationException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testPlaceOrderWithStorePickupDeliveryMethodRegisteredCustomerExistedAddress(): void
     {
@@ -163,12 +166,14 @@ QUERY;
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/create_in_store_pickup_quote_on_eu_website_customer.php
      * @magentoConfigFixture store_for_eu_website_store customer/account_share/scope 0
      *
      * @return void
+     * @throws \Magento\Framework\Exception\AuthenticationException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testPlaceOrderWithStorePickupDeliveryMethodRegisteredCustomerNewAddress(): void
     {
@@ -208,12 +213,14 @@ QUERY;
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/quote_with_save_shipping_address_to_address_book.php
      * @magentoConfigFixture store_for_eu_website_store customer/account_share/scope 0
      *
      * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testPlaceOrderWithStorePickupDeliveryMethodRegisteredCustomerAddressSaveInBook(): void
     {
@@ -257,12 +264,14 @@ QUERY;
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoApiDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/quote_with_shipping_address_same_as_billing.php
      * @magentoConfigFixture store_for_eu_website_store customer/account_share/scope 0
      *
      * @return void
+     * @throws \Magento\Framework\Exception\AuthenticationException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testPlaceOrderWithStorePickupDeliveryMethodRegisteredCustomerSameAsBillingAddress(): void
     {
@@ -304,6 +313,7 @@ QUERY;
      * @param string $password
      *
      * @return array
+     * @throws \Magento\Framework\Exception\AuthenticationException
      */
     private function getAuthHeader(string $username = 'customer@example.com', string $password = 'password'): array
     {
@@ -317,7 +327,9 @@ QUERY;
      * Verify created order.
      *
      * @param array $response
+     *
      * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     private function verifyOrder(array $response): void
     {

--- a/InventoryInStorePickupShipping/Model/Carrier/Validation/PickupLocationsAvailabilityValidator.php
+++ b/InventoryInStorePickupShipping/Model/Carrier/Validation/PickupLocationsAvailabilityValidator.php
@@ -10,7 +10,6 @@ namespace Magento\InventoryInStorePickupShipping\Model\Carrier\Validation;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Validation\ValidationResult;
 use Magento\Framework\Validation\ValidationResultFactory;
-use Magento\InventoryInStorePickup\Model\ProductInfo;
 use Magento\InventoryInStorePickupApi\Api\Data\SearchRequest\ProductInfoInterfaceFactory;
 use Magento\InventoryInStorePickupApi\Api\Data\SearchRequestExtensionFactory;
 use Magento\InventoryInStorePickupApi\Api\Data\SearchRequestExtensionInterface;
@@ -83,6 +82,7 @@ class PickupLocationsAvailabilityValidator implements RequestValidatorInterface
 
     /**
      * @inheritdoc
+     *
      * @throws NoSuchEntityException
      */
     public function validate(RateRequest $rateRequest): ValidationResult
@@ -132,7 +132,7 @@ class PickupLocationsAvailabilityValidator implements RequestValidatorInterface
     {
         $productsInfo = [];
         foreach ($items as $item) {
-            $productsInfo[] = $this->productInfoFactory->create([ProductInfo::SKU => $item->getSku()]);
+            $productsInfo[] = $this->productInfoFactory->create(['sku' => $item->getSku()]);
         }
 
         $extensionAttributes = $this->searchRequestExtensionFactory->create();

--- a/InventoryInStorePickupShipping/Model/Carrier/Validation/PickupLocationsAvailabilityValidator.php
+++ b/InventoryInStorePickupShipping/Model/Carrier/Validation/PickupLocationsAvailabilityValidator.php
@@ -11,6 +11,8 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Validation\ValidationResult;
 use Magento\Framework\Validation\ValidationResultFactory;
 use Magento\InventoryInStorePickup\Model\ProductInfo;
+use Magento\InventoryInStorePickupApi\Api\Data\SearchRequest\ProductInfoInterfaceFactory;
+use Magento\InventoryInStorePickupApi\Api\Data\SearchRequestExtensionFactory;
 use Magento\InventoryInStorePickupApi\Api\Data\SearchRequestExtensionInterface;
 use Magento\InventoryInStorePickupApi\Api\GetPickupLocationsInterface;
 use Magento\InventoryInStorePickupApi\Model\SearchRequestBuilderInterface;
@@ -87,11 +89,11 @@ class PickupLocationsAvailabilityValidator implements RequestValidatorInterface
     {
         $errors = [];
 
-        if ($this->isAnyPickupLocationAvailable($rateRequest)) {
-            $errors[] = __('No Pickup Locations available to satisfy Rate Request.');
+        if (!$this->isAnyPickupLocationAvailable($rateRequest)) {
+            $errors[] = __('No Pickup Locations available to satisfy the Rate Request.');
         }
 
-        return $this->validationResultFactory->create($errors);
+        return $this->validationResultFactory->create(['errors' => $errors]);
     }
 
     /**

--- a/InventoryInStorePickupShipping/Model/Carrier/Validation/PickupLocationsAvailabilityValidator.php
+++ b/InventoryInStorePickupShipping/Model/Carrier/Validation/PickupLocationsAvailabilityValidator.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryInStorePickupShipping\Model\Carrier\Validation;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Validation\ValidationResult;
+use Magento\Framework\Validation\ValidationResultFactory;
+use Magento\InventoryInStorePickup\Model\ProductInfo;
+use Magento\InventoryInStorePickupApi\Api\Data\SearchRequestExtensionInterface;
+use Magento\InventoryInStorePickupApi\Api\GetPickupLocationsInterface;
+use Magento\InventoryInStorePickupApi\Model\SearchRequestBuilderInterface;
+use Magento\InventoryInStorePickupShippingApi\Model\Carrier\Validation\RequestValidatorInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\Quote\Model\Quote\Address\RateRequest;
+use Magento\Quote\Model\Quote\Item;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+
+/**
+ * Validate that Pickup Locations available for the Rate Request.
+ */
+class PickupLocationsAvailabilityValidator implements RequestValidatorInterface
+{
+    /**
+     * @var WebsiteRepositoryInterface
+     */
+    private $websiteRepository;
+
+    /**
+     * @var ValidationResultFactory
+     */
+    private $validationResultFactory;
+
+    /**
+     * @var SearchRequestBuilderInterface
+     */
+    private $searchRequestBuilder;
+
+    /**
+     * @var GetPickupLocationsInterface
+     */
+    private $getPickupLocations;
+
+    /**
+     * @var SearchRequestExtensionFactory
+     */
+    private $searchRequestExtensionFactory;
+
+    /**
+     * @var ProductInfoInterfaceFactory
+     */
+    private $productInfoFactory;
+
+    /**
+     * @param WebsiteRepositoryInterface $websiteRepository
+     * @param ValidationResultFactory $validationResultFactory
+     * @param SearchRequestBuilderInterface $searchRequestBuilder
+     * @param GetPickupLocationsInterface $getPickupLocations
+     * @param SearchRequestExtensionFactory $searchRequestExtensionFactory ,
+     * @param ProductInfoInterfaceFactory $productInfoFactory
+     */
+    public function __construct(
+        WebsiteRepositoryInterface $websiteRepository,
+        ValidationResultFactory $validationResultFactory,
+        SearchRequestBuilderInterface $searchRequestBuilder,
+        GetPickupLocationsInterface $getPickupLocations,
+        SearchRequestExtensionFactory $searchRequestExtensionFactory,
+        ProductInfoInterfaceFactory $productInfoFactory
+    ) {
+        $this->websiteRepository = $websiteRepository;
+        $this->validationResultFactory = $validationResultFactory;
+        $this->searchRequestBuilder = $searchRequestBuilder;
+        $this->getPickupLocations = $getPickupLocations;
+        $this->searchRequestExtensionFactory = $searchRequestExtensionFactory;
+        $this->productInfoFactory = $productInfoFactory;
+    }
+
+    /**
+     * @inheritdoc
+     * @throws NoSuchEntityException
+     */
+    public function validate(RateRequest $rateRequest): ValidationResult
+    {
+        $errors = [];
+
+        if ($this->isAnyPickupLocationAvailable($rateRequest)) {
+            $errors[] = __('No Pickup Locations available to satisfy Rate Request.');
+        }
+
+        return $this->validationResultFactory->create($errors);
+    }
+
+    /**
+     * Check if at least one Pickup Location satisfy Rate Request.
+     *
+     * @param RateRequest $rateRequest
+     *
+     * @return bool
+     * @throws NoSuchEntityException
+     */
+    public function isAnyPickupLocationAvailable(RateRequest $rateRequest): bool
+    {
+        $website = $this->websiteRepository->getById((int)$rateRequest->getWebsiteId());
+
+        $extensionAttributes = $this->getSearchRequestExtension($rateRequest->getAllItems());
+
+        $searchRequest = $this->searchRequestBuilder->setScopeType(SalesChannelInterface::TYPE_WEBSITE)
+            ->setScopeCode($website->getCode())
+            ->setSearchRequestExtension($extensionAttributes)
+            ->setPageSize(1)
+            ->create();
+
+        $pickupLocations = $this->getPickupLocations->execute($searchRequest);
+
+        return $pickupLocations->getTotalCount() !== 0;
+    }
+
+    /**
+     * Prepare and return Search Request Extension.
+     *
+     * @param Item[] $items
+     *
+     * @return SearchRequestExtensionInterface
+     */
+    private function getSearchRequestExtension(array $items): SearchRequestExtensionInterface
+    {
+        $productsInfo = [];
+        foreach ($items as $item) {
+            $productsInfo[] = $this->productInfoFactory->create([ProductInfo::SKU => $item->getSku()]);
+        }
+
+        $extensionAttributes = $this->searchRequestExtensionFactory->create();
+        $extensionAttributes->setProductsInfo($productsInfo);
+
+        return $extensionAttributes;
+    }
+}

--- a/InventoryInStorePickupShipping/Model/Carrier/Validation/SalesChannelValidator.php
+++ b/InventoryInStorePickupShipping/Model/Carrier/Validation/SalesChannelValidator.php
@@ -33,31 +33,15 @@ class SalesChannelValidator implements RequestValidatorInterface
     private $validationResultFactory;
 
     /**
-     * @var SearchRequestBuilderInterface
-     */
-    private $searchRequestBuilder;
-
-    /**
-     * @var GetPickupLocationsInterface
-     */
-    private $getPickupLocations;
-
-    /**
      * @param WebsiteRepositoryInterface $websiteRepository
      * @param ValidationResultFactory $validationResultFactory
-     * @param SearchRequestBuilderInterface $searchRequestBuilder
-     * @param GetPickupLocationsInterface $getPickupLocations
      */
     public function __construct(
         WebsiteRepositoryInterface $websiteRepository,
-        ValidationResultFactory $validationResultFactory,
-        SearchRequestBuilderInterface $searchRequestBuilder,
-        GetPickupLocationsInterface $getPickupLocations
+        ValidationResultFactory $validationResultFactory
     ) {
         $this->websiteRepository = $websiteRepository;
         $this->validationResultFactory = $validationResultFactory;
-        $this->searchRequestBuilder = $searchRequestBuilder;
-        $this->getPickupLocations = $getPickupLocations;
     }
 
     /**
@@ -68,34 +52,11 @@ class SalesChannelValidator implements RequestValidatorInterface
         $errors = [];
 
         try {
-            $website = $this->websiteRepository->getById((int)$rateRequest->getWebsiteId());
-
-            if (!$this->isAnyPickupLocationAvailable($website->getCode())) {
-                $errors[] = __('No Pickup Locations available for Sales Channel %1.', $website->getCode());
-            }
+            $this->websiteRepository->getById((int)$rateRequest->getWebsiteId());
         } catch (NoSuchEntityException $exception) {
             $errors[] = __('Can not resolve Sales Channel for Website with id %1.', $rateRequest->getWebsiteId());
         }
 
         return $this->validationResultFactory->create(['errors' => $errors]);
-    }
-
-    /**
-     * Check if at least one Pickup Location is available for the website sales channel.
-     *
-     * @param string $websiteCode
-     *
-     * @return bool
-     */
-    private function isAnyPickupLocationAvailable(string $websiteCode): bool
-    {
-        $searchRequest = $this->searchRequestBuilder->setScopeType(SalesChannelInterface::TYPE_WEBSITE)
-            ->setScopeCode($websiteCode)
-            ->setPageSize(1)
-            ->create();
-
-        $pickupLocations = $this->getPickupLocations->execute($searchRequest);
-
-        return (bool) $pickupLocations->getTotalCount();
     }
 }

--- a/InventoryInStorePickupShipping/Test/Integration/Carrier/InStorePickupTest.php
+++ b/InventoryInStorePickupShipping/Test/Integration/Carrier/InStorePickupTest.php
@@ -49,7 +49,7 @@ class InStorePickupTest extends TestCase
      * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/create_in_store_pickup_quote_on_eu_website_guest.php
      *
@@ -78,7 +78,7 @@ class InStorePickupTest extends TestCase
      * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
      * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
      * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
-     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_items_eu_stock_only.php
      * @magentoDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoDataFixture Magento/Sales/_files/quote.php
      *
@@ -113,6 +113,36 @@ class InStorePickupTest extends TestCase
         $this->cartRepository->save($cart);
 
         $cart = $this->cartRepository->get($cart->getId());
+
+        $this->assertEmpty($cart->getShippingAddress()->getShippingMethod());
+        $this->assertEquals(0, $cart->getShippingAddress()->getShippingAmount());
+    }
+
+    /**
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/products.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/sources.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_addresses.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryInStorePickupApi/Test/_files/source_pickup_location_attributes.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stock_source_links.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/websites_with_stores.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventorySalesApi/Test/_files/stock_website_sales_channels.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/source_items_eu_stock_only.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryInStorePickupSalesApi/Test/_files/create_in_store_pickup_quote_on_eu_website_guest.php
+     *
+     * @magentoConfigFixture store_for_eu_website_store carriers/in_store/active 1
+     * @magentoConfigFixture store_for_eu_website_store carriers/in_store/price 5.95
+     *
+     * @magentoDbIsolation disabled
+     */
+    public function testShippingMethodWithoutProductsIntersection()
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter('reserved_order_id', 'in_store_pickup_test_order')
+            ->create();
+        /** @var \Magento\Quote\Api\Data\CartInterface $cart */
+        $cart = current($this->cartRepository->getList($searchCriteria)->getItems());
 
         $this->assertEmpty($cart->getShippingAddress()->getShippingMethod());
         $this->assertEquals(0, $cart->getShippingAddress()->getShippingAmount());

--- a/InventoryInStorePickupShipping/etc/di.xml
+++ b/InventoryInStorePickupShipping/etc/di.xml
@@ -15,6 +15,7 @@
         <arguments>
             <argument name="validators" xsi:type="array">
                 <item name="sales_channel" xsi:type="object">Magento\InventoryInStorePickupShipping\Model\Carrier\Validation\SalesChannelValidator</item>
+                <item name="pickup_locations_availability" xsi:type="object">Magento\InventoryInStorePickupShipping\Model\Carrier\Validation\PickupLocationsAvailabilityValidator</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
### Description (*)
https://github.com/magento/inventory/issues/2825

### Fixed Issues (if relevant)
1. magento/inventory#2825: Hide store pickup during order submissions if one of the products is not available for pickup

### Dependencies ###
Depends on https://github.com/magento/inventory/pull/2839