### PR TITLE
MC-33760: Low Stock Report Export Error in Magento2.3.4

### DIFF
--- a/InventoryAdminUi/Test/Mftf/Data/CatalogInventoryConfigData.xml
+++ b/InventoryAdminUi/Test/Mftf/Data/CatalogInventoryConfigData.xml
@@ -90,6 +90,10 @@
         <data key="path">cataloginventory/item_options/min_qty</data>
         <data key="value">0</data>
     </entity>
+    <entity name="NotifyQuantityBelowOne">
+        <data key="path">cataloginventory/item_options/notify_stock_qty</data>
+        <data key="value">1</data>
+    </entity>
     <entity name="NotifyQuantityBelow">
         <data key="path">cataloginventory/item_options/notify_stock_qty</data>
         <data key="value">5</data>

--- a/InventoryAdminUi/Test/Mftf/Test/AdminLowStockReportForSimpleProductWithDefaultStockAndZeroQuantityTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminLowStockReportForSimpleProductWithDefaultStockAndZeroQuantityTest.xml
@@ -25,9 +25,17 @@
             <createData entity="SimpleProduct" stepKey="product">
                 <requiredEntity createDataKey="category"/>
             </createData>
+            <!--Enable Manage Stock in case it's been disabled in previous tests.-->
+            <magentoCLI command="config:set {{TurnOnManageStockConfig.path}} {{TurnOnManageStockConfig.value}}" stepKey="enableManageStock"/>
+            <!--Set "Notify Quantity Below" configuration.-->
+            <magentoCLI command="config:set {{NotifyQuantityBelowOne.path}} {{NotifyQuantityBelowOne.value}}" stepKey="setNotifyQuantityBelow"/>
             <actionGroup ref="LoginAsAdmin" stepKey="loginToAdminArea"/>
         </before>
         <after>
+            <!--Disable "Manage Stock" in configuration.-->
+            <magentoCLI command="config:set {{TurnOffManageStockConfig.path}} {{TurnOnManageStockConfig.value}}" stepKey="disableManageStock"/>
+            <!--Revert "Notify Quantity Below" configuration.-->
+            <magentoCLI command="config:set {{RevertNotifyQuantityBelow.path}} {{RevertNotifyQuantityBelow.value}}" stepKey="revertNotifyQtyBelow"/>
             <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
             <deleteData createDataKey="category" stepKey="deleteCategory"/>
             <deleteData createDataKey="product" stepKey="deleteProduct"/>

--- a/InventoryLowQuantityNotificationAdminUi/Controller/Adminhtml/Report/ExportLowstockCsv.php
+++ b/InventoryLowQuantityNotificationAdminUi/Controller/Adminhtml/Report/ExportLowstockCsv.php
@@ -1,18 +1,22 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);
-
 namespace Magento\InventoryLowQuantityNotificationAdminUi\Controller\Adminhtml\Report;
 
-use Magento\Framework\App\ResponseInterface;
+use Exception;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Reports\Controller\Adminhtml\Report\Product as ProductReportController;
 
-class ExportLowstockCsv extends ProductReportController
+/**
+ * Export low stock products in CSV format
+ */
+class ExportLowstockCsv extends ProductReportController implements HttpGetActionInterface
 {
     /**
      * Authorization level of a basic admin session
@@ -25,21 +29,24 @@ class ExportLowstockCsv extends ProductReportController
      * Export low stock products report to CSV format
      *
      * @return ResponseInterface
+     * @throws \Exception
      */
     public function execute()
     {
-        $this->_view->loadLayout(false);
-        $fileName = 'products_lowstock.csv';
-
-        $exportBlock = $this->_view->getLayout()->getChildBlock(
-            'adminhtml.block.report.product.inventory.lowstock.grid',
-            'grid.export'
-        );
-
-        return $this->_fileFactory->create(
-            $fileName,
-            $exportBlock->getCsvFile(),
-            DirectoryList::VAR_DIR
-        );
+        try {
+            $this->_view->loadLayout('reports_report_product_lowstock');
+            $fileName = 'products_lowstock.csv';
+            $exportBlock = $this->_view->getLayout()->getChildBlock(
+                'adminhtml.block.report.product.inventory.lowstock.grid',
+                'grid.export'
+            );
+            return $this->_fileFactory->create(
+                $fileName,
+                $exportBlock->getCsvFile(),
+                DirectoryList::VAR_DIR
+            );
+        } catch (Exception $e) {
+            throw new LocalizedException(__('Could not export low stock report'), $e);
+        }
     }
 }

--- a/InventoryLowQuantityNotificationAdminUi/Controller/Adminhtml/Report/ExportLowstockExcel.php
+++ b/InventoryLowQuantityNotificationAdminUi/Controller/Adminhtml/Report/ExportLowstockExcel.php
@@ -1,18 +1,22 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);
-
 namespace Magento\InventoryLowQuantityNotificationAdminUi\Controller\Adminhtml\Report;
 
-use Magento\Framework\App\ResponseInterface;
+use Exception;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Reports\Controller\Adminhtml\Report\Product  as ProductReportController;
 
-class ExportLowstockExcel extends ProductReportController
+/**
+ * Export low stock products in Excel format
+ */
+class ExportLowstockExcel extends ProductReportController implements HttpGetActionInterface
 {
     /**
      * Authorization level of a basic admin session
@@ -25,21 +29,24 @@ class ExportLowstockExcel extends ProductReportController
      * Export low stock products report to XML format
      *
      * @return ResponseInterface
+     * @throws Exception
      */
     public function execute()
     {
-        $this->_view->loadLayout(false);
-        $fileName = 'products_lowstock.xml';
-
-        $exportBlock = $this->_view->getLayout()->getChildBlock(
-            'adminhtml.block.report.product.inventory.lowstock.grid',
-            'grid.export'
-        );
-
-        return $this->_fileFactory->create(
-            $fileName,
-            $exportBlock->getExcelFile(),
-            DirectoryList::VAR_DIR
-        );
+        try {
+            $this->_view->loadLayout('reports_report_product_lowstock');
+            $fileName = 'products_lowstock.xml';
+            $exportBlock = $this->_view->getLayout()->getChildBlock(
+                'adminhtml.block.report.product.inventory.lowstock.grid',
+                'grid.export'
+            );
+            return $this->_fileFactory->create(
+                $fileName,
+                $exportBlock->getExcelFile(),
+                DirectoryList::VAR_DIR
+            );
+        } catch (Exception $e) {
+            throw new LocalizedException(__('Could not export low stock report'), $e);
+        }
     }
 }

--- a/InventoryLowQuantityNotificationAdminUi/Test/Mftf/Section/LowStockProductGridSection.xml
+++ b/InventoryLowQuantityNotificationAdminUi/Test/Mftf/Section/LowStockProductGridSection.xml
@@ -10,5 +10,6 @@
           xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="LowStockProductGridSection">
         <element name="productSourceCode" type="input" selector="//tr[1]/td[@data-column='sourceCode']"/>
+        <element name="exportButton" type="button" selector="//button[@title='Export']"/>
     </section>
 </sections>

--- a/InventoryLowQuantityNotificationAdminUi/Test/Mftf/Test/AdminLowStockReportExportVerificationTest.xml
+++ b/InventoryLowQuantityNotificationAdminUi/Test/Mftf/Test/AdminLowStockReportExportVerificationTest.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminLowStockReportExportVerificationTest">
+        <annotations>
+            <stories value="Low Stock Report Export Error"/>
+            <title value="Low Stock Report Export Error"/>
+            <description value="Verify Low Stock Report Export Error"/>
+            <testCaseId value="MC-33760"/>
+            <severity value="MAJOR"/>
+            <group value="msi"/>
+            <group value="multi_mode"/>
+        </annotations>
+        <before>
+            <!--Create category and product.-->
+            <createData entity="SimpleSubCategory" stepKey="category"/>
+            <createData entity="SimpleProduct" stepKey="firstProduct">
+                <field key="status">1</field>
+                <requiredEntity createDataKey="category"/>
+            </createData>
+            <!--Enable Manage Stock in case it's been disabled in previous tests.-->
+            <magentoCLI command="config:set {{TurnOnManageStockConfig.path}} {{TurnOnManageStockConfig.value}}" stepKey="enableManageStock"/>
+            <!--Set "Notify Quantity Below" configuration.-->
+            <magentoCLI command="config:set {{NotifyQuantityBelow.path}} {{NotifyQuantityBelow.value}}" stepKey="setNotifyQuantityBelow"/>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginToAdminArea"/>
+        </before>
+        <after>
+            <deleteData createDataKey="firstProduct" stepKey="deleteFirstProduct"/>
+            <deleteData createDataKey="category" stepKey="deleteCategory"/>
+            <!--Revert "Notify Quantity Below" configuration.-->
+            <magentoCLI command="config:set {{RevertNotifyQuantityBelow.path}} {{RevertNotifyQuantityBelow.value}}" stepKey="revertNotifyQtyBelow"/>
+            <!--Disable "Manage Stock" in configuration.-->
+            <magentoCLI command="config:set {{TurnOffManageStockConfig.path}} {{TurnOnManageStockConfig.value}}" stepKey="disableManageStock"/>
+            <actionGroup ref="logout" stepKey="logoutFromAdminArea"/>
+        </after>
+
+        <!--Disable additional sources.-->
+        <actionGroup ref="DisableAllSourcesActionGroup" stepKey="disableAllSources"/>
+        <!--Set first product qty to 4.-->
+        <amOnPage url="{{AdminProductEditPage.url($$firstProduct.id$$)}}" stepKey="openFirstProductEditPageToChangeQty4"/>
+        <fillField selector="{{AdminProductFormSection.productQuantity}}" userInput="4" stepKey="fillFirstProductQtyWith4"/>
+        <selectOption selector="{{AdminProductFormSection.productStockStatus}}" userInput="In Stock" stepKey="selectFirstProductInStockStatus"/>
+        <actionGroup ref="AdminFormSaveAndClose" stepKey="saveFirstProductWithChangedQuantity"/>
+        <waitForPageLoad time="60" stepKey="waitForFirstProductSave"/>
+
+        <!--Verify report is available with in stock product.-->
+        <amOnPage url="{{LowStockReportPage.url}}" stepKey="navigateToLowStockReportPage"/>
+        <click selector="{{LowStockProductGridSection.exportButton}}" stepKey="exportCSV"/>
+        <waitForPageLoad time="30" stepKey="waitForExport"/>
+        <dontSee userInput="Could not export low stock report" stepKey="verifyThereIsNoError"/>
+
+        <!--Verify there are no errors and we can see the product after export has been done.-->
+        <actionGroup ref="AdminSearchLowStockReportByProductSkuAndSourceCodeActionGroup" stepKey="searchFirstProduct">
+            <argument name="productSku" value="$$firstProduct.sku$$"/>
+            <argument name="sourceCode" value="{{_defaultSource.source_code}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminVerifyLowStockProductReportActionGroup" stepKey="verifyFirstProductInReport">
+            <argument name="product" value="$$firstProduct$$"/>
+            <argument name="productQty" value="4"/>
+            <argument name="source" value="_defaultSource"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
**Low Stock Report Export Error in Magento2.3.4**

<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When trying to export low stock report as CSV or Excel XML an error appears

This issue occurs when Magento is installed with Inventory modules. 

***Steps to recreate***

1) Navigate to Admin. -> Reports -> Products -> Low stock (no need to have any low stock data)

2) Try to export CSV

3) Below error appear

 
`
Fatal error: Uncaught Error: Call to a member function getCsvFile() on boolean in /Users/kodithuw/sites/m23inventory/inventory/InventoryLowQuantityNotificationAdminUi/Controller/Adminhtml/Report/ExportLowstockCsv.php:41 Stack trace: #0 /Users/kodithuw/sites/m23inventory/magento2ce/generated/code/Magento/InventoryLowQuantityNotificationAdminUi/Controller/Adminhtml/Report/ExportLowstockCsv/Interceptor.php(24): Magento\InventoryLowQuantityNotificationAdminUi\Controller\Adminhtml\Report\ExportLowstockCsv->execute() #1 /Users/kodithuw/sites/m23inventory/magento2ce/lib/internal/Magento/Framework/App/Action/Action.php(107): Magento\InventoryLowQuantityNotificationAdminUi\Controller\Adminhtml\Report\ExportLowstockCsv\Interceptor->execute() #2 /Users/kodithuw/sites/m23inventory/magento2ce/app/code/Magento/Backend/App/AbstractAction.php(231): Magento\Framework\App\Action\Action->dispatch(Object(Magento\Framework\App\Request\Http)) #3 /Users/kodithuw/sites/m23inventory/magento2ce/lib/internal/Magento/Framework/Interception/Intercept in /Users/kodithuw/sites/m23inventory/inventory/InventoryLowQuantityNotificationAdminUi/Controller/Adminhtml/Report/ExportLowstockCsv.php on line 41`

***Expected***
Error should not occur when doing export

***Actual***
Error appears when exporting CSV or Excel XML
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/inventory#MC-33760: https://jira.corp.magento.com/browse/MC-33760


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
**Reason:**
There is no layout file for exporting the files. Adding layout in AdminHtml Controller will export the CSV/XML properly
**Solution**
This is the backport of the original 2.4.x ticket https://github.com/magento/inventory/pull/3100 which has been successfully merged to the 2.4.x branch.
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
