### PR TITLE
MC-35486: Incorrect qty is returned for "Backorders with Notify Custo…

### DIFF
--- a/InventorySales/Model/IsProductSalableCondition/BackOrderNotifyCustomerCondition.php
+++ b/InventorySales/Model/IsProductSalableCondition/BackOrderNotifyCustomerCondition.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventorySales\Model\IsProductSalableCondition;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\InventoryConfigurationApi\Api\Data\StockItemConfigurationInterface;
 use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
 use Magento\InventorySalesApi\Api\Data\ProductSalabilityErrorInterfaceFactory;
@@ -14,8 +15,11 @@ use Magento\InventorySalesApi\Api\Data\ProductSalableResultInterface;
 use Magento\InventorySalesApi\Api\Data\ProductSalableResultInterfaceFactory;
 use Magento\InventorySalesApi\Api\IsProductSalableForRequestedQtyInterface;
 use Magento\InventorySalesApi\Model\GetStockItemDataInterface;
+use Magento\InventorySalesApi\Api\GetProductSalableQtyInterface;
 
 /**
+ * Get back order notify for customer condition
+ *
  * @inheritdoc
  */
 class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQtyInterface
@@ -36,6 +40,11 @@ class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQt
     private $productSalableResultFactory;
 
     /**
+     * @var GetProductSalableQtyInterface
+     */
+    private $getProductSalableQty;
+
+    /**
      * @var ProductSalabilityErrorInterfaceFactory
      */
     private $productSalabilityErrorFactory;
@@ -45,17 +54,21 @@ class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQt
      * @param GetStockItemDataInterface $getStockItemData
      * @param ProductSalableResultInterfaceFactory $productSalableResultFactory
      * @param ProductSalabilityErrorInterfaceFactory $productSalabilityErrorFactory
+     * @param GetProductSalableQtyInterface|null $getProductSalableQty
      */
     public function __construct(
         GetStockItemConfigurationInterface $getStockItemConfiguration,
         GetStockItemDataInterface $getStockItemData,
         ProductSalableResultInterfaceFactory $productSalableResultFactory,
-        ProductSalabilityErrorInterfaceFactory $productSalabilityErrorFactory
+        ProductSalabilityErrorInterfaceFactory $productSalabilityErrorFactory,
+        ?GetProductSalableQtyInterface $getProductSalableQty = null
     ) {
         $this->getStockItemConfiguration = $getStockItemConfiguration;
         $this->getStockItemData = $getStockItemData;
         $this->productSalableResultFactory = $productSalableResultFactory;
         $this->productSalabilityErrorFactory = $productSalabilityErrorFactory;
+        $this->getProductSalableQty = $getProductSalableQty
+            ?? ObjectManager::getInstance()->get(GetProductSalableQtyInterface::class);
     }
 
     /**
@@ -73,15 +86,18 @@ class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQt
                 return $this->productSalableResultFactory->create(['errors' => []]);
             }
 
-            $backOrderQty = $requestedQty - $stockItemData[GetStockItemDataInterface::QUANTITY];
-            if ($backOrderQty > 0) {
+            $salableQty = $this->getProductSalableQty->execute($sku, $stockId);
+            $backOrderQty = $requestedQty - $salableQty;
+            $displayQty = $this->getDisplayQty($backOrderQty, $salableQty, $requestedQty);
+
+            if ($displayQty > 0) {
                 $errors = [
                     $this->productSalabilityErrorFactory->create([
                             'code' => 'back_order-not-enough',
                             'message' => __(
                                 'We don\'t have as many quantity as you requested, '
                                 . 'but we\'ll back order the remaining %1.',
-                                $backOrderQty * 1
+                                $displayQty * 1
                             )])
                 ];
                 return $this->productSalableResultFactory->create(['errors' => $errors]);
@@ -89,5 +105,24 @@ class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQt
         }
 
         return $this->productSalableResultFactory->create(['errors' => []]);
+    }
+
+    /**
+     * Get display quantity to show the number of quantity customer can backorder
+     *
+     * @param float $backOrderQty
+     * @param float $salableQty
+     * @param float $requestedQty
+     * @return float
+     */
+    private function getDisplayQty(float $backOrderQty, float $salableQty, float $requestedQty): float
+    {
+        $displayQty = 0;
+        if ($backOrderQty > 0 && $salableQty > 0) {
+            $displayQty = $backOrderQty;
+        } elseif ($requestedQty > $salableQty) {
+            $displayQty = $requestedQty;
+        }
+        return $displayQty;
     }
 }

--- a/InventorySales/Test/Unit/Model/IsProductSalableCondition/BackOrderNotifyCustomerConditionTest.php
+++ b/InventorySales/Test/Unit/Model/IsProductSalableCondition/BackOrderNotifyCustomerConditionTest.php
@@ -16,6 +16,7 @@ use Magento\InventorySalesApi\Api\Data\ProductSalabilityErrorInterface;
 use Magento\InventorySalesApi\Api\Data\ProductSalabilityErrorInterfaceFactory;
 use Magento\InventorySalesApi\Api\Data\ProductSalableResultInterface;
 use Magento\InventorySalesApi\Api\Data\ProductSalableResultInterfaceFactory;
+use Magento\InventorySalesApi\Api\GetProductSalableQtyInterface;
 use Magento\InventorySalesApi\Model\GetStockItemDataInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -29,14 +30,21 @@ class BackOrderNotifyCustomerConditionTest extends TestCase
      * @var BackOrderNotifyCustomerCondition
      */
     private $model;
+
     /**
      * @var StockItemConfigurationInterface|MockObject
      */
     private $stockItemConfiguration;
+
     /**
      * @var array|null
      */
     private $stockItemData;
+
+    /**
+     * @var GetProductSalableQtyInterface|MockObject
+     */
+    private $getProductSalableQty;
 
     /**
      * @inheritDoc
@@ -47,6 +55,9 @@ class BackOrderNotifyCustomerConditionTest extends TestCase
         $objectManager = new ObjectManager($this);
         $productSalableResultFactory = $this->createMock(
             ProductSalableResultInterfaceFactory::class
+        );
+        $this->getProductSalableQty = $this->createMock(
+            GetProductSalableQtyInterface::class
         );
         $productSalableResultFactory->method('create')
             ->willReturnCallback(
@@ -95,6 +106,7 @@ class BackOrderNotifyCustomerConditionTest extends TestCase
                 'getStockItemData' => $getStockItemData,
                 'productSalableResultFactory' => $productSalableResultFactory,
                 'productSalabilityErrorFactory' => $productSalabilityErrorFactory,
+                'getProductSalableQty' => $this->getProductSalableQty
             ]
         );
     }
@@ -105,17 +117,26 @@ class BackOrderNotifyCustomerConditionTest extends TestCase
      * @dataProvider executeDataProvider
      * @param array|null $stockData
      * @param int $reqQty
+     * @param int $salableQty
      * @param int $backOrders
      * @param bool $manageStock
      * @param array $errors
      * @throws LocalizedException
      */
-    public function testExecute(?array $stockData, int $reqQty, int $backOrders, bool $manageStock, array $errors): void
-    {
+    public function testExecute(
+        ?array $stockData,
+        int $reqQty,
+        int $salableQty,
+        int $backOrders,
+        bool $manageStock,
+        array $errors
+    ): void {
         $this->stockItemConfiguration->method('isManageStock')
             ->willReturn($manageStock);
         $this->stockItemConfiguration->method('getBackorders')
             ->willReturn($backOrders);
+        $this->getProductSalableQty->method('execute')
+            ->willReturn($salableQty);
         $this->stockItemData = $stockData;
         $actualErrors = [];
         foreach ($this->model->execute('simple', 1, $reqQty)->getErrors() as $error) {
@@ -126,14 +147,16 @@ class BackOrderNotifyCustomerConditionTest extends TestCase
 
     /**
      * @return array
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function executeDataProvider(): array
     {
         return [
-            'StockQty=0, ReqQty=1, Backorders=YesNotify, ManageStock=Yes' => [
+            'StockQty=1, ReqQty=2, SalableQty=1, Backorders=YesNotify, ManageStock=Yes' => [
                 [
-                    GetStockItemDataInterface::QUANTITY => 0,
+                    GetStockItemDataInterface::QUANTITY => 1,
                 ],
+                2,
                 1,
                 StockItemConfigurationInterface::BACKORDERS_YES_NOTIFY,
                 true,
@@ -145,44 +168,81 @@ class BackOrderNotifyCustomerConditionTest extends TestCase
                     ]
                 ],
             ],
-            'StockQty=1, ReqQty=1, Backorders=YesNotify, ManageStock=Yes' => [
+            'StockQty=10, ReqQty=20, SalableQty=0, Backorders=YesNotify, ManageStock=Yes' => [
+                [
+                    GetStockItemDataInterface::QUANTITY => 10,
+                ],
+                20,
+                0,
+                StockItemConfigurationInterface::BACKORDERS_YES_NOTIFY,
+                true,
+                [
+                    [
+                        'code' => 'back_order-not-enough',
+                        'message' => 'We don\'t have as many quantity as you requested,'
+                            . ' but we\'ll back order the remaining 20.'
+                    ]
+                ],
+            ],
+            'StockQty=10, ReqQty=20, SalableQty=15, Backorders=YesNotify, ManageStock=Yes' => [
+                [
+                    GetStockItemDataInterface::QUANTITY => 10,
+                ],
+                20,
+                15,
+                StockItemConfigurationInterface::BACKORDERS_YES_NOTIFY,
+                true,
+                [
+                    [
+                        'code' => 'back_order-not-enough',
+                        'message' => 'We don\'t have as many quantity as you requested,'
+                            . ' but we\'ll back order the remaining 5.'
+                    ]
+                ],
+            ],
+            'StockQty=1, ReqQty=1, SalableQty=1, Backorders=YesNotify, ManageStock=Yes' => [
                 [
                     GetStockItemDataInterface::QUANTITY => 1,
                 ],
                 1,
-                StockItemConfigurationInterface::BACKORDERS_YES_NOTIFY,
-                true,
-                [],
-            ],
-            'StockQty=?, ReqQty=1, Backorders=YesNotify, ManageStock=Yes' => [
-                null,
                 1,
                 StockItemConfigurationInterface::BACKORDERS_YES_NOTIFY,
                 true,
                 [],
             ],
-            'StockQty=0, ReqQty=1, Backorders=No, ManageStock=Yes' => [
+            'StockQty=?, ReqQty=1, SalableQty=1, Backorders=YesNotify, ManageStock=Yes' => [
+                null,
+                1,
+                1,
+                StockItemConfigurationInterface::BACKORDERS_YES_NOTIFY,
+                true,
+                [],
+            ],
+            'StockQty=0, ReqQty=1, SalableQty=1, Backorders=No, ManageStock=Yes' => [
                 [
                     GetStockItemDataInterface::QUANTITY => 0,
                 ],
+                1,
                 1,
                 StockItemConfigurationInterface::BACKORDERS_NO,
                 true,
                 [],
             ],
-            'StockQty=0, ReqQty=1, Backorders=Yes, ManageStock=Yes' => [
+            'StockQty=0, ReqQty=1, SalableQty=1, Backorders=Yes, ManageStock=Yes' => [
                 [
                     GetStockItemDataInterface::QUANTITY => 0,
                 ],
+                1,
                 1,
                 StockItemConfigurationInterface::BACKORDERS_YES_NONOTIFY,
                 true,
                 [],
             ],
-            'StockQty=0, ReqQty=1, Backorders=YesNotify, ManageStock=No' => [
+            'StockQty=0, ReqQty=1, SalableQty=1, Backorders=YesNotify, ManageStock=No' => [
                 [
                     GetStockItemDataInterface::QUANTITY => 0,
                 ],
+                1,
                 1,
                 StockItemConfigurationInterface::BACKORDERS_YES_NOTIFY,
                 false,


### PR DESCRIPTION
**MC-35486: Incorrect qty is returned for "Backorders with Notify Customer"**
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
### Issue:
Incorrect qty is returned for "Backorders with Notify Customer"
**Steps to reproduce:**
1) Set theme to "Magento Blank".
2) Create a new Simple product with "Backorders" set to "Allow Qty Below Zero and Notify Customer" and the Qty set to 10. ("Notify for Qty Below")
3) Place an order for 5 of this simple product. Do not ship the order
4) Notice that the Qty for this product is 10, 5 are on reserve, and the Salable Qty is 5.
5) On the frontend, add 20 to your cart.

**Actual result:**
It says "We don't have as many quantity as you requested, but we'll back order the remaining 10."

**Expected result:**
"We don't have as many quantity as you requested, but we'll back order the remaining 15."
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/inventory#MC-35486: https://jira.corp.magento.com/browse/MC-35486

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
**Reason:**
The reason for this bug, because the back order quantity does not calculate the salable quantity. To calculate correct backOrder quantity we need to calculate the other order reserved quantity in terms of salable quantity.
**Solution:**
First, we need to calculate the reservedQty of that stock. Based on that, we need to find out the reservedQty and then calculate the backOrder qty. The backorder qty will be displayed based on the available salable quantity and requested quantity.
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
