### PR TITLE
Allow higher versions of magento/inventory-composer-installer to be installed in the future

### DIFF
--- a/_metapackage/composer.json
+++ b/_metapackage/composer.json
@@ -4,7 +4,7 @@
     "description": "Metapackage with Magento Inventory modules for simple installation",
     "type": "metapackage",
     "require": {
-        "magento/inventory-composer-installer": "1.2.0",
+        "magento/inventory-composer-installer": "^1.2.0",
         "magento/module-inventory": "*",
         "magento/module-inventory-admin-ui": "*",
         "magento/module-inventory-advanced-checkout": "*",


### PR DESCRIPTION
### Description (*)
This change will allow higher versions of the package `magento/inventory-composer-installer` to be installed in the future.
Magento is in control of versioning of `magento/inventory-composer-installer` and can follow semver best-practices, so there is no reason to keep a fixed requirement for this package.

This is done in order to avoid us to have to potentially implement workarounds [like these](https://gist.github.com/hostep/26de0bf2bb695eb3b6d51858c2e4562e) in the future so we can install newer versions of this package on previously released Magento versions if composer decides to increase the `composer-plugin-api` version again in the future.

<img width="1120" alt="Screenshot 2021-02-23 at 21 48 35" src="https://user-images.githubusercontent.com/85479/108907035-e2713380-7621-11eb-8616-523d9c73f347.png">

/cc @fascinosum

### Fixed Issues (if relevant)
1. Not that I know of

### Manual testing scenarios (*)
1. ...

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
