### PR TITLE
[TSG] MC-33244: [MSI][MFTF] AdminUserCreateOrderWithSimpleProductOnTestStockFromCustomWebsiteTest fails because of bad design

### DIFF
--- a/InventoryAdminUi/Test/Mftf/Test/StorefrontLoggedInCustomerCreateOrderWithSimpleProductOnTestStockFromCustomWebsiteTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/StorefrontLoggedInCustomerCreateOrderWithSimpleProductOnTestStockFromCustomWebsiteTest.xml
@@ -62,6 +62,8 @@
             <magentoCLI command="cache:flush" stepKey="flushCache" />
         </before>
         <after>
+            <!--Delete category-->
+            <deleteData createDataKey="simpleCategory" stepKey="deleteCategory"/>
             <!--Assign Default Stock to Default Website.-->
             <actionGroup ref="AssignWebsiteToStockActionGroup" stepKey="assignMainWebsiteToDefaultStock">
                 <argument name="stockName" value="{{_defaultStock.name}}"/>
@@ -78,7 +80,6 @@
             <magentoCLI
                 command="config:set {{StorefrontDisableAddStoreCodeToUrls.path}} {{StorefrontDisableAddStoreCodeToUrls.value}}"
                 stepKey="addStoreCodeToUrlDisable" />
-            <deleteData createDataKey="simpleCategory" stepKey="deleteCategory"/>
         </after>
 
         <!-- Assign product to custom website -->


### PR DESCRIPTION
## Scope

### Bug - P1
* [MC-33244](https://jira.corp.magento.com/browse/MC-33244) [MSI][MFTF] AdminUserCreateOrderWithSimpleProductOnTestStockFromCustomWebsiteTest fails because of bad design

### Bamboo CI builds

### Related Pull Requests

- CE https://github.com/magento-tsg/magento2ce/pull/788

### CE Checklist

- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Unit, Extended FAT CE, Extended FAT EE and Extended FAT B2B builds are green


Created by : @zakdma
Internal PR: https://github.com/magento-tsg/magento2ce/pull/762