### PR TITLE
MSI-2904: Fatal error in `inventory:reservation:list-inconsistencies` because of wrong sku parameter type. [Backport]

### DIFF
--- a/InventoryReservationCli/Model/SalableQuantityInconsistency/FilterManagedStockProducts.php
+++ b/InventoryReservationCli/Model/SalableQuantityInconsistency/FilterManagedStockProducts.php
@@ -53,11 +53,14 @@ class FilterManagedStockProducts
         foreach ($inconsistencies as $inconsistency) {
             $filteredItems = [];
             foreach ($inconsistency->getItems() as $sku => $qty) {
-                if (false === $this->isProductAssignedToStock->execute($sku, $inconsistency->getStockId())) {
+                if (false === $this->isProductAssignedToStock->execute((string)$sku, $inconsistency->getStockId())) {
                     continue;
                 }
 
-                $stockConfiguration = $this->getStockItemConfiguration->execute($sku, $inconsistency->getStockId());
+                $stockConfiguration = $this->getStockItemConfiguration->execute(
+                    (string)$sku,
+                    $inconsistency->getStockId()
+                );
                 if ($stockConfiguration->isManageStock()) {
                     $filteredItems[$sku] = $qty;
                 }

--- a/InventoryReservationCli/Test/Integration/Model/GetSalableQuantityInconsistenciesTest.php
+++ b/InventoryReservationCli/Test/Integration/Model/GetSalableQuantityInconsistenciesTest.php
@@ -59,6 +59,17 @@ class GetSalableQuantityInconsistenciesTest extends TestCase
     }
 
     /**
+     * Verify GetSalableQuantityInconsistencies::execute() won't throw error in case product sku is numeric.
+     *
+     * @magentoDataFixture ../../../../app/code/Magento/InventoryReservationCli/Test/Integration/_files/create_incomplete_order_without_reservation_numeric_sku.php
+     */
+    public function testIncompleteOrderWithoutReservationNumericSku(): void
+    {
+        $inconsistencies = $this->getSalableQuantityInconsistencies->execute();
+        self::assertCount(1, $inconsistencies);
+    }
+
+    /**
      * @magentoDataFixture ../../../../app/code/Magento/InventoryReservationCli/Test/Integration/_files/order_with_reservation.php
      * @throws \Magento\Framework\Validation\ValidationException
      */

--- a/InventoryReservationCli/Test/Integration/_files/create_incomplete_order_without_reservation_numeric_sku.php
+++ b/InventoryReservationCli/Test/Integration/_files/create_incomplete_order_without_reservation_numeric_sku.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Address as OrderAddress;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Sales\Model\Order\Payment;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+require __DIR__ . '/../../../../../../../dev/tests/integration/testsuite/Magento/Sales/_files/default_rollback.php';
+require __DIR__ . '/simple_product_numeric_sku.php';
+
+$addressData = include __DIR__ .
+    '/../../../../../../../dev/tests/integration/testsuite/Magento/Sales/_files/address_data.php';
+
+$objectManager = Bootstrap::getObjectManager();
+$billingAddress = $objectManager->create(OrderAddress::class, ['data' => $addressData]);
+$billingAddress->setAddressType('billing');
+
+$shippingAddress = clone $billingAddress;
+$shippingAddress->setId(null)->setAddressType('shipping');
+
+$payment = $objectManager->create(Payment::class);
+$payment->setMethod('checkmo')
+    ->setAdditionalInformation('last_trans_id', '11122')
+    ->setAdditionalInformation(
+        'metadata',
+        [
+            'type' => 'free',
+            'fraudulent' => false,
+        ]
+    );
+
+$orderItem = $objectManager->create(OrderItem::class);
+$orderItem->setProductId($product->getId())
+    ->setQtyOrdered(2)
+    ->setSku($product->getSku())
+    ->setBasePrice($product->getPrice())
+    ->setPrice($product->getPrice())
+    ->setRowTotal($product->getPrice())
+    ->setProductType('simple')
+    ->setName($product->getName());
+
+$order = $objectManager->create(Order::class);
+$order->setIncrementId('100000001')
+    ->setState(Order::STATE_PROCESSING)
+    ->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING))
+    ->setSubtotal(100)
+    ->setGrandTotal(100)
+    ->setBaseSubtotal(100)
+    ->setBaseGrandTotal(100)
+    ->setCustomerIsGuest(true)
+    ->setCustomerEmail('customer@null.com')
+    ->setBillingAddress($billingAddress)
+    ->setShippingAddress($shippingAddress)
+    ->setStoreId($objectManager->get(StoreManagerInterface::class)->getStore()->getId())
+    ->addItem($orderItem)
+    ->setPayment($payment);
+
+$orderRepository = $objectManager->create(OrderRepositoryInterface::class);
+$orderRepository->save($order);

--- a/InventoryReservationCli/Test/Integration/_files/simple_product_numeric_sku.php
+++ b/InventoryReservationCli/Test/Integration/_files/simple_product_numeric_sku.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ProductFactory;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$product = Bootstrap::getObjectManager()->get(ProductFactory::class)->create();
+$productRepository = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class);
+$product->setTypeId(Type::TYPE_SIMPLE)
+    ->setAttributeSetId(4)
+    ->setStoreId(1)
+    ->setWebsiteIds([1])
+    ->setName('12345')
+    ->setSku('12345')
+    ->setPrice(100)
+    ->setWeight(1)
+    ->setStockData(
+        [
+            'use_config_manage_stock' => 1,
+            'qty' => 100,
+            'is_qty_decimal' => 0,
+            'is_in_stock' => 1,
+        ]
+    )
+    ->setVisibility(Visibility::VISIBILITY_BOTH)
+    ->setStatus(Status::STATUS_ENABLED);
+$productRepository->save($product);

--- a/InventoryReservationCli/Test/Integration/_files/simple_product_numeric_sku_rollback.php
+++ b/InventoryReservationCli/Test/Integration/_files/simple_product_numeric_sku_rollback.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Registry;
+use Magento\TestFramework\Helper\Bootstrap;
+
+Bootstrap::getInstance()->getInstance()->reinitialize();
+$registry = Bootstrap::getObjectManager()->get(Registry::class);
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+$productRepository = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class);
+try {
+    $product = $productRepository->get('12345', false, null, true);
+    $productRepository->delete($product);
+} catch (NoSuchEntityException $e) {
+    //Product already deleted.
+}
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Original PR: https://github.com/magento/inventory/pull/2907

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/inventory/issues/2904: Fatal error in `inventory:reservation:list-inconsistencies` because of wrong sku parameter type

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. see https://github.com/magento/inventory/issues/2904

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
