### PR TITLE
Eliminate old CatalogInventory index by plugin

### DIFF
--- a/InventoryIndexer/Plugin/Indexer/RemoveOldCatalogInventoryIndexPlugin.php
+++ b/InventoryIndexer/Plugin/Indexer/RemoveOldCatalogInventoryIndexPlugin.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryIndexer\Plugin\Indexer;
+
+use Magento\Indexer\Model\Config;
+
+/**
+ * Remove old catalogInventory index
+ */
+class RemoveOldCatalogInventoryIndexPlugin
+{
+    private const CATALOGINVENTORY_INDEX = 'cataloginventory_stock';
+
+    /**
+     * Remove old cataloginventory_stock index
+     *
+     * @param Config $subject
+     * @param $result
+     * @return array
+     */
+    public function afterGetIndexers(
+        Config $subject,
+        $result
+    ) {
+        unset($result[self::CATALOGINVENTORY_INDEX]);
+        return $result;
+    }
+}

--- a/InventoryIndexer/Plugin/Indexer/RemoveOldCatalogInventoryIndexPlugin.php
+++ b/InventoryIndexer/Plugin/Indexer/RemoveOldCatalogInventoryIndexPlugin.php
@@ -20,8 +20,9 @@ class RemoveOldCatalogInventoryIndexPlugin
      * Remove old cataloginventory_stock index
      *
      * @param Config $subject
-     * @param $result
+     * @param array $result
      * @return array
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterGetIndexers(
         Config $subject,

--- a/InventoryIndexer/composer.json
+++ b/InventoryIndexer/composer.json
@@ -9,7 +9,8 @@
         "magento/module-inventory-api": "*",
         "magento/module-inventory-catalog-api": "*",
         "magento/module-inventory-sales-api": "*",
-        "magento/module-inventory-sales": "*"
+        "magento/module-inventory-sales": "*",
+        "magento/module-indexer": "*"
     },
     "suggest": {
         "magento/module-catalog": "*"

--- a/InventoryIndexer/etc/di.xml
+++ b/InventoryIndexer/etc/di.xml
@@ -61,4 +61,8 @@
             <argument name="dimensionName" xsi:type="string">stock_</argument>
         </arguments>
     </type>
+    <!-- remove old cataloginventory index -->
+    <type name="Magento\Framework\Indexer\ConfigInterface">
+        <plugin name="remove_old_cataloginventory_index" type="Magento\InventoryIndexer\Plugin\Indexer\RemoveOldCatalogInventoryIndexPlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
### Description (*)
Eliminate old CatalogInventory index by plugin

### Fixed Issues (if relevant)
1. magento/inventory#220: Eliminate old CatalogInventory index

### Manual testing scenarios (*)
1. access index management

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
