### PR TITLE
MC-30348: [Inventory]Rest salesShipOrderV1 API w/ Bundles error: "You can't create a shipment without products"

### DIFF
--- a/InventoryShipping/Test/Integration/SourceDeductionForBundleProductsOnDefaultStockTest.php
+++ b/InventoryShipping/Test/Integration/SourceDeductionForBundleProductsOnDefaultStockTest.php
@@ -92,11 +92,6 @@ class SourceDeductionForBundleProductsOnDefaultStockTest extends TestCase
         $item = $this->getBundleOrderItemByShipmentType($order, AbstractType::SHIPMENT_SEPARATELY);
 
         $items = [];
-        /** @var ShipmentItemCreationInterface $invoiceItemCreation */
-        $shipmentItemCreation = $this->shipmentItemCreationFactory->create();
-        $shipmentItemCreation->setOrderItemId($item->getId());
-        $shipmentItemCreation->setQty(1);
-        $items[] = $shipmentItemCreation;
         foreach ($item->getChildrenItems() as $childItem) {
             /** @var ShipmentItemCreationInterface $invoiceItemCreation */
             $shipmentItemCreation = $this->shipmentItemCreationFactory->create();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR created for fix test failure caused by changes in main PR
https://github.com/magento/magento2/pull/30813

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes SourceDeductionForBundleProductsOnDefaultStockTest integration test failure

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. No additional manual testing required

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
