### PR TITLE
Fix unable to install magento with existing websites configuration and different default website

### DIFF
--- a/InventorySales/Setup/Operation/AssignWebsiteToDefaultStock.php
+++ b/InventorySales/Setup/Operation/AssignWebsiteToDefaultStock.php
@@ -39,6 +39,8 @@ class AssignWebsiteToDefaultStock
     private $storeManager;
 
     /**
+     * Initialize dependencies
+     *
      * @param StockRepositoryInterface $stockRepository
      * @param DefaultStockProviderInterface $defaultStockProvider
      * @param SalesChannelInterfaceFactory $salesChannelFactory
@@ -57,15 +59,15 @@ class AssignWebsiteToDefaultStock
     }
 
     /**
-     * @inheritdoc
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     * @throws \Magento\Framework\Exception\CouldNotSaveException
-     * @throws \Magento\Framework\Validation\ValidationException
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * Assign default website to the default stock
+     *
+     * @param string|null $websiteCode
      */
-    public function execute()
+    public function execute(string $websiteCode = null)
     {
-        $websiteCode = $this->storeManager->getWebsite()->getCode();
+        if ($websiteCode === null) {
+            $websiteCode = $this->storeManager->getWebsite()->getCode();
+        }
 
         $defaultStockId = $this->defaultStockProvider->getId();
         $defaultStock = $this->stockRepository->get($defaultStockId);

--- a/InventorySales/Setup/Patch/Schema/InitializeWebsiteDefaultSock.php
+++ b/InventorySales/Setup/Patch/Schema/InitializeWebsiteDefaultSock.php
@@ -7,20 +7,37 @@ declare(strict_types=1);
 
 namespace Magento\InventorySales\Setup\Patch\Schema;
 
+use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\SchemaPatchInterface;
 use Magento\InventorySales\Setup\Operation\AssignWebsiteToDefaultStock;
 use Magento\Store\Setup\Patch\Schema\InitializeStoresAndWebsites;
 
+/**
+ * Assign default website to default stock
+ */
 class InitializeWebsiteDefaultSock implements SchemaPatchInterface
 {
     /**
      * @var AssignWebsiteToDefaultStock
      */
     private $assignWebsiteToDefaultStock;
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
 
-    public function __construct(AssignWebsiteToDefaultStock $assignWebsiteToDefaultStock)
-    {
+    /**
+     * Initialize dependencies.
+     *
+     * @param AssignWebsiteToDefaultStock $assignWebsiteToDefaultStock
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     */
+    public function __construct(
+        AssignWebsiteToDefaultStock $assignWebsiteToDefaultStock,
+        ModuleDataSetupInterface $moduleDataSetup
+    ) {
         $this->assignWebsiteToDefaultStock = $assignWebsiteToDefaultStock;
+        $this->moduleDataSetup = $moduleDataSetup;
     }
 
     /**
@@ -28,9 +45,22 @@ class InitializeWebsiteDefaultSock implements SchemaPatchInterface
      */
     public function apply()
     {
-        $this->assignWebsiteToDefaultStock->execute();
+        $this->assignWebsiteToDefaultStock->execute($this->getDefaultWebsiteCode());
 
         return $this;
+    }
+
+    /**
+     * Get the default website
+     *
+     * @return string
+     */
+    private function getDefaultWebsiteCode(): string
+    {
+        $websiteTable = $this->moduleDataSetup->getTable('store_website');
+        $connection = $this->moduleDataSetup->getConnection();
+        $select = $connection->select()->from($websiteTable, ['code'])->where('is_default=?', 1);
+        return $connection->fetchOne($select);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Unable to install magento with existing websites configuration and different default website

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
`Magento\Store\App\Config\Type\Scopes` is using aggregated source which combines both initial and runtime scopes config and leads to two default websites in the app config if the default website code was renamed in the config file.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

- Install Magento
- Rename main website code
- Dump config
- Reinstall magento with existing config

**ACTUAL**
Installation failed with error "The default website is invalid. Make sure no more than one default is defined and try again."

**EXPECTED**
Magento is installed successfully

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
The solution provided avoids WebsiteRepository as it uses app config which combines both DB and config.php scopes and throws exception when more than one default website is found.

**Why we must not change anything in WebsiteRepository?**

I think this has to do with deployment process isolation that allows process like static content deploy to run on non production environment. And to avoid any DB transaction, the app config is exported and used offline in process of deployment.
That's the reason why `Magento\Store\App\Config\Type\Scopes` is using both file based configuration and DB configuration (if connection exist). see [Magento/Store/etc/di.xml](https://github.com/magento/magento2/blob/591c13d91f8ff1c78c680fb7c082b6e40e3e9cda/app/code/Magento/Store/etc/di.xml#L340)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
