### PR TITLE
MSI-2213: Add plugin to the isSalable method of the product model

### DIFF
--- a/InventoryCatalog/Plugin/Catalog/Model/IsProductSalablePlugin.php
+++ b/InventoryCatalog/Plugin/Catalog/Model/IsProductSalablePlugin.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryCatalog\Plugin\Catalog\Model;
+
+use Magento\Catalog\Model\Product;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\InventorySalesApi\Api\AreProductsSalableInterface;
+use Magento\InventorySalesApi\Model\GetAssignedStockIdForWebsiteInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Apply the inventory is-salable result to the according method of the product model
+ */
+class IsProductSalablePlugin
+{
+    /**
+     * @var GetAssignedStockIdForWebsiteInterface
+     */
+    private $getAssignedStockIdForWebsite;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var AreProductsSalableInterface
+     */
+    private $areProductsSalable;
+
+    /**
+     * @param GetAssignedStockIdForWebsiteInterface $getAssignedStockIdForWebsite
+     * @param StoreManagerInterface $storeManager
+     * @param AreProductsSalableInterface $areProductsSalable
+     */
+    public function __construct(
+        GetAssignedStockIdForWebsiteInterface $getAssignedStockIdForWebsite,
+        StoreManagerInterface $storeManager,
+        AreProductsSalableInterface $areProductsSalable
+    ) {
+        $this->getAssignedStockIdForWebsite = $getAssignedStockIdForWebsite;
+        $this->storeManager = $storeManager;
+        $this->areProductsSalable = $areProductsSalable;
+    }
+
+    /**
+     * @param Product $subject
+     * @param callable $proceed
+     * @return bool
+     * @throws LocalizedException
+     */
+    public function aroundIsSalable(Product $subject, callable $proceed)
+    {
+        $sku = $subject->getSku();
+        $currentWebsite = $this->storeManager->getWebsite();
+        $results = $this->areProductsSalable->execute(
+            [$sku],
+            $this->getAssignedStockIdForWebsite->execute($currentWebsite->getCode())
+        );
+
+        foreach ($results as $result) {
+            if ($result->getSku() === $sku) {
+                return $result->isSalable();
+            }
+        }
+
+        return $proceed();
+    }
+}

--- a/InventoryCatalog/etc/di.xml
+++ b/InventoryCatalog/etc/di.xml
@@ -158,6 +158,9 @@
         <plugin name="delete_source_items" type="Magento\InventoryCatalog\Plugin\Catalog\Model\ResourceModel\Product\DeleteSourceItemsPlugin"/>
         <plugin name="process_source_items_after_product_save" type="Magento\InventoryCatalog\Plugin\Catalog\Model\ResourceModel\Product\ProcessSourceItemsPlugin"/>
     </type>
+    <type name="Magento\Catalog\Model\Product">
+        <plugin name="is_product_salable" type="Magento\InventoryCatalog\Plugin\Catalog\Model\IsProductSalablePlugin"/>
+    </type>
     <type name="Magento\Catalog\Controller\Adminhtml\Product\Action\Attribute\Save">
         <plugin name="inventoryUpdate" type="Magento\InventoryCatalog\Plugin\Catalog\Controller\Adminhtml\Product\Action\Attribute\Save\ProcessInventoryPlugin"/>
         <plugin name="massAction" disabled="true"/>

--- a/InventoryCatalog/etc/di.xml
+++ b/InventoryCatalog/etc/di.xml
@@ -158,8 +158,8 @@
         <plugin name="delete_source_items" type="Magento\InventoryCatalog\Plugin\Catalog\Model\ResourceModel\Product\DeleteSourceItemsPlugin"/>
         <plugin name="process_source_items_after_product_save" type="Magento\InventoryCatalog\Plugin\Catalog\Model\ResourceModel\Product\ProcessSourceItemsPlugin"/>
     </type>
-    <type name="Magento\Catalog\Model\Product">
-        <plugin name="is_product_salable" type="Magento\InventoryCatalog\Plugin\Catalog\Model\IsProductSalablePlugin"/>
+    <type name="Magento\Catalog\Model\Product\Type\Simple">
+        <plugin name="is_simple_product_salable" type="Magento\InventoryCatalog\Plugin\Catalog\Model\Type\Simple\IsSalablePlugin"/>
     </type>
     <type name="Magento\Catalog\Controller\Adminhtml\Product\Action\Attribute\Save">
         <plugin name="inventoryUpdate" type="Magento\InventoryCatalog\Plugin\Catalog\Controller\Adminhtml\Product\Action\Attribute\Save\ProcessInventoryPlugin"/>


### PR DESCRIPTION
# Description (*)
Create an around plugin for the `isSalable` method of `Magento\Catalog\Model\Product\Type\Simple`

### Fixed Issues (if relevant)
1. magento/inventory#2213: Discover pluginization of isSaleable method on product model in Magento

### Manual testing scenarios (*)
1. Ensure you are using multi-stock feature (create additional source and stock, assign the new stock to your website)
2. Create a product with stock 1
3. Buy the product
4. Go to the product detail page => The product should be displayed as "out-of-stock"

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
