### PR TITLE
Remove deprecated framework interfaces

### DIFF
--- a/InventoryDistanceBasedSourceSelectionAdminUi/Model/Config/Source/DistanceProvider.php
+++ b/InventoryDistanceBasedSourceSelectionAdminUi/Model/Config/Source/DistanceProvider.php
@@ -7,9 +7,9 @@ declare(strict_types=1);
 
 namespace Magento\InventoryDistanceBasedSourceSelectionAdminUi\Model\Config\Source;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
-class DistanceProvider implements ArrayInterface
+class DistanceProvider implements OptionSourceInterface
 {
     /**
      * @var array|string[]

--- a/InventoryDistanceBasedSourceSelectionAdminUi/Model/Config/Source/GoogleDistanceProvider/Mode.php
+++ b/InventoryDistanceBasedSourceSelectionAdminUi/Model/Config/Source/GoogleDistanceProvider/Mode.php
@@ -7,9 +7,9 @@ declare(strict_types=1);
 
 namespace Magento\InventoryDistanceBasedSourceSelectionAdminUi\Model\Config\Source\GoogleDistanceProvider;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
-class Mode implements ArrayInterface
+class Mode implements OptionSourceInterface
 {
     private const MODE_DRIVING = 'driving';
     private const MODE_WALKING = 'walking';

--- a/InventoryDistanceBasedSourceSelectionAdminUi/Model/Config/Source/GoogleDistanceProvider/Value.php
+++ b/InventoryDistanceBasedSourceSelectionAdminUi/Model/Config/Source/GoogleDistanceProvider/Value.php
@@ -7,9 +7,9 @@ declare(strict_types=1);
 
 namespace Magento\InventoryDistanceBasedSourceSelectionAdminUi\Model\Config\Source\GoogleDistanceProvider;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
-class Value implements ArrayInterface
+class Value implements OptionSourceInterface
 {
     private const MODE_DISTANCE = 'distance';
     private const MODE_TIME = 'time';


### PR DESCRIPTION
### Description (*)
Fix dependencies on the following interfaces:
 - `lib/internal/Magento/Framework/Option/ArrayInterface.php`

### Related Pull Requests
https://github.com/magento/magento2/pull/32328
https://github.com/magento/partners-magento2ee/pull/512
https://github.com/magento/partners-magento2b2b/pull/558
https://github.com/magento/magento2-page-builder/pull/735
https://github.com/magento/magento2-page-builder-ee/pull/187
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#32062

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
