### PR TITLE
MSI-3110-In-Store-Pickup-delivery-not-available-for-order-with-Configurable-product.

### DIFF
--- a/InventoryInStorePickup/Model/SearchCriteria/ResolveIntersection.php
+++ b/InventoryInStorePickup/Model/SearchCriteria/ResolveIntersection.php
@@ -53,7 +53,9 @@ class ResolveIntersection implements ResolverInterface
         $extensionAttributes = $searchRequest->getExtensionAttributes();
         $skus = [];
         foreach ($extensionAttributes->getProductsInfo() as $item) {
-            $skus[] = $item->getSku();
+            if (!in_array($item->getSku(), $skus)) {
+                $skus[] = $item->getSku();
+            }
         }
 
         $codes = $this->getPickupLocationIntersectionForSkus->execute($skus);

--- a/InventoryInStorePickupApi/Test/Api/GetPickupLocationsTest.php
+++ b/InventoryInStorePickupApi/Test/Api/GetPickupLocationsTest.php
@@ -122,6 +122,12 @@ class GetPickupLocationsTest extends WebapiAbstract
                             [
                                 'sku' => 'SKU-3',
                             ],
+                            [
+                                'sku' => 'SKU-3',
+                            ],
+                            [
+                                'sku' => 'SKU-3',
+                            ],
                         ],
                     ],
                     'scopeType' => 'website',

--- a/InventoryInStorePickupShipping/Model/Carrier/Validation/PickupLocationsAvailabilityValidator.php
+++ b/InventoryInStorePickupShipping/Model/Carrier/Validation/PickupLocationsAvailabilityValidator.php
@@ -132,6 +132,10 @@ class PickupLocationsAvailabilityValidator implements RequestValidatorInterface
     {
         $productsInfo = [];
         foreach ($items as $item) {
+            if (!empty($item->getChildren())) {
+                continue;
+            }
+
             $productsInfo[] = $this->productInfoFactory->create(['sku' => $item->getSku()]);
         }
 


### PR DESCRIPTION
Fix issue of In-Store Pikcup availability with composite products.
Fix issue of In-Store Pickup availability with repeatable SKUs.

### Fixed Issues (if relevant)
1. https://github.com/magento/inventory/issues/3110
2. https://github.com/magento/inventory/issues/3115

### Manual testing scenarios (*)
**Case#1:**
1. Enable In Store Pickup delivery method in Admin Configuration
2. Create custom stock with custom active for In Store Pickup source and assign Main website
3. Create Configurable product with inventory on created source
4. Add configuration product to the shopping cart and proceed to checkout

**E.R.**
In Store Pickup delivery method should be available for selection
**A.R.**
In Store Pickup delivery method is not available

**Case#2:**
1. Steps from Case#1
2. Create bundle product and add same simple product as an option.
3. Add bundle product to the cart and proceed to checkout (configurable should be already added).

**E.R.**
In Store Pickup delivery method should be available for selection
**A.R.**
In Store Pickup delivery method is not available