### PR TITLE
MC-34169: MSI Low Stock Report Grid Empty

### DIFF
--- a/InventoryAdminUi/Test/Mftf/Test/AdminLowStockReportForSimpleProductWithDefaultStockAndZeroQuantityTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminLowStockReportForSimpleProductWithDefaultStockAndZeroQuantityTest.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminLowStockReportForSimpleProductWithDefaultStockAndZeroQuantityTest">
+        <annotations>
+            <stories value="MSI Low Stock Report Grid Empty"/>
+            <title value="Low Stock Report For Simple Product With Zero Quantity"/>
+            <description value="Verify Low Stock Report With Zero Quantity Product Appears In The Report."/>
+            <testCaseId value="MC-34169"/>
+            <severity value="MAJOR"/>
+            <group value="msi"/>
+            <group value="multi_mode"/>
+        </annotations>
+
+        <before>
+            <!--Create category and product.-->
+            <createData entity="SimpleSubCategory" stepKey="category"/>
+            <createData entity="SimpleProduct" stepKey="product">
+                <requiredEntity createDataKey="category"/>
+            </createData>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginToAdminArea"/>
+        </before>
+        <after>
+            <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
+            <deleteData createDataKey="category" stepKey="deleteCategory"/>
+            <deleteData createDataKey="product" stepKey="deleteProduct"/>
+        </after>
+
+        <!--Disable additional sources.-->
+        <actionGroup ref="DisableAllSourcesActionGroup" stepKey="disableAllSources"/>
+        <!--Set Low Stock Notification quantity to zero for created product.-->
+        <amOnPage url="{{AdminProductEditPage.url($$product.id$$)}}" stepKey="openProductEditPageToSetQty"/>
+        <fillField selector="{{AdminProductFormSection.productQuantity}}" userInput="0" stepKey="fillProductWithZeroQuantity"/>
+        <actionGroup ref="AdminFormSaveAndClose" stepKey="saveProductWithZeroQuantity"/>
+        <!--Verify report is available with zero quantity.-->
+        <amOnPage url="{{LowStockReportPage.url}}" stepKey="navigateToLowStockReportPageWithZeroQuantity"/>
+        <actionGroup ref="AdminSearchLowStockReportByProductSkuAndSourceCodeActionGroup" stepKey="verifyLowStockReportIsEmptyWithZeroQuantity">
+            <argument name="productSku" value="$$product.sku$$"/>
+            <argument name="sourceCode" value="{{_defaultSource.source_code}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminVerifyLowStockProductReportActionGroup" stepKey="verifyProductReportWithZeroQuantity">
+            <argument name="product" value="$$product$$"/>
+            <argument name="productQty" value="0"/>
+            <argument name="source" value="_defaultSource"/>
+        </actionGroup>
+
+        <!--Set Low Stock Notification quantity to zero and status out of stock for created product.-->
+        <amOnPage url="{{AdminProductEditPage.url($$product.id$$)}}" stepKey="openProductEditPageToSetStatus"/>
+        <selectOption selector="{{AdminProductFormSection.productStockStatus}}" userInput="Out of Stock" stepKey="selectOutOfStockStatus"/>
+        <actionGroup ref="AdminFormSaveAndClose" stepKey="saveProductWithSetOutOfStockStatus"/>
+        <!--Verify report is available with out of stock status.-->
+        <amOnPage url="{{LowStockReportPage.url}}" stepKey="navigateToLowStockReportPageWithSetOutOfStockStatusOfCurrentProduct"/>
+        <actionGroup ref="AdminSearchLowStockReportByProductSkuAndSourceCodeActionGroup" stepKey="verifyLowStockReportIsEmptyWithSetOutOfStockStatusOfCurrentProduct">
+            <argument name="productSku" value="$$product.sku$$"/>
+            <argument name="sourceCode" value="{{_defaultSource.source_code}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminVerifyLowStockProductReportActionGroup" stepKey="verifyProductReportWithSetOutOfStockStatusOfCurrentProduct">
+            <argument name="product" value="$$product$$"/>
+            <argument name="productQty" value="0"/>
+            <argument name="source" value="_defaultSource"/>
+        </actionGroup>
+        <!--Set product qty to 10.-->
+        <amOnPage url="{{AdminProductEditPage.url($$product.id$$)}}" stepKey="openProductEditPageToChangeQty10"/>
+        <fillField selector="{{AdminProductFormSection.productQuantity}}" userInput="10" stepKey="fillProductQtyWith10"/>
+        <selectOption selector="{{AdminProductFormSection.productStockStatus}}" userInput="In Stock" stepKey="selectInStockStatus"/>
+        <actionGroup ref="AdminFormSaveAndClose" stepKey="saveProductWithChangedQuantity"/>
+        <!--Verify report does not contain product.-->
+        <amOnPage url="{{LowStockReportPage.url}}" stepKey="navigateToLowStockReportPageAfterApplyCustomNotifyQtyForProduct"/>
+        <actionGroup ref="AdminSearchLowStockReportByProductSkuAndSourceCodeActionGroup" stepKey="verifyLowStockReportIsEmpty">
+            <argument name="productSku" value="$$product.sku$$"/>
+            <argument name="sourceCode" value="{{_defaultSource.source_code}}"/>
+        </actionGroup>
+        <see userInput="We couldn't find any records." stepKey="verifyRowsAreEmpty"/>
+    </test>
+</tests>

--- a/InventoryLowQuantityNotification/Model/ResourceModel/LowQuantityCollection.php
+++ b/InventoryLowQuantityNotification/Model/ResourceModel/LowQuantityCollection.php
@@ -300,6 +300,9 @@ class LowQuantityCollection extends AbstractCollection
      */
     private function addSourceItemInStockFilter(): void
     {
-        $this->addFieldToFilter('main_table.status', SourceItemInterface::STATUS_IN_STOCK);
+        $condition = '(' . SourceItemInterface::QUANTITY . ' > 0 AND main_table.status = ' .
+            SourceItemInterface::STATUS_IN_STOCK . ') OR
+            (' . SourceItemInterface::QUANTITY . ' = 0)';
+        $this->getSelect()->where($condition);
     }
 }


### PR DESCRIPTION
**MC-34169: MSI Low Stock Report Grid Empty**
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
**ISSUE:**
Low Stock Report Grid is empty after creating a new out of stock product with 0 stock.

**STEPS TO REPLICATE:**

1. Install clean 2.3-develop + MSI
2. Create a new product with "Quantity > 0" and "Stock Status = In Stock" ("Out-of-Stock Threshold = 0")
3. Set the Quantity to 0 and leave the "Stock Status" dropdown "In Stock"
4. After saving, go to Reports > Low Stock Report and check that you can see the product in the "Low Stock Report Grid"
5. Reopen the product page in the backend: the "Stock Status" dropdown is "Out of stock" (expected behavior)
6. After saving the product again (with or without making any changes), go to Reports > Low Stock Report
**ACTUAL RESULTS:**
The grid is empty.

**EXPECTED RESULTS:**
The grid should show the product as it was shown it before the 2nd saving
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/inventory#MC-34169: https://jira.corp.magento.com/browse/MC-34169


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example, if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
**Reason:** The reason for showing the Low Stock Report Empty with zero quantity because when we set quantity zero the product automatically sets the status 'Out of Stock'. And 'Low Stock Report' only consider 'In Stock' status. For the first time, when we set the product with zero quantity, status does not get changed. After resaving it, it changed to 'Out of Stock'. That's why the issue happens. FOr the first time it shows in the report for the zero quantity and again if you visit the product and re-save with some data, then it disappears from the report.

**Proposed Solution:** If we want to show 'Low Stock Report' with zero quantity, we need to check the product status. So, proposed solution check, if the quantity os zero then it includes in the 'Low Stock Report' and for quantity greater than zero, it checks the status

**Regular CE edition:** Regular CE has the filter, to show zero quantity product with/without status check. That's why it appears in the report though the product is 'Out Of Stock'

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
