### PR TITLE
Ensure that numeric source codes are preserved

### DIFF
--- a/InventoryInStorePickup/Model/ResourceModel/Source/GetOrderedDistanceToSources.php
+++ b/InventoryInStorePickup/Model/ResourceModel/Source/GetOrderedDistanceToSources.php
@@ -62,7 +62,7 @@ class GetOrderedDistanceToSources
         }
         $distances = [];
         foreach (array_reverse($distancesChunks) as $distanceChunk) {
-          $distances = $distances + $distanceChunk;
+            $distances = $distances + $distanceChunk;
         }
 
         return array_map('floatval', $distances);
@@ -75,6 +75,7 @@ class GetOrderedDistanceToSources
      * @param int $radius
      * @param array $latLngs
      * @return Select
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     private function processHavingClause(Select $query, int $radius, array $latLngs): Select
     {

--- a/InventoryInStorePickup/Model/ResourceModel/Source/GetOrderedDistanceToSources.php
+++ b/InventoryInStorePickup/Model/ResourceModel/Source/GetOrderedDistanceToSources.php
@@ -50,7 +50,7 @@ class GetOrderedDistanceToSources
         $connection = $this->resourceConnection->getConnection();
         $sourceTable = $this->resourceConnection->getTableName('inventory_source');
         $latsLngsChunks = array_chunk($latsLngs, self::CHUNK);
-        $distances = [[]];
+        $distancesChunks = [[]];
         foreach ($latsLngsChunks as $latsLngsChunk) {
             $query = $connection->select()
                 ->from($sourceTable)
@@ -58,9 +58,12 @@ class GetOrderedDistanceToSources
                 ->reset(Select::COLUMNS)
                 ->columns($this->createDistanceColumns($latsLngsChunk));
             $query = $this->processHavingClause($query, $radius, $latsLngsChunk);
-            $distances[] = $connection->fetchPairs($query);
+            $distancesChunks[] = $connection->fetchPairs($query);
         }
-        $distances = array_merge(...$distances);
+        $distances = [];
+        foreach (array_reverse($distancesChunks) as $distanceChunk) {
+          $distances = $distances + $distanceChunk;
+        }
 
         return array_map('floatval', $distances);
     }


### PR DESCRIPTION
## Description
If source codes are numeric values, they are overwritten by `array_merge` in ascending order and no correct results will be shown for pick-up store selection in checkout.
To avoid this, concatenate the identified relevant distances chunks by `+` summing up the arrays. To mimic `array_merge`'s behavior of preserving the last occurrence of a key, do an `array_reverse` on the array containing all the chunked arrays.

### Fixed Issues (if relevant)
/

### Manual testing scenarios (*)
1. Create sources that have numeric value as sources (e.g. 200, 202, 300, 301, ...)
2. Assign them with qty to a product
3. Add the product to cart and in checkout select InStore pickup as delivery method

Before the PR:
No source could be found

After the PR:
Sources are found

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
