### PR TITLE
MC-33900: Issue with oversell of products

### DIFF
--- a/InventoryReservationCli/Model/ResourceModel/GetOrderDataForOrderInFinalState.php
+++ b/InventoryReservationCli/Model/ResourceModel/GetOrderDataForOrderInFinalState.php
@@ -41,12 +41,16 @@ class GetOrderDataForOrderInFinalState
      * Load order data for order, which are in final state
      *
      * @param array $orderIds
+     * @param array $orderIncrementIds
      * @return array
      */
-    public function execute(array $orderIds): array
+    public function execute(array $orderIds, array $orderIncrementIds): array
     {
         $connection = $this->resourceConnection->getConnection('sales');
         $orderTableName = $this->resourceConnection->getTableName('sales_order', 'sales');
+
+        $entityIdCondition = $connection->quoteInto('main_table.entity_id IN (?)', $orderIds);
+        $incrementIdCondition = $connection->quoteInto('main_table.increment_id IN (?)', $orderIncrementIds);
 
         $query = $connection
             ->select()
@@ -59,7 +63,7 @@ class GetOrderDataForOrderInFinalState
                     'main_table.store_id'
                 ]
             )
-            ->where('main_table.entity_id IN (?)', $orderIds)
+            ->where($entityIdCondition . ' OR ' . $incrementIdCondition)
             ->where('main_table.state IN (?)', $this->getCompleteOrderStateList->execute());
 
         $orders = $connection->fetchAll($query);

--- a/InventoryReservationCli/Model/ResourceModel/GetOrderIncrementId.php
+++ b/InventoryReservationCli/Model/ResourceModel/GetOrderIncrementId.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryReservationCli\Model\ResourceModel;
+
+use Magento\Framework\App\ResourceConnection;
+
+/**
+ * Get order increment id by entity id
+ */
+class GetOrderIncrementId
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection
+    ) {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Get increment id by entity id
+     *
+     * @param int $entityId
+     * @return string
+     */
+    public function execute(int $entityId): string
+    {
+        $connection = $this->resourceConnection->getConnection('sales');
+        $orderTableName = $this->resourceConnection->getTableName('sales_order', 'sales');
+
+        $query = $connection
+            ->select()
+            ->from(
+                ['main_table' => $orderTableName],
+                ['main_table.increment_id']
+            )
+            ->where('main_table.entity_id = ?', $entityId);
+        return (string)$connection->fetchOne($query);
+    }
+}

--- a/InventoryReservationCli/Model/SalableQuantityInconsistency.php
+++ b/InventoryReservationCli/Model/SalableQuantityInconsistency.php
@@ -135,8 +135,17 @@ class SalableQuantityInconsistency
      */
     public function setOrderIncrementId(string $orderIncrementId): void
     {
-        $this->hasAssignedOrder = true;
         $this->orderIncrementId = $orderIncrementId;
+    }
+
+    /**
+     * Setter for hasAssignedOrder property
+     *
+     * @param bool $hasAssignedOrder
+     */
+    public function setHasAssignedOrder(bool $hasAssignedOrder): void
+    {
+        $this->hasAssignedOrder = $hasAssignedOrder;
     }
 
     /**

--- a/InventoryReservationCli/Model/SalableQuantityInconsistency/AddCompletedOrdersToForUnresolvedReservations.php
+++ b/InventoryReservationCli/Model/SalableQuantityInconsistency/AddCompletedOrdersToForUnresolvedReservations.php
@@ -38,11 +38,17 @@ class AddCompletedOrdersToForUnresolvedReservations
         $inconsistencies = $collector->getItems();
 
         $orderIds = [];
+        $orderIncrementIds = [];
         foreach ($inconsistencies as $inconsistency) {
-            $orderIds[] = $inconsistency->getObjectId();
+            if ($inconsistency->getObjectId()) {
+                $orderIds[] = $inconsistency->getObjectId();
+            }
+            if ($inconsistency->getOrderIncrementId()) {
+                $orderIncrementIds[] = $inconsistency->getOrderIncrementId();
+            }
         }
 
-        foreach ($this->getOrderDataForOrderInFinalState->execute($orderIds) as $orderData) {
+        foreach ($this->getOrderDataForOrderInFinalState->execute($orderIds, $orderIncrementIds) as $orderData) {
             $collector->addOrderData($orderData);
         }
 

--- a/InventoryReservationCli/Model/SalableQuantityInconsistency/AddExpectedReservations.php
+++ b/InventoryReservationCli/Model/SalableQuantityInconsistency/AddExpectedReservations.php
@@ -74,7 +74,12 @@ class AddExpectedReservations
                 ->setSku($data['sku'])
                 ->setQuantity((float)$data['qty_ordered'])
                 ->setStockId($stockId)
-                ->setMetadata($this->serializer->serialize(['object_id' => (int)$data['entity_id']]))
+                ->setMetadata($this->serializer->serialize(
+                    [
+                        'object_id' => (int)$data['entity_id'],
+                        'object_increment_id' => (string)$data['increment_id']
+                    ]
+                ))
                 ->build();
 
             $collector->addReservation($reservation);

--- a/InventoryReservationCli/Model/SalableQuantityInconsistency/Collector.php
+++ b/InventoryReservationCli/Model/SalableQuantityInconsistency/Collector.php
@@ -10,6 +10,7 @@ namespace Magento\InventoryReservationCli\Model\SalableQuantityInconsistency;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\InventoryReservationCli\Model\SalableQuantityInconsistency;
 use Magento\InventoryReservationCli\Model\SalableQuantityInconsistencyFactory;
+use Magento\InventoryReservationCli\Model\ResourceModel\GetOrderIncrementId;
 use Magento\InventoryReservationsApi\Model\ReservationInterface;
 use Magento\InventorySalesApi\Model\StockByWebsiteIdResolverInterface;
 use Magento\Sales\Api\Data\OrderInterface;
@@ -40,18 +41,26 @@ class Collector
     private $stockByWebsiteIdResolver;
 
     /**
+     * @var GetOrderIncrementId
+     */
+    private $getOrderIncrementId;
+
+    /**
      * @param SalableQuantityInconsistencyFactory $salableQuantityInconsistencyFactory
      * @param SerializerInterface $serializer
      * @param StockByWebsiteIdResolverInterface $stockByWebsiteIdResolver
+     * @param GetOrderIncrementId $getOrderIncrementId
      */
     public function __construct(
         SalableQuantityInconsistencyFactory $salableQuantityInconsistencyFactory,
         SerializerInterface $serializer,
-        StockByWebsiteIdResolverInterface $stockByWebsiteIdResolver
+        StockByWebsiteIdResolverInterface $stockByWebsiteIdResolver,
+        GetOrderIncrementId $getOrderIncrementId
     ) {
         $this->salableQuantityInconsistencyFactory = $salableQuantityInconsistencyFactory;
         $this->serializer = $serializer;
         $this->stockByWebsiteIdResolver = $stockByWebsiteIdResolver;
+        $this->getOrderIncrementId = $getOrderIncrementId;
     }
 
     /**
@@ -63,14 +72,17 @@ class Collector
     {
         $metadata = $this->serializer->unserialize($reservation->getMetadata());
         $objectId = $metadata['object_id'];
+        $objectIncrementId = $metadata['object_increment_id'] ?? $this->getOrderIncrementId->execute((int)$objectId);
         $stockId = $reservation->getStockId();
-        $key = $objectId . '-' . $stockId;
+        $key = $objectIncrementId . '-' . $stockId;
 
         if (!isset($this->items[$key])) {
             $this->items[$key] = $this->salableQuantityInconsistencyFactory->create();
         }
 
         $this->items[$key]->setObjectId((int)$objectId);
+        $this->items[$key]->setOrderIncrementId((string)$objectIncrementId);
+        $this->items[$key]->setHasAssignedOrder((int)$objectId || (string)$objectIncrementId);
         $this->items[$key]->setStockId((int)$stockId);
         $this->items[$key]->addItemQty($reservation->getSku(), $reservation->getQuantity());
     }
@@ -82,16 +94,17 @@ class Collector
      */
     public function addOrder(OrderInterface $order): void
     {
-        $objectId = $order->getEntityId();
+        $objectIncrementId = $order->getIncrementId();
         $websiteId = (int)$order->getStore()->getWebsiteId();
         $stockId = (int)$this->stockByWebsiteIdResolver->execute((int)$websiteId)->getStockId();
-        $key = $objectId . '-' . $stockId;
+        $key = $objectIncrementId . '-' . $stockId;
 
         if (!isset($this->items[$key])) {
             $this->items[$key] = $this->salableQuantityInconsistencyFactory->create();
         }
 
-        $this->items[$key]->setOrderIncrementId($order->getIncrementId());
+        $this->items[$key]->setOrderIncrementId($objectIncrementId);
+        $this->items[$key]->setHasAssignedOrder(true);
         $this->items[$key]->setOrderStatus($order->getStatus());
     }
 
@@ -102,16 +115,17 @@ class Collector
      */
     public function addOrderData(array $orderData): void
     {
-        $objectId = $orderData['entity_id'];
+        $objectIncrementId = $orderData['increment_id'];
         $websiteId = (int)$orderData['website_id'];
         $stockId = (int)$this->stockByWebsiteIdResolver->execute((int)$websiteId)->getStockId();
-        $key = $objectId . '-' . $stockId;
+        $key = $objectIncrementId . '-' . $stockId;
 
         if (!isset($this->items[$key])) {
             $this->items[$key] = $this->salableQuantityInconsistencyFactory->create();
         }
 
         $this->items[$key]->setOrderIncrementId($orderData['increment_id']);
+        $this->items[$key]->setHasAssignedOrder(true);
         $this->items[$key]->setOrderStatus($orderData['status']);
     }
 

--- a/InventoryReservationCli/Test/Unit/Model/ResourceModel/GetOrderDataForOrderInFinalStateTest.php
+++ b/InventoryReservationCli/Test/Unit/Model/ResourceModel/GetOrderDataForOrderInFinalStateTest.php
@@ -97,7 +97,7 @@ class GetOrderDataForOrderInFinalStateTest extends TestCase
                     [$defaultConnectionName, $defaultConnection],
                 ]
             );
-        $this->assertEquals($expected, $this->model->execute([1, 2, 3]));
+        $this->assertEquals($expected, $this->model->execute([1, 2, 3], []));
     }
 
     /**

--- a/InventorySales/Model/SalesEventToArrayConverter.php
+++ b/InventorySales/Model/SalesEventToArrayConverter.php
@@ -22,10 +22,12 @@ class SalesEventToArrayConverter
      */
     public function execute(SalesEventInterface $salesEvent): array
     {
+        $extensionData = $salesEvent->getExtensionAttributes()->__toArray();
         return [
             'event_type' => $salesEvent->getType(),
             'object_type' => $salesEvent->getObjectType(),
             'object_id' => $salesEvent->getObjectId(),
+            'object_increment_id' => $extensionData['objectIncrementId'] ?? ''
         ];
     }
 }

--- a/InventorySales/Plugin/Sales/OrderManagement/AppendReservationsAfterOrderPlacementPlugin.php
+++ b/InventorySales/Plugin/Sales/OrderManagement/AppendReservationsAfterOrderPlacementPlugin.php
@@ -19,9 +19,15 @@ use Magento\Store\Api\WebsiteRepositoryInterface;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
 use Magento\InventorySalesApi\Api\Data\ItemToSellInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionInterface;
 use Magento\InventorySales\Model\CheckItemsQuantity;
 use Magento\InventorySalesApi\Model\StockByWebsiteIdResolverInterface;
 
+/**
+ * Add reservation during order placement
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class AppendReservationsAfterOrderPlacementPlugin
 {
     /**
@@ -75,6 +81,11 @@ class AppendReservationsAfterOrderPlacementPlugin
     private $isSourceItemManagementAllowedForProductType;
 
     /**
+     * @var SalesEventExtensionFactory;
+     */
+    private $salesEventExtensionFactory;
+
+    /**
      * @param PlaceReservationsForSalesEventInterface $placeReservationsForSalesEvent
      * @param GetSkusByProductIdsInterface $getSkusByProductIds
      * @param WebsiteRepositoryInterface $websiteRepository
@@ -85,6 +96,8 @@ class AppendReservationsAfterOrderPlacementPlugin
      * @param StockByWebsiteIdResolverInterface $stockByWebsiteIdResolver
      * @param GetProductTypesBySkusInterface $getProductTypesBySkus
      * @param IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemManagementAllowedForProductType
+     * @param SalesEventExtensionFactory $salesEventExtensionFactory
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         PlaceReservationsForSalesEventInterface $placeReservationsForSalesEvent,
@@ -96,7 +109,8 @@ class AppendReservationsAfterOrderPlacementPlugin
         CheckItemsQuantity $checkItemsQuantity,
         StockByWebsiteIdResolverInterface $stockByWebsiteIdResolver,
         GetProductTypesBySkusInterface $getProductTypesBySkus,
-        IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemManagementAllowedForProductType
+        IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemManagementAllowedForProductType,
+        SalesEventExtensionFactory $salesEventExtensionFactory
     ) {
         $this->placeReservationsForSalesEvent = $placeReservationsForSalesEvent;
         $this->getSkusByProductIds = $getSkusByProductIds;
@@ -108,16 +122,26 @@ class AppendReservationsAfterOrderPlacementPlugin
         $this->stockByWebsiteIdResolver = $stockByWebsiteIdResolver;
         $this->getProductTypesBySkus = $getProductTypesBySkus;
         $this->isSourceItemManagementAllowedForProductType = $isSourceItemManagementAllowedForProductType;
+        $this->salesEventExtensionFactory = $salesEventExtensionFactory;
     }
 
     /**
+     * Add reservation before place order
+     *
+     * In case of error during order placement exception add compensation
+     *
      * @param OrderManagementInterface $subject
+     * @param callable $proceed
      * @param OrderInterface $order
      * @return OrderInterface
+     * @throws \Exception
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterPlace(OrderManagementInterface $subject, OrderInterface $order): OrderInterface
-    {
+    public function aroundPlace(
+        OrderManagementInterface $subject,
+        callable $proceed,
+        OrderInterface $order
+    ): OrderInterface {
         $itemsById = $itemsBySku = $itemsToSell = [];
         foreach ($order->getItems() as $item) {
             if (!isset($itemsById[$item->getProductId()])) {
@@ -146,12 +170,18 @@ class AppendReservationsAfterOrderPlacementPlugin
 
         $this->checkItemsQuantity->execute($itemsBySku, $stockId);
 
+        /** @var SalesEventExtensionInterface */
+        $salesEventExtension = $this->salesEventExtensionFactory->create([
+            'data' => ['objectIncrementId' => (string)$order->getIncrementId()]
+        ]);
+
         /** @var SalesEventInterface $salesEvent */
         $salesEvent = $this->salesEventFactory->create([
             'type' => SalesEventInterface::EVENT_ORDER_PLACED,
             'objectType' => SalesEventInterface::OBJECT_TYPE_ORDER,
             'objectId' => (string)$order->getEntityId()
         ]);
+        $salesEvent->setExtensionAttributes($salesEventExtension);
         $salesChannel = $this->salesChannelFactory->create([
             'data' => [
                 'type' => SalesChannelInterface::TYPE_WEBSITE,
@@ -160,6 +190,27 @@ class AppendReservationsAfterOrderPlacementPlugin
         ]);
 
         $this->placeReservationsForSalesEvent->execute($itemsToSell, $salesChannel, $salesEvent);
+
+        try {
+            $order = $proceed($order);
+        } catch (\Exception $e) {
+            //add compensation
+            foreach ($itemsToSell as $item) {
+                $item->setQuantity(-(float)$item->getQuantity());
+            }
+
+            /** @var SalesEventInterface $salesEvent */
+            $salesEvent = $this->salesEventFactory->create([
+                'type' => SalesEventInterface::EVENT_ORDER_PLACE_FAILED,
+                'objectType' => SalesEventInterface::OBJECT_TYPE_ORDER,
+                'objectId' => (string)$order->getEntityId()
+            ]);
+            $salesEvent->setExtensionAttributes($salesEventExtension);
+
+            $this->placeReservationsForSalesEvent->execute($itemsToSell, $salesChannel, $salesEvent);
+
+            throw $e;
+        }
         return $order;
     }
 }

--- a/InventorySales/Test/Integration/StockManagement/ReservationPlacingDuringRegisterProductsSaleTest.php
+++ b/InventorySales/Test/Integration/StockManagement/ReservationPlacingDuringRegisterProductsSaleTest.php
@@ -191,7 +191,7 @@ class ReservationPlacingDuringRegisterProductsSaleTest extends TestCase
         self::assertEquals(5, $this->getProductSalableQty->execute($sku, $stockId));
         self::assertEquals(-3.5, $this->getReservationsQuantity->execute($sku, $stockId));
         self::assertEquals(
-            '{"event_type":"order_placed","object_type":"order","object_id":"' . $orderId . '"}',
+            '{"event_type":"order_placed","object_type":"order","object_id":"","object_increment_id":"test_order_1"}',
             $this->getReservationMetadata()
         );
 

--- a/InventorySalesApi/Api/Data/SalesEventInterface.php
+++ b/InventorySalesApi/Api/Data/SalesEventInterface.php
@@ -19,6 +19,7 @@ interface SalesEventInterface extends \Magento\Framework\Api\ExtensibleDataInter
      */
     const EVENT_ORDER_PLACED = 'order_placed';
     const EVENT_ORDER_CANCELED = 'order_canceled';
+    const EVENT_ORDER_PLACE_FAILED = 'order_place_failed';
     const EVENT_SHIPMENT_CREATED = 'shipment_created';
     const EVENT_CREDITMEMO_CREATED = 'creditmemo_created';
     const EVENT_INVOICE_CREATED = 'invoice_created';
@@ -31,16 +32,22 @@ interface SalesEventInterface extends \Magento\Framework\Api\ExtensibleDataInter
     /**#@-*/
 
     /**
+     * Get type
+     *
      * @return string
      */
     public function getType(): string;
 
     /**
+     * Get object type
+     *
      * @return string
      */
     public function getObjectType(): string;
 
     /**
+     * Get object id
+     *
      * @return string
      */
     public function getObjectId(): string;

--- a/InventoryShipping/Model/SourceDeductionRequestFromShipmentFactory.php
+++ b/InventoryShipping/Model/SourceDeductionRequestFromShipmentFactory.php
@@ -13,8 +13,11 @@ use Magento\InventorySalesApi\Api\Data\SalesEventInterface;
 use Magento\InventorySalesApi\Api\Data\SalesEventInterfaceFactory;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionInterface;
 use Magento\InventorySourceDeductionApi\Model\SourceDeductionRequestInterfaceFactory;
 use Magento\Store\Api\WebsiteRepositoryInterface;
+
 
 class SourceDeductionRequestFromShipmentFactory
 {
@@ -39,21 +42,29 @@ class SourceDeductionRequestFromShipmentFactory
     private $websiteRepository;
 
     /**
+     * @var SalesEventExtensionFactory;
+     */
+    private $salesEventExtensionFactory;
+
+    /**
      * @param SourceDeductionRequestInterfaceFactory $sourceDeductionRequestFactory
      * @param SalesChannelInterfaceFactory $salesChannelFactory
      * @param SalesEventInterfaceFactory $salesEventFactory
      * @param WebsiteRepositoryInterface $websiteRepository
+     * @param SalesEventExtensionFactory $salesEventExtensionFactory
      */
     public function __construct(
         SourceDeductionRequestInterfaceFactory $sourceDeductionRequestFactory,
         SalesChannelInterfaceFactory $salesChannelFactory,
         SalesEventInterfaceFactory $salesEventFactory,
-        WebsiteRepositoryInterface $websiteRepository
+        WebsiteRepositoryInterface $websiteRepository,
+        SalesEventExtensionFactory $salesEventExtensionFactory
     ) {
         $this->sourceDeductionRequestFactory = $sourceDeductionRequestFactory;
         $this->salesChannelFactory = $salesChannelFactory;
         $this->salesEventFactory = $salesEventFactory;
         $this->websiteRepository = $websiteRepository;
+        $this->salesEventExtensionFactory = $salesEventExtensionFactory;
     }
 
     /**
@@ -69,11 +80,17 @@ class SourceDeductionRequestFromShipmentFactory
     ): SourceDeductionRequestInterface {
         $websiteId = $shipment->getOrder()->getStore()->getWebsiteId();
 
+        /** @var SalesEventExtensionInterface */
+        $salesEventExtension = $this->salesEventExtensionFactory->create([
+            'data' => ['objectIncrementId' => (string)$shipment->getOrder()->getIncrementId()]
+        ]);
+
         $salesEvent = $this->salesEventFactory->create([
             'type' => SalesEventInterface::EVENT_SHIPMENT_CREATED,
             'objectType' => SalesEventInterface::OBJECT_TYPE_ORDER,
-            'objectId' => $shipment->getOrderId()
+            'objectId' => (string)$shipment->getOrderId()
         ]);
+        $salesEvent->setExtensionAttributes($salesEventExtension);
 
         $websiteCode = $this->websiteRepository->getById($websiteId)->getCode();
         $salesChannel = $this->salesChannelFactory->create([


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

New logic are introduced with reservation

### Description (*)
New reservation will be created before order placed (previous realization based on reservation after order placed). In case of errors within order placement additional reservation will be added to compensate


### Fixed Issues (if relevant)
https://jira.corp.magento.com/browse/MC-33900

### Manual testing scenarios (*)
When there is 1 quantity in stock and 2 orders placed to that product simultaneously both orders are going through and the saleable qty is updating to -1. Need to run simultaneously from 2 different browsers (or machines)

01. Add product to the cart which has 1 quantity left
02. Two customers placing orders at the same time for this SKU
03. Both orders will get success

EXPECTED RESULT
Only one order should go through

ACTUAL RESULT
Both orders going through and sellable quantity of the product updated to -1

Also please check functionality of the inventory:reservation:list-inconsistencies cli command with the next scenario: There are some reservations already exists, then update your msi with this changes, make some orders, check that command provide correct output. Place order with payment failure, check that command provide correct output

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
