### PR TITLE
MC-34817: Error in logs after MC-22212

### DIFF
--- a/InventoryCatalog/etc/di.xml
+++ b/InventoryCatalog/etc/di.xml
@@ -40,7 +40,6 @@
     <type name="Magento\CatalogInventory\Model\ResourceModel\Stock\Item">
         <plugin name="update_source_item_at_legacy_stock_item_save"
                 type="Magento\InventoryCatalog\Plugin\CatalogInventory\UpdateSourceItemAtLegacyStockItemSavePlugin"/>
-        <plugin name="priceIndexUpdater" disabled="true"/>
     </type>
     <type name="Magento\CatalogInventory\Model\ResourceModel\Stock\Status">
         <plugin name="adapt_add_stock_data_to_collection"


### PR DESCRIPTION
The “priceIndexUpdater” plugin has been removed but there is still used in Inventory. It causes a notice error in system.log - "Reference to undeclared plugin with name 'priceIndexUpdater'".

### Manual testing scenarios (*)
Install Magento with MSI
Open product page
Check logs

**ACTUAL RESULT:**
"Reference to undeclared plugin with name 'priceIndexUpdater'"

**EXPECTED RESULT:**
no errors

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
