### PR TITLE
[TSG] MC-32302: Error on Backend Orders Page after split database 

### DIFF
--- a/InventoryShippingAdminUi/Model/ResourceModel/GetAllocatedSourcesForOrder.php
+++ b/InventoryShippingAdminUi/Model/ResourceModel/GetAllocatedSourcesForOrder.php
@@ -40,15 +40,16 @@ class GetAllocatedSourcesForOrder
         $sources = [];
         $salesConnection = $this->resourceConnection->getConnection('sales');
         $shipmentTableName = $this->resourceConnection->getTableName('sales_shipment', 'sales');
-
+        /** Get shipment ids for order */
         $shipmentSelect = $salesConnection->select()
             ->from(
                 ['sales_shipment' => $shipmentTableName],
-                ['shipment' => 'sales_shipment.entity_id']
+                ['shipment_id' => 'sales_shipment.entity_id']
             )
             ->where('sales_shipment.order_id = ?', $orderId);
         $shipmentsIds = $salesConnection->fetchCol($shipmentSelect);
 
+        /** Get sources for shipment ids */
         if (!empty($shipmentsIds)) {
             $connection = $this->resourceConnection->getConnection();
             $inventorySourceTableName = $this->resourceConnection->getTableName('inventory_source');

--- a/InventoryShippingAdminUi/Test/Integration/Model/ResourceModel/GetAllocatedSourcesForOrderTest.php
+++ b/InventoryShippingAdminUi/Test/Integration/Model/ResourceModel/GetAllocatedSourcesForOrderTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryShippingAdminUi\Test\Integration\Model\ResourceModel;
+
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\InventoryShippingAdminUi\Model\ResourceModel\GetAllocatedSourcesForOrder;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\OrderRepository;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Test for \Magento\InventoryShippingAdminUi\Model\ResourceModel\GetAllocatedSourcesForOrder
+ */
+class GetAllocatedSourcesForOrderTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var OrderRepository
+     */
+    private $orderRepository;
+
+    /**
+     * @var GetAllocatedSourcesForOrder
+     */
+    private $model;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->orderRepository = $this->objectManager->get(OrderRepository::class);
+
+        $this->model = $this->objectManager->get(GetAllocatedSourcesForOrder::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/shipment.php
+     */
+    public function testExecute(): void
+    {
+        /** @var SearchCriteria $searchCriteria */
+        $searchCriteria = $this->objectManager->create(SearchCriteriaBuilder::class)
+            ->addFilter(OrderInterface::INCREMENT_ID, '100000001')
+            ->create();
+
+        $orders = $this->orderRepository->getList($searchCriteria)->getItems();
+        /** @var OrderInterface|null $order */
+        $order = reset($orders);
+
+        if ($order->getId()) {
+            $expected = ['Default Source'];
+            $result = $this->model->execute((int)$order->getId());
+            $this->assertEquals($expected, $result, 'The source doesn\'t exist');
+        } else {
+            $this->fail(__('The order doesn\'t exist.'));
+        }
+    }
+}

--- a/InventoryShippingAdminUi/Test/Integration/Model/ResourceModel/GetAllocatedSourcesForOrderTest.php
+++ b/InventoryShippingAdminUi/Test/Integration/Model/ResourceModel/GetAllocatedSourcesForOrderTest.php
@@ -45,26 +45,23 @@ class GetAllocatedSourcesForOrderTest extends \PHPUnit\Framework\TestCase
         $this->model = $this->objectManager->get(GetAllocatedSourcesForOrder::class);
     }
 
-    /**
-     * @magentoDataFixture Magento/Sales/_files/shipment.php
-     */
     public function testExecute(): void
     {
-        /** @var SearchCriteria $searchCriteria */
-        $searchCriteria = $this->objectManager->create(SearchCriteriaBuilder::class)
-            ->addFilter(OrderInterface::INCREMENT_ID, '100000001')
-            ->create();
-
-        $orders = $this->orderRepository->getList($searchCriteria)->getItems();
-        /** @var OrderInterface|null $order */
-        $order = reset($orders);
-
-        if ($order->getId()) {
-            $expected = ['Default Source'];
-            $result = $this->model->execute((int)$order->getId());
-            $this->assertEquals($expected, $result, 'The source doesn\'t exist');
-        } else {
-            $this->fail(__('The order doesn\'t exist.'));
-        }
+//        /** @var SearchCriteria $searchCriteria */
+//        $searchCriteria = $this->objectManager->create(SearchCriteriaBuilder::class)
+//            ->addFilter(OrderInterface::INCREMENT_ID, '100000001')
+//            ->create();
+//
+//        $orders = $this->orderRepository->getList($searchCriteria)->getItems();
+//        /** @var OrderInterface|null $order */
+//        $order = reset($orders);
+//
+//        if ($order->getId()) {
+//            $expected = ['Default Source'];
+//            $result = $this->model->execute((int)$order->getId());
+//            $this->assertEquals($expected, $result, 'The source doesn\'t exist');
+//        } else {
+//            $this->fail(__('The order doesn\'t exist.'));
+//        }
     }
 }

--- a/InventoryShippingAdminUi/Test/Integration/Model/ResourceModel/GetAllocatedSourcesForOrderTest.php
+++ b/InventoryShippingAdminUi/Test/Integration/Model/ResourceModel/GetAllocatedSourcesForOrderTest.php
@@ -45,23 +45,26 @@ class GetAllocatedSourcesForOrderTest extends \PHPUnit\Framework\TestCase
         $this->model = $this->objectManager->get(GetAllocatedSourcesForOrder::class);
     }
 
+    /**
+     * @magentoDataFixture Magento/Sales/_files/shipment.php
+     */
     public function testExecute(): void
     {
-//        /** @var SearchCriteria $searchCriteria */
-//        $searchCriteria = $this->objectManager->create(SearchCriteriaBuilder::class)
-//            ->addFilter(OrderInterface::INCREMENT_ID, '100000001')
-//            ->create();
-//
-//        $orders = $this->orderRepository->getList($searchCriteria)->getItems();
-//        /** @var OrderInterface|null $order */
-//        $order = reset($orders);
-//
-//        if ($order->getId()) {
-//            $expected = ['Default Source'];
-//            $result = $this->model->execute((int)$order->getId());
-//            $this->assertEquals($expected, $result, 'The source doesn\'t exist');
-//        } else {
-//            $this->fail(__('The order doesn\'t exist.'));
-//        }
+        /** @var SearchCriteria $searchCriteria */
+        $searchCriteria = $this->objectManager->create(SearchCriteriaBuilder::class)
+            ->addFilter(OrderInterface::INCREMENT_ID, '100000001')
+            ->create();
+
+        $orders = $this->orderRepository->getList($searchCriteria)->getItems();
+        /** @var OrderInterface|null $order */
+        $order = reset($orders);
+
+        if ($order->getId()) {
+            $expected = ['Default Source'];
+            $result = $this->model->execute((int)$order->getId());
+            $this->assertEquals($expected, $result, 'The source doesn\'t exist');
+        } else {
+            $this->fail(__('The order doesn\'t exist.'));
+        }
     }
 }


### PR DESCRIPTION
## Scope

### Bug - P1
* [MC-32302](https://jira.corp.magento.com/browse/MC-32302) Error on Backend Orders Page after split database 

### Bamboo CI builds

* [x] [Performance Acceptance Test](https://bamboo.corp.magento.com/browse/MCCE23-PAT4431/latest)

### Linked Pull Requests

- CE https://github.com/magento/magento2ce/pull/5468

### CE Checklist

- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Unit, Extended FAT CE, Extended FAT EE and Extended FAT B2B builds are green
