### PR TITLE
Added @see tags for deprecated interfaces

### DIFF
--- a/InventorySalesApi/Api/IsProductSalableForRequestedQtyInterface.php
+++ b/InventorySalesApi/Api/IsProductSalableForRequestedQtyInterface.php
@@ -11,7 +11,8 @@ namespace Magento\InventorySalesApi\Api;
  * Service which detects whether a certain Qty of Product is salable for a given Stock (stock data + reservations)
  *
  * @api
- * @deprecated use \Magento\InventorySalesApi\Api\AreProductsSalableForRequestedQtyInterface instead.
+ * @deprecated in favor of bulk API
+ * @see \Magento\InventorySalesApi\Api\AreProductsSalableForRequestedQtyInterface
  */
 interface IsProductSalableForRequestedQtyInterface
 {

--- a/InventorySalesApi/Api/IsProductSalableInterface.php
+++ b/InventorySalesApi/Api/IsProductSalableInterface.php
@@ -11,7 +11,8 @@ namespace Magento\InventorySalesApi\Api;
  * Service which detects whether Product is salable for a given Stock (stock data + reservations)
  *
  * @api
- * @deprecated use \Magento\InventorySalesApi\Api\AreProductsSalableInterface instead.
+ * @deprecated in favor of bulk API
+ * @see \Magento\InventorySalesApi\Api\AreProductsSalableInterface
  */
 interface IsProductSalableInterface
 {


### PR DESCRIPTION
### Description (*)
There are 2 deprecated interfaces without `@see` tags: 
`\Magento\InventorySalesApi\Api\IsProductSalableForRequestedQtyInterface`
and `\Magento\InventorySalesApi\Api\IsProductSalableInterface`

### Manual testing scenarios (*)
Nope

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
