### PR TITLE
Pass number of backordered items back from CheckQuoteItemQtyPlugin so it can be included in QuoteItem and OrderItem

### DIFF
--- a/InventorySales/Model/GetBackorderQty.php
+++ b/InventorySales/Model/GetBackorderQty.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventorySales\Model;
+
+use Magento\InventorySalesApi\Model\GetStockItemDataInterface;
+use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
+use Magento\InventoryConfigurationApi\Api\Data\StockItemConfigurationInterface;
+use Magento\InventorySalesApi\Api\GetProductSalableQtyInterface;
+
+/**
+ * GetBackorderQty class
+ *
+ * Returns the amount of items to be backordered, based on the product sku, stockId
+ * and requested quantity
+ */
+class GetBackorderQty
+{
+    /**
+     * @var GetStockItemConfigurationInterface
+     */
+    private $getStockItemConfiguration;
+
+    /**
+     * @var GetStockItemDataInterface
+     */
+    private $getStockItemData;
+
+    /**
+     * @var GetProductSalableQtyInterface
+     */
+    private $getProductSalableQty;
+
+    /**
+     * @param GetStockItemConfigurationInterface $getStockItemConfig
+     * @param GetStockItemDataInterface $getStockItemData
+     * @param GetProductSalableQtyInterface $getProductSalableQty
+     */
+    public function __construct(
+        GetStockItemConfigurationInterface $getStockItemConfig,
+        GetStockItemDataInterface $getStockItemData,
+        GetProductSalableQtyInterface $getProductSalableQty
+    ) {
+        $this->getStockItemConfiguration = $getStockItemConfig;
+        $this->getStockItemData = $getStockItemData;
+        $this->getProductSalableQty = $getProductSalableQty;
+    }
+
+    /**
+     * Main execute function
+     *
+     * Calculate the amount of a particular product that is to be backordered based on the
+     * salable quantity available, given its sku, stockId and the amount requested.
+     *
+     * @param string $sku
+     * @param integer $stockId
+     * @param float $requestedQty
+     * @return float
+     */
+    public function execute(string $sku, int $stockId, float $requestedQty): float
+    {
+        $stockItemConfiguration = $this->getStockItemConfiguration->execute($sku, $stockId);
+        $backOrderQty = 0;
+
+        if ($stockItemConfiguration->isManageStock()
+            && ($stockItemConfiguration->getBackorders() === StockItemConfigurationInterface::BACKORDERS_YES_NOTIFY ||
+                $stockItemConfiguration->getBackorders() === StockItemConfigurationInterface::BACKORDERS_YES_NONOTIFY)
+        ) {
+            $stockItemData = $this->getStockItemData->execute($sku, $stockId);
+            if (null === $stockItemData) {
+                return $backOrderQty;
+            }
+
+            $salableQty = $this->getProductSalableQty->execute($sku, $stockId);
+            /**
+             * Salable Quantity has had minQty subtracted from it. This means that when minqty is a negative value
+             * it is increasing the value of salable quantity to incorporate the fact that we are allowed to sell
+             * more items than in stock. When calculating backorder quantity to be displayed to customer and to be
+             * logged in sales_order_item, we don't want salable qty to include this, we want the backorder qty to
+             * indicate how many more items than we have in stock are being ordered including any existing
+             * reservations.
+             *
+             * Example calculation
+             *
+             * instock = 10
+             * minqty = -10
+             *
+             * Therefore $salableQty = 20
+             *
+             * $requestedQty = 15
+             *
+             * Therefore the amount to be backordered would be 15 - 20 - (-10) = 5
+             */
+            $minqty = $stockItemConfiguration->getMinQty();
+            $backOrderQty = $requestedQty - $salableQty - $minqty;
+            /**
+             * In cases of more stock available than being ordered, the above calculation returns a
+             * negative result indicating more stock available than requested. Set to zero in this case
+             */
+            if ($backOrderQty < 0) {
+                $backOrderQty = 0;
+            }
+            /**
+             * Catch the situation where we are already in backorders. e.g 0 in stock, reservations already
+             * in for 5 items on other orders, and we get a request for 5 more. Without this check, we would
+             * end up notifying the customer that 10 needed to be backorderd (10 backorderd items are required
+             * to satisfy this order plus all reservations), but only 5 of them are relevant to this
+             * request/customer/order so always cap the backOrderQty to the amount requested.
+             */
+            if (bccomp((string)$requestedQty, (string)$backOrderQty, 4) < 0) {
+                $backOrderQty = $requestedQty;
+            }
+        }
+        return $backOrderQty;
+    }
+}

--- a/InventorySales/Model/IsProductSalableCondition/BackOrderNotifyCustomerCondition.php
+++ b/InventorySales/Model/IsProductSalableCondition/BackOrderNotifyCustomerCondition.php
@@ -16,6 +16,7 @@ use Magento\InventorySalesApi\Api\Data\ProductSalableResultInterfaceFactory;
 use Magento\InventorySalesApi\Api\IsProductSalableForRequestedQtyInterface;
 use Magento\InventorySalesApi\Model\GetStockItemDataInterface;
 use Magento\InventorySalesApi\Api\GetProductSalableQtyInterface;
+use Magento\InventorySales\Model\GetBackorderQty;
 
 /**
  * Get back order notify for customer condition
@@ -30,19 +31,9 @@ class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQt
     private $getStockItemConfiguration;
 
     /**
-     * @var GetStockItemDataInterface
-     */
-    private $getStockItemData;
-
-    /**
      * @var ProductSalableResultInterfaceFactory
      */
     private $productSalableResultFactory;
-
-    /**
-     * @var GetProductSalableQtyInterface
-     */
-    private $getProductSalableQty;
 
     /**
      * @var ProductSalabilityErrorInterfaceFactory
@@ -50,25 +41,32 @@ class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQt
     private $productSalabilityErrorFactory;
 
     /**
+     * GetBackorderQty
+     */
+    private $getBackorderQty;
+
+    /**
      * @param GetStockItemConfigurationInterface $getStockItemConfiguration
-     * @param GetStockItemDataInterface $getStockItemData
+     * @param GetStockItemDataInterface $getStockItemData @deprecated
      * @param ProductSalableResultInterfaceFactory $productSalableResultFactory
      * @param ProductSalabilityErrorInterfaceFactory $productSalabilityErrorFactory
-     * @param GetProductSalableQtyInterface|null $getProductSalableQty
+     * @param GetProductSalableQtyInterface|null $getProductSalableQty @deprecated
+     * @param GetBackorderQty|null $getBackorderQty
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         GetStockItemConfigurationInterface $getStockItemConfiguration,
         GetStockItemDataInterface $getStockItemData,
         ProductSalableResultInterfaceFactory $productSalableResultFactory,
         ProductSalabilityErrorInterfaceFactory $productSalabilityErrorFactory,
-        ?GetProductSalableQtyInterface $getProductSalableQty = null
+        ?GetProductSalableQtyInterface $getProductSalableQty = null,
+        ?GetBackorderQty $getBackorderQty = null
     ) {
         $this->getStockItemConfiguration = $getStockItemConfiguration;
-        $this->getStockItemData = $getStockItemData;
         $this->productSalableResultFactory = $productSalableResultFactory;
         $this->productSalabilityErrorFactory = $productSalabilityErrorFactory;
-        $this->getProductSalableQty = $getProductSalableQty
-            ?? ObjectManager::getInstance()->get(GetProductSalableQtyInterface::class);
+        $this->getBackorderQty = $getBackorderQty
+            ?? ObjectManager::getInstance()->get(GetBackorderQty::class);
     }
 
     /**
@@ -81,23 +79,16 @@ class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQt
         if ($stockItemConfiguration->isManageStock()
             && $stockItemConfiguration->getBackorders() === StockItemConfigurationInterface::BACKORDERS_YES_NOTIFY
         ) {
-            $stockItemData = $this->getStockItemData->execute($sku, $stockId);
-            if (null === $stockItemData) {
-                return $this->productSalableResultFactory->create(['errors' => []]);
-            }
+            $backorderQty = $this->getBackorderQty->execute($sku, $stockId, $requestedQty);
 
-            $salableQty = $this->getProductSalableQty->execute($sku, $stockId);
-            $backOrderQty = $requestedQty - $salableQty;
-            $displayQty = $this->getDisplayQty($backOrderQty, $salableQty, $requestedQty);
-
-            if ($displayQty > 0) {
+            if ($backorderQty > 0) {
                 $errors = [
                     $this->productSalabilityErrorFactory->create([
                             'code' => 'back_order-not-enough',
                             'message' => __(
                                 'We don\'t have as many quantity as you requested, '
                                 . 'but we\'ll back order the remaining %1.',
-                                $displayQty * 1
+                                $backorderQty * 1
                             )])
                 ];
                 return $this->productSalableResultFactory->create(['errors' => $errors]);
@@ -105,24 +96,5 @@ class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQt
         }
 
         return $this->productSalableResultFactory->create(['errors' => []]);
-    }
-
-    /**
-     * Get display quantity to show the number of quantity customer can backorder
-     *
-     * @param float $backOrderQty
-     * @param float $salableQty
-     * @param float $requestedQty
-     * @return float
-     */
-    private function getDisplayQty(float $backOrderQty, float $salableQty, float $requestedQty): float
-    {
-        $displayQty = 0;
-        if ($backOrderQty > 0 && $salableQty > 0) {
-            $displayQty = $backOrderQty;
-        } elseif ($requestedQty > $salableQty) {
-            $displayQty = $requestedQty;
-        }
-        return $displayQty;
     }
 }

--- a/InventorySales/Test/Integration/Order/PlaceOrderOnDefaultStockTest.php
+++ b/InventorySales/Test/Integration/Order/PlaceOrderOnDefaultStockTest.php
@@ -121,6 +121,7 @@ class PlaceOrderOnDefaultStockTest extends TestCase
         $orderId = $this->cartManagement->placeOrder($cart->getId());
 
         self::assertNotNull($orderId);
+        self::assertNull($this->orderRepository->get($orderId)->getItems()[0]->getQtyBackordered());
 
         //cleanup
         $this->deleteOrderById((int)$orderId);
@@ -170,6 +171,12 @@ class PlaceOrderOnDefaultStockTest extends TestCase
         $orderId = $this->cartManagement->placeOrder($cart->getId());
 
         self::assertNotNull($orderId);
+
+        /**
+         * This assert can be introduced once https://github.com/magento/magento2/pull/29881
+         * has been merged
+         */
+        //self::assertEquals($this->orderRepository->get($orderId)->getItems()[0]->getQtyBackordered(), 3);
 
         //cleanup
         $this->deleteOrderById((int)$orderId);

--- a/InventorySales/Test/Integration/Order/PlaceOrderOnNotDefaultStockTest.php
+++ b/InventorySales/Test/Integration/Order/PlaceOrderOnNotDefaultStockTest.php
@@ -154,6 +154,7 @@ class PlaceOrderOnNotDefaultStockTest extends TestCase
         $orderId = $this->cartManagement->placeOrder($cart->getId());
 
         self::assertNotNull($orderId);
+        self::assertNull($this->orderRepository->get($orderId)->getItems()[0]->getQtyBackordered());
 
         $this->deleteOrderById((int)$orderId);
     }
@@ -220,6 +221,12 @@ class PlaceOrderOnNotDefaultStockTest extends TestCase
         $orderId = $this->cartManagement->placeOrder($cart->getId());
 
         self::assertNotNull($orderId);
+
+        /**
+         * This assert can be introduced once https://github.com/magento/magento2/pull/29881
+         * has been merged
+         */
+        //self::assertEquals($this->orderRepository->get($orderId)->getItems()[0]->getQtyBackordered(), 1.5);
 
         //cleanup
         $this->deleteOrderById((int)$orderId);

--- a/InventorySales/Test/Integration/StockState/CheckQuoteItemQtyPluginTest.php
+++ b/InventorySales/Test/Integration/StockState/CheckQuoteItemQtyPluginTest.php
@@ -72,4 +72,44 @@ class CheckQuoteItemQtyPluginTest extends TestCase
         self::assertEquals('The requested sku is not assigned to given stock.', $result->getQuoteMessage());
         self::assertEquals('qty', $result->getQuoteMessageIndex());
     }
+
+    /**
+     * Verify, CheckQuoteItemQtyPlugin does not indicated backordered for an in stock item with backorders on.
+     *
+     * @magentoDataFixture Magento_InventoryApi::Test/_files/products.php
+     * @magentoDataFixture Magento_InventoryCatalog::Test/_files/source_items_on_default_source.php
+     * @magentoConfigFixture current_store cataloginventory/item_options/backorders 2
+     *
+     * @return void
+     */
+    public function testCheckQuoteItemQtyPluginBackorderQtyWithInStockItem(): void
+    {
+        $itemQty = $qtyToCheck = $origQty = 1;
+        $storeManager = Bootstrap::getObjectManager()->get(StoreManagerInterface::class);
+        $websiteId = $storeManager->getDefaultStoreView()->getWebsiteId();
+        $product = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class)->get('SKU-1');
+        $result = $this->stockState->checkQuoteItemQty($product->getId(), $itemQty, $qtyToCheck, $origQty, $websiteId);
+        self::assertFalse($result->getHasError());
+        self::assertNull($result->getItemBackorders());
+    }
+
+    /**
+     * Verify, CheckQuoteItemQtyPlugin indicates backordered for an out of stock item with backorders on.
+     *
+     * @magentoDataFixture Magento_InventoryApi::Test/_files/products.php
+     * @magentoDataFixture Magento_InventoryCatalog::Test/_files/source_items_on_default_source.php
+     * @magentoConfigFixture current_store cataloginventory/item_options/backorders 2
+     *
+     * @return void
+     */
+    public function testCheckQuoteItemQtyPluginBackorderQtyWithOutOfStockItem(): void
+    {
+        $itemQty = $qtyToCheck = $origQty = 10;
+        $storeManager = Bootstrap::getObjectManager()->get(StoreManagerInterface::class);
+        $websiteId = $storeManager->getDefaultStoreView()->getWebsiteId();
+        $product = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class)->get('SKU-1');
+        $result = $this->stockState->checkQuoteItemQty($product->getId(), $itemQty, $qtyToCheck, $origQty, $websiteId);
+        self::assertFalse($result->getHasError());
+        self::assertEquals($result->getItemBackorders(), 4.5);
+    }
 }


### PR DESCRIPTION
### Description (*)
Created new GetBackorderQty class which provides a single place to calculate backorder qty, given product, stockid and qty. Note, the logic that calculates the backorder qty has been reworked as it was not including the minQty value, which is necessary when minQty is set to anything other than zero.

BackorderNotifyCustomerCondition updated to use GetBackorderQty() class.

CheckQuoteItemQtyPlugin updated to use GetBackorderQty() class.

CheckQuoteItemQtyPlugin now returns backorder quantity to the order processing where it is included in QuoteItem and ultimately OrderItem.

This backorder quantity returned by these changes `($result->setItemBackorders(........))` will only be used by Magento Core, if the following PR is also merged. https://github.com/magento/magento2/pull/29881

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/inventory#3181: Backorder amount recorded in sales_order_grid does not take into account reservations. (Also needs magento/magento2#29881). The reason why we currently do get backorder qty recorded in sales_order_grid is because of bug magento/magento2#29881. It is actually using backorder qty generated by CatalogInventory, which does not know anything about reservations. By returning the value (this PR) and getting core to use it (magento/magento2#29881) then the full chain is made.

2. Fixes magento/inventory#3180: Backorders not recorded properly in sales_order_item when product is not assigned to default source (Also needs magento/magento2#29881). The reason this issue occurs is also because of bug magento/magento2#29881. The bug causes magento to use backorder qty calculated from CatalogInventory instead of MSI (which would only have worked anyway if this PR is merged), but in doing so, CatalogInventory checks that the item is_in_stock in catalog_inventory. When the product is not in default source, is_in_stock in catalog_inventory is set to false. This is not used when selling the product (that correctly uses MSI) so the product gets sold, but the bug causes the backorder calc to return with no backorders because of is_in_stock being false and this is what goes on to be used in QuoteItem and ultimately OrderItem.

### Manual testing scenarios (*)
There is an integration test as part of https://github.com/magento/magento2/pull/29881 which tests that the backorder qty returned by this PR is set in the OrderItem object, and thus recorded in sales_order_item table.

Additional integration tests to check for the backorder qty being returned from the CheckQuoteItemQtyPlugin are also included in this PR.

### Questions or comments
N/A

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
