### PR TITLE
Fixes inventory sales BackOrderNotifyCustomerConditionTest.php local failure

### DIFF
--- a/InventorySales/Test/Unit/Model/IsProductSalableCondition/BackOrderNotifyCustomerConditionTest.php
+++ b/InventorySales/Test/Unit/Model/IsProductSalableCondition/BackOrderNotifyCustomerConditionTest.php
@@ -76,7 +76,7 @@ class BackOrderNotifyCustomerConditionTest extends TestCase
                 function ($args) {
                     $mock = $this->getMockForAbstractClass(ProductSalabilityErrorInterface::class);
                     $mock->method('getCode')->willReturn($args['code'] ?? null);
-                    $mock->method('getMessage')->willReturn($args['message'] ?? null);
+                    $mock->method('getMessage')->willReturn((string)$args['message'] ?? null);
                     return $mock;
                 }
             );
@@ -117,7 +117,7 @@ class BackOrderNotifyCustomerConditionTest extends TestCase
      * @dataProvider executeDataProvider
      * @param array|null $stockData
      * @param int $reqQty
-     * @param int $salableQty
+     * @param float $salableQty
      * @param int $backOrders
      * @param bool $manageStock
      * @param array $errors
@@ -126,7 +126,7 @@ class BackOrderNotifyCustomerConditionTest extends TestCase
     public function testExecute(
         ?array $stockData,
         int $reqQty,
-        int $salableQty,
+        float $salableQty,
         int $backOrders,
         bool $manageStock,
         array $errors


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
run \Magento\InventorySales\Test\Unit\Model\IsProductSalableCondition\BackOrderNotifyCustomerConditionTest causes warnings

Original PR:https://github.com/magento/inventory/pull/3256

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/inventory#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
