### PR TITLE
Fix for 2936 - ReindexAfterSourceItemsDeletePlugin is more efficient

### DIFF
--- a/InventoryIndexer/Indexer/SourceItem/GetSourceItemsWithId.php
+++ b/InventoryIndexer/Indexer/SourceItem/GetSourceItemsWithId.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryIndexer\Indexer\SourceItem;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Inventory\Model\ResourceModel\SourceItem as SourceItemResourceModel;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+
+/**
+ * Get SourceItem records from datastore from array of SourceItems
+ */
+class GetSourceItemsWithId
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(ResourceConnection $resourceConnection)
+    {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Retrieve source items by ids.
+     *
+     * @param SourceItemInterface[] $sourceItems
+     * @return array
+     */
+    public function execute(array $sourceItems): array
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $skusBySourceCode = [];
+        $sourceItemRecords = [];
+        foreach ($sourceItems as $sourceItem) {
+            $skusBySourceCode[$sourceItem->getSourceCode()][] = $sourceItem->getSku();
+        }
+        foreach ($skusBySourceCode as $sourceCode => $skus) {
+            $select = $connection->select()
+                ->from(
+                    $this->resourceConnection->getTableName(SourceItemResourceModel::TABLE_NAME_SOURCE_ITEM),
+                    [SourceItemResourceModel::ID_FIELD_NAME, SourceItemInterface::SOURCE_CODE, SourceItemInterface::SKU]
+                )->where('sku IN (?)', $skus)->where('source_code = ?', $sourceCode);
+            $item = $connection->fetchAssoc($select);
+            if (empty($item)) {
+                // no guarantee we got in first.
+                continue;
+            }
+            $sourceItemRecords += $item;
+        }
+
+        return $sourceItemRecords;
+    }
+}

--- a/InventoryIndexer/Indexer/SourceItem/SourceItemIndexer.php
+++ b/InventoryIndexer/Indexer/SourceItem/SourceItemIndexer.php
@@ -97,6 +97,8 @@ class SourceItemIndexer
     }
 
     /**
+     * Run a full reindex
+     *
      * @return void
      */
     public function executeFull()
@@ -105,6 +107,8 @@ class SourceItemIndexer
     }
 
     /**
+     * Execute the indexer for a single source item id
+     *
      * @param int $sourceItemId
      * @return void
      */
@@ -114,6 +118,8 @@ class SourceItemIndexer
     }
 
     /**
+     * Exec the indexer for the provided source item ids
+     *
      * @param array $sourceItemIds
      * @return void
      */
@@ -157,7 +163,7 @@ class SourceItemIndexer
     /**
      * Individually clear out source items from the index that no longer link to a source.
      * More performant than reindexing the entire stock list.
-     * 
+     *
      * @param array $sourceCodeSkuMap [source_code => [sku, sku, sku], ....]
      * @return void
      */

--- a/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsDeletePlugin.php
+++ b/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsDeletePlugin.php
@@ -9,7 +9,8 @@ namespace Magento\InventoryIndexer\Plugin\InventoryApi;
 
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
 use Magento\InventoryApi\Api\SourceItemsDeleteInterface;
-use Magento\InventoryIndexer\Indexer\Source\SourceIndexer;
+use Magento\InventoryIndexer\Indexer\SourceItem\GetSourceItemIds;
+use Magento\InventoryIndexer\Indexer\SourceItem\SourceItemIndexer;
 
 /**
  * Reindex after source items delete plugin
@@ -17,16 +18,23 @@ use Magento\InventoryIndexer\Indexer\Source\SourceIndexer;
 class ReindexAfterSourceItemsDeletePlugin
 {
     /**
-     * @var SourceIndexer
+     * @var GetSourceItemIds
      */
-    private $sourceIndexer;
+    private $getSourceItemIds;
 
     /**
-     * @param SourceIndexer $sourceIndexer
+     * @var SourceItemIndexer
      */
-    public function __construct(SourceIndexer $sourceIndexer)
+    private $sourceItemIndexer;
+
+    /**
+     * @param GetSourceItemIds $getSourceItemIds
+     * @param SourceItemIndexer $sourceItemIndexer
+     */
+    public function __construct(GetSourceItemIds $getSourceItemIds, SourceItemIndexer $sourceItemIndexer)
     {
-        $this->sourceIndexer = $sourceIndexer;
+        $this->getSourceItemIds = $getSourceItemIds;
+        $this->sourceItemIndexer = $sourceItemIndexer;
     }
 
     /**
@@ -41,15 +49,13 @@ class ReindexAfterSourceItemsDeletePlugin
         callable $proceed,
         array $sourceItems
     ) {
-        $sourceCodes = [];
-        foreach ($sourceItems as $sourceItem) {
-            $sourceCodes[] = $sourceItem->getSourceCode();
-        }
+
+        $sourceItemIds = $this->getSourceItemIds->execute($sourceItems);
 
         $proceed($sourceItems);
 
-        if (count($sourceCodes)) {
-            $this->sourceIndexer->executeList($sourceCodes);
+        if (count($sourceItemIds)) {
+            $this->sourceItemIndexer->executeList($sourceItemIds);
         }
     }
 }

--- a/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsDeletePlugin.php
+++ b/InventoryIndexer/Plugin/InventoryApi/ReindexAfterSourceItemsDeletePlugin.php
@@ -38,14 +38,23 @@ class ReindexAfterSourceItemsDeletePlugin
      * @param SourceItemIndexer $sourceItemIndexer
      * @param GetSourcesItemById $getSourceItemsWithId
      */
-    public function __construct(GetSourceItemIds $getSourceItemIds, SourceItemIndexer $sourceItemIndexer, GetSourceItemsWithId $getSourceItemsWithId)
-    {
+    public function __construct(
+        GetSourceItemIds $getSourceItemIds,
+        SourceItemIndexer $sourceItemIndexer,
+        GetSourceItemsWithId $getSourceItemsWithId
+    ) {
         $this->getSourceItemIds = $getSourceItemIds;
         $this->sourceItemIndexer = $sourceItemIndexer;
         $this->getSourceItemsWithId = $getSourceItemsWithId;
     }
 
     /**
+     * Clean up indexes around the deletion of source items.
+     * 
+     * Uses a two-step method;
+     *  1 - index the items that have source links.
+     *  2 - remove index entries for those items that are no longer connected to a source
+     *
      * @param SourceItemsDeleteInterface $subject
      * @param callable $proceed
      * @param SourceItemInterface[] $sourceItems
@@ -58,7 +67,8 @@ class ReindexAfterSourceItemsDeletePlugin
         array $sourceItems
     ) {
 
-        // We need to double-pump the source item list, as we will end up with skus that still have some sources, and some that have none
+        // We need to double-pump the source item list, as we will end up with skus 
+        // that still have some sources, and some that have none
         $sourceItemsBefore = $this->getSourceItemsWithId->execute($sourceItems);
 
         $proceed($sourceItems);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Currently, any changes to product stock assignments triggers a full rebuild of the `inventory_stock_x` index.

This is caused by the plugin `InventoryIndexer\Plugin\InventoryApi\ReindexAfterSourceItemsDeletePlugin` chaining it's indexing calls down to sourceIndexer, and then over to stockindexer.

The plugin no longer chains it's way down to the stock indexer and will act on the information available to it. There is a "double-pump" for checking source items, to ensure we do pick up and remove items that no longer belong in a particular stock index

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/inventory#2936: `ReindexAfterSourceItemsDeletePlugin` triggers a full stock reindex for a single source removal

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Have a working magento 2.4-develop and inventory 1.2-develop system working with sample data
1. Export the entirety of "Stock Sources" using the magento export process
1. Create one new stock and an additional source.
1. Duplicate the records in the export to include stock for the new sources
1. Enable database query logging
1. Import the modified "Stock Sources" file exported using "Add/Update behaviour" 
1. Consult the database query logs - individual index updates should be observed and a full reindex should not have occured. All products should have appropriate stock levels available in the indexes and in the admin catalog product index page.
1. Import the modified "Stock Sources" file  with import behaviour "Delete"
1. Consult the database query logs - individual index updates should be observed and a full reindex should not have occured. All products should have no stock levels available in the indexes or on the admin catalog product index page.
1. Import the modified "Stock Sources" file using "Replace behaviour" 
1. Consult the database query logs - individual index updates should be observed and a full reindex should not have occured. All products should have appropriate stock levels available in the indexes and in the admin catalog product index page.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

I need to run through more test scenarios and do some performance testing before I can consider this "perfect". There will also be other scenarios I have not been able to test;
https://github.com/magento/inventory/issues/2002#issuecomment-459662076

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
