### PR TITLE
Remove inventory reservations based on orders

### DIFF
--- a/InventoryReservations/Model/ResourceModel/CleanupReservations.php
+++ b/InventoryReservations/Model/ResourceModel/CleanupReservations.php
@@ -51,7 +51,7 @@ class CleanupReservations implements CleanupReservationsInterface
                 $reservationTable,
                 ['GROUP_CONCAT(' . ReservationInterface::RESERVATION_ID . ')']
             )
-            ->group([ReservationInterface::STOCK_ID, ReservationInterface::SKU])
+            ->group("JSON_EXTRACT(metadata, '$.object_id')")
             ->having('SUM(' . ReservationInterface::QUANTITY . ') = 0');
             $connection->query('SET group_concat_max_len = ' . $this->groupConcatMaxLen);
         $groupedReservationIds = implode(',', $connection->fetchCol($select));


### PR DESCRIPTION
Original PR #2420
Created this PR after my conversation with @ishakhsuvarov on slack.

### Description (*)
Our client relies heavily on the rest API to create/update products, fetch order and create shipments. We recently had some issues where they were calling the create shipment API for the same order multiple times. This resulted in multiple shipments being created (this a whole different problem, let't not discuss that now :slightly_smiling_face: ).
So let's say this happenend for order 1, the source reservations will be:
```
+----------+----------+-------------------------------------------------------------------------+
| sku      | quantity | metadata                                                                |
+----------+----------+-------------------------------------------------------------------------+
| MT014958 | -10      | {"event_type":"order_placed","object_type":"order","object_id":"1"}     |
| MT014958 | 10       | {"event_type":"shipment_created","object_type":"order","object_id":"1"} |
| MT014958 | 10       | {"event_type":"shipment_created","object_type":"order","object_id":"1"} |
+----------+----------+-------------------------------------------------------------------------+
```
When a new order is being placed (order 2) another reservation is placed:
```
+----------+----------+-------------------------------------------------------------------------+
| sku      | quantity | metadata                                                                |
+----------+----------+-------------------------------------------------------------------------+
| MT014958 | -10      | {"event_type":"order_placed","object_type":"order","object_id":"1"}     |
| MT014958 | 10       | {"event_type":"shipment_created","object_type":"order","object_id":"1"} |
| MT014958 | 10       | {"event_type":"shipment_created","object_type":"order","object_id":"1"} |
| MT014958 | -10      | {"event_type":"shipment_created","object_type":"order","object_id":"2"} |
+----------+----------+-------------------------------------------------------------------------+
```
Order 2 is placed after the cut-off time so it won't be shipped untill tomorrow. The cronjob inventory_cleanup_reservations will then run and sees the sum of these reservations is 0 and thus will delete the reservations, resulting in a wrong salable quantity for that product.

### Partially fixed Issues
1. magento/inventory#2311: Improve reservations clean up cron job

### Manual testing scenarios (*)
See description.

### Questions or comments
This is the implementation we are currently using. It doesn't fix magento/inventory#2311 completely but might help. It will clean reservations based on the `object_id` saved in the `metadata` column.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
