### PR TITLE
Moved address from request into distance algorithm as only there is r…

### DIFF
--- a/InventorySourceSelection/etc/extension_attributes.xml
+++ b/InventorySourceSelection/etc/extension_attributes.xml
@@ -8,6 +8,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
     <extension_attributes for="Magento\InventorySourceSelectionApi\Api\Data\InventoryRequestInterface">
-        <attribute code="destination_address" type="Magento\InventorySourceSelectionApi\Api\Data\AddressInterface" />
+        <attribute code="order" type="Magento\Sales\Api\Data\OrderInterface" />
     </extension_attributes>
 </config>

--- a/InventorySourceSelectionApi/Model/GetInventoryRequestFromOrder.php
+++ b/InventorySourceSelectionApi/Model/GetInventoryRequestFromOrder.php
@@ -41,11 +41,6 @@ class GetInventoryRequestFromOrder
     private $orderRepository;
 
     /**
-     * @var AddressInterfaceFactory
-     */
-    private $addressInterfaceFactory;
-
-    /**
      * @var StoreManagerInterface
      */
     private $storeManager;
@@ -59,7 +54,6 @@ class GetInventoryRequestFromOrder
      * @param InventoryRequestInterfaceFactory $inventoryRequestFactory
      * @param InventoryRequestExtensionInterfaceFactory $inventoryRequestExtensionFactory
      * @param OrderRepositoryInterface $orderRepository
-     * @param AddressInterfaceFactory $addressInterfaceFactory
      * @param StoreManagerInterface $storeManager
      * @param StockByWebsiteIdResolverInterface $stockByWebsiteIdResolver
      */
@@ -67,14 +61,12 @@ class GetInventoryRequestFromOrder
         InventoryRequestInterfaceFactory $inventoryRequestFactory,
         InventoryRequestExtensionInterfaceFactory $inventoryRequestExtensionFactory,
         OrderRepositoryInterface $orderRepository,
-        AddressInterfaceFactory $addressInterfaceFactory,
         StoreManagerInterface $storeManager,
         StockByWebsiteIdResolverInterface $stockByWebsiteIdResolver
     ) {
         $this->inventoryRequestFactory = $inventoryRequestFactory;
         $this->inventoryRequestExtensionFactory = $inventoryRequestExtensionFactory;
         $this->orderRepository = $orderRepository;
-        $this->addressInterfaceFactory = $addressInterfaceFactory;
         $this->storeManager = $storeManager;
         $this->stockByWebsiteIdResolver = $stockByWebsiteIdResolver;
     }
@@ -100,39 +92,10 @@ class GetInventoryRequestFromOrder
             ]
         );
 
-        $address = $this->getAddressFromOrder($order);
-        if ($address !== null) {
-            $extensionAttributes = $this->inventoryRequestExtensionFactory->create();
-            $extensionAttributes->setDestinationAddress($address);
-            $inventoryRequest->setExtensionAttributes($extensionAttributes);
-        }
+        $extensionAttributes = $this->inventoryRequestExtensionFactory->create();
+        $extensionAttributes->setOrder($order);
+        $inventoryRequest->setExtensionAttributes($extensionAttributes);
 
         return $inventoryRequest;
-    }
-
-    /**
-     * Create an address from an order
-     *
-     * @param OrderInterface $order
-     *
-     * @return null|AddressInterface
-     */
-    private function getAddressFromOrder(OrderInterface $order): ?AddressInterface
-    {
-        /** @var Address $shippingAddress */
-        $shippingAddress = $order->getShippingAddress();
-        if ($shippingAddress === null) {
-            return null;
-        }
-
-        return $this->addressInterfaceFactory->create(
-            [
-                'country' => $shippingAddress->getCountryId(),
-                'postcode' => $shippingAddress->getPostcode() ?? '',
-                'street' => implode("\n", $shippingAddress->getStreet()),
-                'region' => $shippingAddress->getRegion() ?? $shippingAddress->getRegionCode() ?? '',
-                'city' => $shippingAddress->getCity()
-            ]
-        );
     }
 }


### PR DESCRIPTION
SUGESTED CHANGE

As there is no need of address object on the inventoryRequest and only use in distance based algorith, we can pass order object in inventory request. Order can be used by other algorithms, address not so much and can also be extracted from order anytine if object is present.

