### PR TITLE
[REST] Unable to create a product without type_id

### DIFF
--- a/InventoryLowQuantityNotification/Plugin/Catalog/Model/ResourceModel/Product/ProcessDefaultSourceItemConfigurationPlugin.php
+++ b/InventoryLowQuantityNotification/Plugin/Catalog/Model/ResourceModel/Product/ProcessDefaultSourceItemConfigurationPlugin.php
@@ -80,7 +80,8 @@ class ProcessDefaultSourceItemConfigurationPlugin
      */
     public function afterSave(Product $subject, Product $result, AbstractModel $product): Product
     {
-        if ($this->isSourceItemManagementAllowedForProductType->execute($product->getTypeId()) === false
+        $productTypeId = $product->getTypeId() ?? \Magento\Catalog\Model\Product\Type::DEFAULT_TYPE;
+        if ($this->isSourceItemManagementAllowedForProductType->execute($productTypeId) === false
             || !$product->getExtensionAttributes()->getStockItem()) {
             return $result;
         }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Customer is not able to create a product via WEB-API without setting type_id. This PR provides fix for the issue.

### Fixed Issues (if relevant)
1. https://github.com/magento/inventory/issues/2946: [REST] Unable to create a product without type_id

### Manual testing scenarios (*)
1. Open any REST client
2. Set API request endpoint to `/rest/default/V1/products`
3. Set Method  to `POST`
4. Set Headers to the following:
`Content-Type`: `application/json; charset=UTF-8`
`Accept`: `application/json`
`Authorization`: `Bearer [access_token]`
5. Body 
```
{
    "product": {
        "sku": "sku-test-1",
        "name": "Product_1",
        "attributeSetId": 4
    }
}
```
6. Send request.
7. Product created.

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
