### PR TITLE
Fix exception when a product is not assigned to all stocks during IsOrderSourceManageable check

### DIFF
--- a/InventoryShippingAdminUi/Model/IsOrderSourceManageable.php
+++ b/InventoryShippingAdminUi/Model/IsOrderSourceManageable.php
@@ -75,10 +75,15 @@ class IsOrderSourceManageable
 
             /** @var StockInterface $stock */
             foreach ($stocks as $stock) {
-                $inventoryConfiguration = $this->getStockItemConfiguration->execute(
-                    $this->getSkuFromOrderItem->execute($orderItem),
-                    $stock->getStockId()
-                );
+                try {
+                    $inventoryConfiguration = $this->getStockItemConfiguration->execute(
+                        $this->getSkuFromOrderItem->execute($orderItem),
+                        $stock->getStockId()
+                    );
+                } catch (\Magento\InventoryConfigurationApi\Exception\SkuIsNotAssignedToStockException $exception) {
+                    // it's okay if a product is not assigned to a stock
+                    continue;
+                }
 
                 if ($inventoryConfiguration->isManageStock()) {
                     return true;

--- a/InventoryShippingAdminUi/Test/Integration/Model/IsOrderSourceManageableTest.php
+++ b/InventoryShippingAdminUi/Test/Integration/Model/IsOrderSourceManageableTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryShippingAdminUi\Test\Integration\Model;
+
+use Magento\InventoryShippingAdminUi\Model\IsOrderSourceManageable;
+use Magento\Sales\Model\OrderFactory;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verify IsOrderSourceManageable service.
+ */
+class IsOrderSourceManageableTest extends TestCase
+{
+    /**
+     * Test subject.
+     *
+     * @var IsOrderSourceManageable
+     */
+    private $isOrderSourceManageable;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        $this->isOrderSourceManageable = Bootstrap::getObjectManager()->get(IsOrderSourceManageable::class);
+    }
+
+    /**
+     * Verify order with not assigned to all stocks items won't throw exception.
+     *
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     *
+     */
+    public function testOrderWithProductsNotAssignedToStocks(): void
+    {
+        $order = Bootstrap::getObjectManager()->get(OrderFactory::class)->create()->loadByIncrementId('100000001');
+        $result = $this->isOrderSourceManageable->execute($order);
+        self::assertFalse($result);
+    }
+}

--- a/InventoryShippingAdminUi/Test/Integration/Model/IsOrderSourceManageableTest.php
+++ b/InventoryShippingAdminUi/Test/Integration/Model/IsOrderSourceManageableTest.php
@@ -35,8 +35,8 @@ class IsOrderSourceManageableTest extends TestCase
     /**
      * Verify order with not assigned to all stocks items won't throw exception.
      *
-     * @magentoDataFixture ../../../../ext/magento/inventory/InventoryIndexer/Test/_files/reindex_inventory.php
-     * @magentoDataFixture ../../../../ext/magento/inventory/InventoryApi/Test/_files/stocks.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
      * @magentoDataFixture Magento/Sales/_files/order.php
      *
      * @magentoDbIsolation disabled

--- a/InventoryShippingAdminUi/Test/Integration/Model/IsOrderSourceManageableTest.php
+++ b/InventoryShippingAdminUi/Test/Integration/Model/IsOrderSourceManageableTest.php
@@ -7,6 +7,9 @@ declare(strict_types=1);
 
 namespace Magento\InventoryShippingAdminUi\Test\Integration\Model;
 
+use Magento\CatalogInventory\Api\StockItemRepositoryInterface;
+use Magento\InventoryCatalog\Model\DeleteSourceItemsBySkus;
+use Magento\InventoryConfiguration\Model\GetLegacyStockItem;
 use Magento\InventoryShippingAdminUi\Model\IsOrderSourceManageable;
 use Magento\Sales\Model\OrderFactory;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -30,21 +33,46 @@ class IsOrderSourceManageableTest extends TestCase
     protected function setUp()
     {
         $this->isOrderSourceManageable = Bootstrap::getObjectManager()->get(IsOrderSourceManageable::class);
+        $this->disableManageStock();
+        $this->cleanUpSourceItems();
     }
 
     /**
      * Verify order with not assigned to all stocks items won't throw exception.
      *
-     * @magentoDataFixture ../../../../app/code/Magento/InventoryIndexer/Test/_files/reindex_inventory.php
      * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
      * @magentoDataFixture Magento/Sales/_files/order.php
-     *
-     * @magentoDbIsolation disabled
      */
     public function testOrderWithProductsNotAssignedToStocks(): void
     {
         $order = Bootstrap::getObjectManager()->get(OrderFactory::class)->create()->loadByIncrementId('100000001');
         $result = $this->isOrderSourceManageable->execute($order);
         self::assertFalse($result);
+    }
+
+    /**
+     * Clean up source items for test product as they may be left by other tests run.
+     *
+     * @return void
+     */
+    private function cleanUpSourceItems(): void
+    {
+        $deleteSourceItems = Bootstrap::getObjectManager()->get(DeleteSourceItemsBySkus::class);
+        $deleteSourceItems->execute(['simple']);
+    }
+
+    /**
+     * Disable manage stock for default stock item.
+     *
+     * @return void
+     */
+    private function disableManageStock(): void
+    {
+        $getLegacyStockItem = Bootstrap::getObjectManager()->get(GetLegacyStockItem::class);
+        $stockItemRepository = Bootstrap::getObjectManager()->get(StockItemRepositoryInterface::class);
+        $stockItem = $getLegacyStockItem->execute('simple');
+        $stockItem->setManageStock(false);
+        $stockItem->setUseConfigManageStock(false);
+        $stockItemRepository->save($stockItem);
     }
 }

--- a/InventoryShippingAdminUi/Test/Integration/Model/IsOrderSourceManageableTest.php
+++ b/InventoryShippingAdminUi/Test/Integration/Model/IsOrderSourceManageableTest.php
@@ -35,9 +35,11 @@ class IsOrderSourceManageableTest extends TestCase
     /**
      * Verify order with not assigned to all stocks items won't throw exception.
      *
-     * @magentoDataFixture ../../../../app/code/Magento/InventoryApi/Test/_files/stocks.php
+     * @magentoDataFixture ../../../../ext/magento/inventory/InventoryIndexer/Test/_files/reindex_inventory.php
+     * @magentoDataFixture ../../../../ext/magento/inventory/InventoryApi/Test/_files/stocks.php
      * @magentoDataFixture Magento/Sales/_files/order.php
      *
+     * @magentoDbIsolation disabled
      */
     public function testOrderWithProductsNotAssignedToStocks(): void
     {


### PR DESCRIPTION
# Description (*)

There's an issue with orders which do not allow to open order page due to exception. An exception occurs if one of the products in the order is not assigned to all existing stock which is quite normal.
The exception itself is documented in a called interface but wasn't properly handled in a caller.

### Fixed Issues (if relevant)

I'm not aware of open issues regarding this case


### Manual testing scenarios (*)

#### Sources
* Default source
* 2nd source
* 3rd source

#### Stocks
* Default stock
* 2nd stock
	* Websites: none
	* Assigned sources: none
* 3rd stock:
	* Websites: Main website
	* Assigned sources: 
		* 2nd source
		* 3rd source

#### Products
* Create a product
	* Advanced Inventory
		Manage stock = no
	* Assign sources:
		* 2nd source

Clean caches & reindex after executing preconditions

#### Steps to reproduce

1. Create an order with the product
2. Go to orders grid and open the order
3. Before the fix, there’s an exception which redirects you back to orders grid

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
