### PR TITLE
Fixed tests to compatibility to order increment_id wih prefix

### DIFF
--- a/InventoryAdminUi/Test/Mftf/Test/AdminCreateCreditMemoPartialRefundFullInvoiceFullShipmentBundleProductDefaultStockTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCreateCreditMemoPartialRefundFullInvoiceFullShipmentBundleProductDefaultStockTest.xml
@@ -92,11 +92,12 @@
         <actionGroup ref="OpenOrderByIdActionGroup" stepKey="openOrder">
             <argument name="orderId" value="{$orderNumber}"/>
         </actionGroup>
+        <grabFromCurrentUrl regex="~/order_id/(\d+)/~" stepKey="getOrderIdFromUrl"/>
         <actionGroup ref="AdminShipThePendingOrderActionGroup" stepKey="createShipment"/>
         <actionGroup ref="AdminCreateInvoiceActionGroup" stepKey="createInvoice"/>
         <!--Process credit memo partial refund.-->
         <actionGroup ref="StartToCreateCreditMemoActionGroup" stepKey="startToCreateCreditMemo">
-            <argument name="orderId" value="{$orderNumber}"/>
+            <argument name="orderId" value="{$getOrderIdFromUrl}"/>
         </actionGroup>
         <fillField selector="{{AdminCreditMemoItemsSection.itemQtyToRefund('1')}}" userInput="{{fivePiecesAddToCart.value}}" stepKey="partialRefund"/>
         <click selector="{{AdminCreditMemoItemsSection.updateQty}}" stepKey="updateQuantityToRefund"/>

--- a/InventoryAdminUi/Test/Mftf/Test/AdminCreateCreditMemoPartialRefundFullInvoicePartialShipmentBundleProductDefaultStockTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCreateCreditMemoPartialRefundFullInvoicePartialShipmentBundleProductDefaultStockTest.xml
@@ -92,13 +92,14 @@
         <actionGroup ref="OpenOrderByIdActionGroup" stepKey="openOrder">
             <argument name="orderId" value="{$orderNumber}"/>
         </actionGroup>
+        <grabFromCurrentUrl regex="~/order_id/(\d+)/~" stepKey="getOrderIdFromUrl"/>
         <actionGroup ref="AdminCreateInvoiceActionGroup" stepKey="createInvoice"/>
         <click selector="{{AdminOrderDetailsMainActionsSection.ship}}" stepKey="clickShipAction"/>
         <fillField selector=".order-shipment-table tbody:nth-of-type(1) .col-qty input" userInput="{{fivePiecesAddToCart.value}}" stepKey="shipFiveItems"/>
         <click selector="{{AdminShipmentMainActionsSection.submitShipment}}" stepKey="clickSubmitShipment"/>
         <!--Process credit memo partial refund.-->
         <actionGroup ref="StartToCreateCreditMemoActionGroup" stepKey="startToCreateCreditMemo">
-            <argument name="orderId" value="{$orderNumber}"/>
+            <argument name="orderId" value="{$getOrderIdFromUrl}"/>
         </actionGroup>
         <fillField selector="{{AdminCreditMemoItemsSection.itemQtyToRefund('1')}}" userInput="{{fivePiecesAddToCart.value}}" stepKey="partialRefund"/>
         <click selector="{{AdminCreditMemoItemsSection.updateQty}}" stepKey="updateQuantityToRefund"/>

--- a/InventoryAdminUi/Test/Mftf/Test/AdminCreditMemoCreatedForWholeOrderWithSimpleProductOnDefaultStockAfterFullInvoiceAndShipmentInAdminTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCreditMemoCreatedForWholeOrderWithSimpleProductOnDefaultStockAfterFullInvoiceAndShipmentInAdminTest.xml
@@ -71,13 +71,14 @@
         <actionGroup ref="OpenOrderByIdActionGroup" stepKey="openOrderToCreateShipment">
             <argument name="orderId" value="{$orderNumber}"/>
         </actionGroup>
+        <grabFromCurrentUrl regex="~/order_id/(\d+)/~" stepKey="getOrderIdFromUrl"/>
         <actionGroup ref="AdminShipThePendingOrderActionGroup" stepKey="shipOrder"/>
         <!--Admin Area Process Full Invoice-->
         <actionGroup ref="StartCreateInvoiceFromOrderPageActionGroup" stepKey="startCreateInvoice"/>
         <actionGroup ref="SubmitInvoiceActionGroup" stepKey="submitInvoice"/>
         <!--Admin Area Create Full Credit Memo-->
         <actionGroup ref="StartToCreateCreditMemoActionGroup" stepKey="startToCreateCreditMemo">
-            <argument name="orderId" value="{$orderNumber}"/>
+            <argument name="orderId" value="{$getOrderIdFromUrl}"/>
         </actionGroup>
         <click selector="{{AdminCreditMemoItemsSection.itemReturnToStock('1')}}" stepKey="returnToStockCheckbox"/>
         <actionGroup ref="SubmitCreditMemoActionGroup" stepKey="submitCreditMemo"/>

--- a/InventoryAdminUi/Test/Mftf/Test/AdminCreditMemoCreatedWithFullRefundWithSimpleProductOnDefaultStockAfterFullInvoiceAndPartialShipment.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminCreditMemoCreatedWithFullRefundWithSimpleProductOnDefaultStockAfterFullInvoiceAndPartialShipment.xml
@@ -81,11 +81,12 @@
         <actionGroup ref="OpenOrderByIdActionGroup" stepKey="openOrderToCreateInvoice">
             <argument name="orderId" value="{$orderNumber}"/>
         </actionGroup>
+        <grabFromCurrentUrl regex="~/order_id/(\d+)/~" stepKey="getOrderIdFromUrl"/>
         <actionGroup ref="StartCreateInvoiceFromOrderPageActionGroup" stepKey="startCreateInvoice"/>
         <actionGroup ref="SubmitInvoiceActionGroup" stepKey="submitInvoice"/>
         <!--Admin Area Create Full Credit Memo-->
         <actionGroup ref="StartToCreateCreditMemoActionGroup" stepKey="startToCreateCreditMemo">
-            <argument name="orderId" value="{$orderNumber}"/>
+            <argument name="orderId" value="{$getOrderIdFromUrl}"/>
         </actionGroup>
         <click selector="{{AdminCreditMemoItemsSection.itemReturnToStock('1')}}" stepKey="returnToStockCheckbox"/>
         <actionGroup ref="SubmitCreditMemoActionGroup" stepKey="submitCreditMemo"/>


### PR DESCRIPTION
### Description (*)
This PR fixed following tests error related to fixing the problem magento/magento2#30863.
- InventoryAdminUi/Test/Mftf/Test/AdminCreateCreditMemoPartialRefundFullInvoiceFullShipmentBundleProductDefaultStockTest.xml
- InventoryAdminUi/Test/Mftf/Test/AdminCreateCreditMemoPartialRefundFullInvoicePartialShipmentBundleProductDefaultStockTest.xml
- InventoryAdminUi/Test/Mftf/Test/AdminCreditMemoCreatedForWholeOrderWithSimpleProductOnDefaultStockAfterFullInvoiceAndShipmentInAdminTest.xml
- InventoryAdminUi/Test/Mftf/Test/AdminCreditMemoCreatedWithFullRefundWithSimpleProductOnDefaultStockAfterFullInvoiceAndPartialShipment.xml

### Related Pull Requests
https://github.com/magento/magento2/pull/31447
https://github.com/magento/partners-magento2ee/pull/471
https://github.com/magento/partners-magento2b2b/pull/557
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixed magento/magento2#30863

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
