### PR TITLE
Prevent Type Error PHP exception for numeric SKU

### DIFF
--- a/InventoryIndexer/Model/Queue/UpdateIndexSalabilityStatus/IndexProcessor.php
+++ b/InventoryIndexer/Model/Queue/UpdateIndexSalabilityStatus/IndexProcessor.php
@@ -116,7 +116,7 @@ class IndexProcessor
     {
         $data = [];
         foreach ($salabilityData as $sku => $isSalable) {
-            $currentStatus = $this->getIndexSalabilityStatus($sku, $stockId);
+            $currentStatus = $this->getIndexSalabilityStatus((string)$sku, $stockId);
             if ($isSalable != $currentStatus && $currentStatus !== null) {
                 $data[$sku] = $isSalable;
             }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento Inventory.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If SKU is numeric, PHP will auto type to integer and throw a Type Error exception when the consumer process a job including such SKU.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Not aware of any open issue

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.  Queue a message with the following topic and body
```
topic_name: inventory.reservations.updateSalabilityStatus
body: {"skus":["15438","15439"],"stock":6}
```
2.  Start a consumer 
`bin/magento queue:consumers:start inventory.reservations.updateSalabilityStatus`

3.  Watch the following error message in your log or termnal
```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\InventoryIndexer\Model\Queue\UpdateIndexSalabilityStatus\IndexProcessor::getIndexSalabilityStatus() must be of the type string, int given, called in /home/magento2/Projects/harald-nyborg/magento2/vendor/magento/module-inventory-indexer/Model/Queue/UpdateIndexSalabilityStatus/IndexProcessor.php on line 119 and defined in /home/magento2/Projects/harald-nyborg/magento2/vendor/magento/module-inventory-indexer/Model/Queue/UpdateIndexSalabilityStatus/IndexProcessor.php:136
Stack trace:
#0 /home/magento2/Projects/harald-nyborg/magento2/vendor/magento/module-inventory-indexer/Model/Queue/UpdateIndexSalabilityStatus/IndexProcessor.php(119): Magento\InventoryIndexer\Model\Queue\UpdateIndexSalabilityStatus\IndexProcessor->getIndexSalabilityStatus(15438, 6)
#1 /home/magento2/Projects/harald-nyborg/magento2/vendor/magento/module-inventory-indexer/Model/Queue/UpdateIndexSalabilityStatus/IndexProcessor.php(97): Magento\InventoryIndexer\Model\Queue\UpdateIndexSalabilityStatus\ in /home/magento2/Projects/harald-nyborg/magento2/vendor/magento/module-inventory-indexer/Model/Queue/UpdateIndexSalabilityStatus/IndexProcessor.php on line 136
```


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
I am not sure which branch this should go into. The problem is on latest 2.3.6-p1 which is still popular. It would be great to get this fix into the upcoming 2.3.7 or other service releases.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/inventory#3442: Prevent Type Error PHP exception for numeric SKU