### PR TITLE
inventory:reservation:list-inconsistencies command fails with split database config

### DIFF
--- a/InventoryReservationCli/Model/ResourceModel/GetOrderDataForOrderInFinalState.php
+++ b/InventoryReservationCli/Model/ResourceModel/GetOrderDataForOrderInFinalState.php
@@ -45,9 +45,8 @@ class GetOrderDataForOrderInFinalState
      */
     public function execute(array $orderIds): array
     {
-        $connection = $this->resourceConnection->getConnection();
-        $orderTableName = $this->resourceConnection->getTableName('sales_order');
-        $storeTableName = $this->resourceConnection->getTableName('store');
+        $connection = $this->resourceConnection->getConnection('sales');
+        $orderTableName = $this->resourceConnection->getTableName('sales_order', 'sales');
 
         $query = $connection
             ->select()
@@ -57,16 +56,40 @@ class GetOrderDataForOrderInFinalState
                     'main_table.entity_id',
                     'main_table.status',
                     'main_table.increment_id',
+                    'main_table.store_id'
                 ]
-            )
-            ->join(
-                ['store' => $storeTableName],
-                'store.store_id = main_table.store_id',
-                ['store.website_id']
             )
             ->where('main_table.entity_id IN (?)', $orderIds)
             ->where('main_table.state IN (?)', $this->getCompleteOrderStateList->execute());
 
-        return $connection->fetchAll($query);
+        $orders = $connection->fetchAll($query);
+        $storeWebsiteIds = $this->getStoreWebsiteIds();
+        foreach ($orders as $key => $order) {
+            $order['website_id'] = $storeWebsiteIds[$order['store_id']];
+            $orders[$key] = $order;
+        }
+        return $orders;
+    }
+
+    /**
+     * Get storeIds with their websiteIds
+     *
+     * @return array
+     */
+    private function getStoreWebsiteIds(): array
+    {
+        $storeWebsiteIds = [];
+        $connection = $this->resourceConnection->getConnection();
+        $storeTableName = $this->resourceConnection->getTableName('store');
+        $query = $connection
+            ->select()
+            ->from(
+                ['main_table' => $storeTableName],
+                ['store_id', 'website_id']
+            );
+        foreach ($connection->fetchAll($query) as $store) {
+            $storeWebsiteIds[$store['store_id']] = $store['website_id'];
+        }
+        return $storeWebsiteIds;
     }
 }

--- a/InventoryReservationCli/Model/ResourceModel/GetOrdersTotalCount.php
+++ b/InventoryReservationCli/Model/ResourceModel/GetOrdersTotalCount.php
@@ -35,8 +35,8 @@ class GetOrdersTotalCount
      */
     public function execute(): int
     {
-        $connection = $this->resourceConnection->getConnection();
-        $orderTableName = $this->resourceConnection->getTableName('sales_order');
+        $connection = $this->resourceConnection->getConnection('sales');
+        $orderTableName = $this->resourceConnection->getTableName('sales_order', 'sales');
 
         $query = $connection
             ->select()

--- a/InventoryReservationCli/Test/Unit/Model/ResourceModel/GetOrderDataForOrderInFinalStateTest.php
+++ b/InventoryReservationCli/Test/Unit/Model/ResourceModel/GetOrderDataForOrderInFinalStateTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryReservationCli\Test\Unit\Model\ResourceModel;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\InventoryReservationCli\Model\ResourceModel\GetOrderDataForOrderInFinalState;
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GetOrderDataForOrderInFinalStateTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $resourceConnection;
+    /**
+     * @var GetOrderDataForOrderInFinalState
+     */
+    private $model;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $objectManager = new ObjectManager($this);
+        $this->resourceConnection = $this->createMock(
+            ResourceConnection::class
+        );
+        $this->model = $objectManager->getObject(
+            GetOrderDataForOrderInFinalState::class,
+            [
+                'resourceConnection' => $this->resourceConnection
+            ]
+        );
+    }
+
+    /**
+     * Test that proper connection names are used to retrieve orders.
+     */
+    public function testExecute(): void
+    {
+        $salesConnectionName = 'sales';
+        $defaultConnectionName = 'default';
+        $orders = [
+            [
+                'entity_id' => 1,
+                'status' => Order::STATE_COMPLETE,
+                'increment_id' => 1,
+                'store_id' => 3,
+            ]
+        ];
+        $stores = [
+            [
+                'store_id' => 3,
+                'website_id' => 2,
+            ]
+        ];
+        $expected = [
+            [
+                'entity_id' => 1,
+                'status' => Order::STATE_COMPLETE,
+                'increment_id' => 1,
+                'store_id' => 3,
+                'website_id' => 2,
+            ]
+        ];
+        $selectOrders = $this->createSelectMock();
+        $selectStores = $this->createSelectMock();
+        $salesConnection = $this->createConnectionMock($selectOrders);
+        $salesConnection->method('fetchAll')
+            ->willReturn($orders);
+        $defaultConnection = $this->createConnectionMock($selectStores);
+        $defaultConnection->method('fetchAll')
+            ->willReturn($stores);
+        $this->resourceConnection->method('getTableName')
+            ->willReturnArgument(0);
+        $this->resourceConnection->expects($this->exactly(2))
+            ->method('getConnection')
+            ->withConsecutive(
+                [$this->equalTo($salesConnectionName)],
+                [$this->equalTo($defaultConnectionName)]
+            )
+            ->willReturnMap(
+                [
+                    [$salesConnectionName, $salesConnection],
+                    [$defaultConnectionName, $defaultConnection],
+                ]
+            );
+        $this->assertEquals($expected, $this->model->execute([1, 2, 3]));
+    }
+
+    /**
+     * @param MockObject $select
+     * @return MockObject
+     */
+    private function createConnectionMock(MockObject $select): MockObject
+    {
+        $connection = $this->createMock(AdapterInterface::class);
+        $connection->method('select')
+            ->willReturn($select);
+        return $connection;
+    }
+
+    /**
+     * @return MockObject
+     */
+    private function createSelectMock(): MockObject
+    {
+        $select = $this->createPartialMock(
+            Select::class,
+            [
+                'from',
+                'where',
+                'join',
+            ]
+        );
+        $select->method('from')
+            ->willReturnSelf();
+        $select->method('where')
+            ->willReturnSelf();
+        $select->method('join')
+            ->willReturnSelf();
+        return $select;
+    }
+}

--- a/InventoryReservationCli/Test/Unit/Model/ResourceModel/GetOrderItemsDataForOrdersInNotFinalStateTest.php
+++ b/InventoryReservationCli/Test/Unit/Model/ResourceModel/GetOrderItemsDataForOrdersInNotFinalStateTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryReservationCli\Test\Unit\Model\ResourceModel;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\InventoryReservationCli\Model\ResourceModel\GetOrderItemsDataForOrdersInNotFinalState;
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GetOrderItemsDataForOrdersInNotFinalStateTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $resourceConnection;
+    /**
+     * @var GetOrderItemsDataForOrdersInNotFinalState
+     */
+    private $model;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $objectManager = new ObjectManager($this);
+        $this->resourceConnection = $this->createMock(
+            ResourceConnection::class
+        );
+        $this->model = $objectManager->getObject(
+            GetOrderItemsDataForOrdersInNotFinalState::class,
+            [
+                'resourceConnection' => $this->resourceConnection
+            ]
+        );
+    }
+
+    /**
+     * Test that proper connection names are used to retrieve orders items.
+     */
+    public function testExecute(): void
+    {
+        $salesConnectionName = 'sales';
+        $defaultConnectionName = 'default';
+        $orders = [
+            [
+                'entity_id' => 1,
+                'status' => Order::STATE_COMPLETE,
+                'increment_id' => 1,
+                'store_id' => 3,
+                'sku' => 'QYU321-Z',
+                'qty_ordered' => 1,
+            ]
+        ];
+        $stores = [
+            [
+                'store_id' => 3,
+                'website_id' => 2,
+            ]
+        ];
+        $expected = [
+            [
+                'entity_id' => 1,
+                'status' => Order::STATE_COMPLETE,
+                'increment_id' => 1,
+                'store_id' => 3,
+                'sku' => 'QYU321-Z',
+                'qty_ordered' => 1,
+                'website_id' => 2,
+            ]
+        ];
+        $selectOrders = $this->createSelectMock();
+        $selectStores = $this->createSelectMock();
+        $salesConnection = $this->createConnectionMock($selectOrders);
+        $salesConnection->method('fetchAll')
+            ->willReturn($orders);
+        $defaultConnection = $this->createConnectionMock($selectStores);
+        $defaultConnection->method('fetchAll')
+            ->willReturn($stores);
+        $this->resourceConnection->method('getTableName')
+            ->willReturnArgument(0);
+        $this->resourceConnection->expects($this->exactly(2))
+            ->method('getConnection')
+            ->withConsecutive(
+                [$this->equalTo($salesConnectionName)],
+                [$this->equalTo($defaultConnectionName)]
+            )
+            ->willReturnMap(
+                [
+                    [$salesConnectionName, $salesConnection],
+                    [$defaultConnectionName, $defaultConnection],
+                ]
+            );
+        $this->assertEquals($expected, $this->model->execute(10, 1));
+    }
+
+    /**
+     * @param MockObject $select
+     * @return MockObject
+     */
+    private function createConnectionMock(MockObject $select): MockObject
+    {
+        $connection = $this->createMock(AdapterInterface::class);
+        $connection->method('select')
+            ->willReturn($select);
+        return $connection;
+    }
+
+    /**
+     * @return MockObject
+     */
+    private function createSelectMock(): MockObject
+    {
+        $select = $this->createPartialMock(
+            Select::class,
+            [
+                'from',
+                'where',
+                'join',
+            ]
+        );
+        $select->method('from')
+            ->willReturnSelf();
+        $select->method('where')
+            ->willReturnSelf();
+        $select->method('join')
+            ->willReturnSelf();
+        return $select;
+    }
+}

--- a/InventoryReservationCli/Test/Unit/Model/ResourceModel/GetOrdersTotalCountTest.php
+++ b/InventoryReservationCli/Test/Unit/Model/ResourceModel/GetOrdersTotalCountTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryReservationCli\Test\Unit\Model\ResourceModel;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\InventoryReservationCli\Model\ResourceModel\GetOrdersTotalCount;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GetOrdersTotalCountTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $resourceConnection;
+    /**
+     * @var GetOrdersTotalCount
+     */
+    private $model;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $objectManager = new ObjectManager($this);
+        $this->resourceConnection = $this->createMock(
+            ResourceConnection::class
+        );
+        $this->model = $objectManager->getObject(
+            GetOrdersTotalCount::class,
+            [
+                'resourceConnection' => $this->resourceConnection
+            ]
+        );
+    }
+
+    /**
+     * Test that proper connections names are used to retrieve orders count.
+     */
+    public function testExecute(): void
+    {
+        $salesConnectionName = 'sales';
+        $ordersCount = 423;
+        $selectOrders = $this->createSelectMock();
+        $salesConnection = $this->createConnectionMock($selectOrders);
+        $salesConnection->method('fetchOne')
+            ->willReturn($ordersCount);
+        $this->resourceConnection->method('getTableName')
+            ->willReturnArgument(0);
+        $this->resourceConnection->expects($this->exactly(1))
+            ->method('getConnection')
+            ->with($this->equalTo($salesConnectionName))
+            ->willReturn($salesConnection);
+        $this->assertEquals($ordersCount, $this->model->execute());
+    }
+
+    /**
+     * @param MockObject $select
+     * @return MockObject
+     */
+    private function createConnectionMock(MockObject $select): MockObject
+    {
+        $connection = $this->createMock(AdapterInterface::class);
+        $connection->method('select')
+            ->willReturn($select);
+        return $connection;
+    }
+
+    /**
+     * @return MockObject
+     */
+    private function createSelectMock(): MockObject
+    {
+        $select = $this->createPartialMock(
+            Select::class,
+            [
+                'from',
+                'where',
+                'join',
+            ]
+        );
+        $select->method('from')
+            ->willReturnSelf();
+        $select->method('where')
+            ->willReturnSelf();
+        $select->method('join')
+            ->willReturnSelf();
+        return $select;
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

inventory:reservation:list-inconsistencies command fails with split database config

**Root cause of the issue:**

- Direct usage of resource connection instead of appropriate resource models
- JOIN queries between tables from different functional areas

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Install Magento CE+EE+MSI
2. Configure Split Database following Magento [guidelines](https://devdocs.magento.com/guides/v2.3/config-guide/multi-master/multi-master_masterdb.html)
3. Place few orders on storefront
4. Run `bin/magento inventory:reservation:list-inconsistencies`

ACTUAL RESULT
```
In Mysql.php line 110:  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'root_html.sales_order' doesn't exist, query was: SELECT COUNT(main_table.entity_id) AS
   `count` FROM `sales_order` AS `main_table`
In Mysql.php line 91:  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'root_html.sales_order' doesn't exist
inventory:reservation:list-inconsistencies [-c|--complete-orders] [-i|--incomplete-orders] [-b|--bunch-size [BUNCH-SIZE]] [-r|--raw] 
```
EXPECTED RESULT
Output list of order inconsistencies or message "No order inconsistencies were found"

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
