### PR TITLE
#32540  Throw error when updating stock when auto increment is exceed…

### DIFF
--- a/Inventory/Model/ResourceModel/SourceItem/SaveMultiple.php
+++ b/Inventory/Model/ResourceModel/SourceItem/SaveMultiple.php
@@ -53,18 +53,15 @@ class SaveMultiple
             SourceItemInterface::STATUS
         ]);
         $valuesSql = $this->buildValuesSqlPart($sourceItems);
-        $onDuplicateSql = $this->buildOnDuplicateSqlPart([
-            SourceItemInterface::QUANTITY,
-            SourceItemInterface::STATUS,
-        ]);
         $bind = $this->getSqlBindData($sourceItems);
 
+        /* can not use "INSERT ... ON DUPLICATE KEY UPDATE" statement against a table having more than one unique
+        or primary key because it is unsafe */
         $insertSql = sprintf(
-            'INSERT INTO `%s` (%s) VALUES %s %s',
+            'INSERT INTO `%s` (%s) VALUES %s',
             $tableName,
             $columnsSql,
-            $valuesSql,
-            $onDuplicateSql
+            $valuesSql
         );
         $connection->query($insertSql, $bind);
     }

--- a/Inventory/Model/SourceItem/Command/Handler/SourceItemsSaveHandler.php
+++ b/Inventory/Model/SourceItem/Command/Handler/SourceItemsSaveHandler.php
@@ -11,6 +11,7 @@ use Exception;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Validation\ValidationException;
+use Magento\Inventory\Model\ResourceModel\SourceItem\DeleteMultiple;
 use Magento\Inventory\Model\ResourceModel\SourceItem\SaveMultiple;
 use Magento\Inventory\Model\SourceItem\Validator\SourceItemsValidator;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
@@ -37,18 +38,26 @@ class SourceItemsSaveHandler
     private $logger;
 
     /**
+     * @var DeleteMultiple
+     */
+    private $deleteMultiple;
+
+    /**
      * @param SourceItemsValidator $sourceItemsValidator
+     * @param DeleteMultiple $deleteMultiple
      * @param SaveMultiple $saveMultiple
      * @param LoggerInterface $logger
      */
     public function __construct(
         SourceItemsValidator $sourceItemsValidator,
+        DeleteMultiple $deleteMultiple,
         SaveMultiple $saveMultiple,
         LoggerInterface $logger
     ) {
         $this->sourceItemsValidator = $sourceItemsValidator;
         $this->saveMultiple = $saveMultiple;
         $this->logger = $logger;
+        $this->deleteMultiple = $deleteMultiple;
     }
 
     /**
@@ -73,6 +82,7 @@ class SourceItemsSaveHandler
         }
 
         try {
+            $this->deleteMultiple->execute($sourceItems);
             $this->saveMultiple->execute($sourceItems);
         } catch (Exception $e) {
             $this->logger->error($e->getMessage());

--- a/Inventory/Test/Integration/Model/SourceItem/Command/Handler/SourceItemsSaveHandlerTest.php
+++ b/Inventory/Test/Integration/Model/SourceItem/Command/Handler/SourceItemsSaveHandlerTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Inventory\Test\Integration\Model\SourceItem\Command\Handler;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\InventoryApi\Api\Data\SourceInterface;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\Inventory\Model\ResourceModel\SourceItem;
+use Magento\InventoryApi\Api\Data\SourceItemInterfaceFactory;
+use Magento\Inventory\Model\SourceItem\Command\Handler\SourceItemsSaveHandler;
+use Magento\InventoryCatalogApi\Api\DefaultSourceProviderInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test SourceItemsSaveHandler
+ */
+class SourceItemsSaveHandlerTest extends TestCase
+{
+    /**
+     * @var SourceItemsSaveHandler
+     */
+    private $sourceItemsSaveHandler;
+
+    /**
+     * @var SourceItemInterfaceFactory
+     */
+    private $sourceItemFactory;
+
+    /**
+     * @var DefaultSourceProviderInterface
+     */
+    private $defaultSourceProvider;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->sourceItemsSaveHandler = $objectManager->get(SourceItemsSaveHandler::class);
+        $this->sourceItemFactory = $objectManager->get(SourceItemInterfaceFactory::class);
+        $this->defaultSourceProvider = $objectManager->get(DefaultSourceProviderInterface::class);
+    }
+
+    /**
+     * Make sure exception is thrown when max auto_increment in inventory_source_item is reached
+     *
+     * @magentoDataFixture Magento_InventoryApi::Test/_files/products.php
+     * @magentoDbIsolation disabled
+     */
+    public function testMaxAutoIncrementIsReached(): void
+    {
+        $this->expectException(CouldNotSaveException::class);
+        /** @var ResourceConnection $resourceConnection */
+        $resourceConnection = Bootstrap::getObjectManager()->get(ResourceConnection::class);
+
+        //insert record with maximum increment to inventory_source_item table
+        $tableName = $resourceConnection->getTableName('inventory_source_item');
+        $maxIncrementValue = 4294967295;
+
+        $resourceConnection->getConnection()->insert($tableName, [
+            SourceItem::ID_FIELD_NAME        => $maxIncrementValue,
+            SourceItemInterface::SOURCE_CODE => $this->defaultSourceProvider->getCode(),
+            SourceItemInterface::SKU         => 'dummy-sku',
+            SourceItemInterface::QUANTITY    => 100,
+            SourceItemInterface::STATUS      => 1
+        ]);
+
+        $sourceItemParams = [
+            'data' => [
+                SourceItemInterface::SOURCE_CODE => $this->defaultSourceProvider->getCode(),
+                SourceItemInterface::SKU         => 'SKU-1',
+                SourceItemInterface::QUANTITY    => 100,
+                SourceItemInterface::STATUS      => 1
+            ]
+        ];
+
+        $sourceItem = $this->sourceItemFactory->create($sourceItemParams);
+
+        $this->sourceItemsSaveHandler->execute([$sourceItem]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDown(): void
+    {
+        /** @var ResourceConnection $resourceConnection */
+        $resourceConnection = Bootstrap::getObjectManager()->get(ResourceConnection::class);
+        $sourceItemTableName = $resourceConnection->getTableName('inventory_source_item');
+
+        //reset auto_increment
+        $resourceConnection->getConnection()
+            ->delete($sourceItemTableName, [SourceItemInterface::SKU . ' = (?)' => 'dummy-sku']);
+        $maxSourceItemIdQuery = sprintf("select max(%s) from %s", SourceItem::ID_FIELD_NAME, $sourceItemTableName);
+        $maxSourceItemId = $resourceConnection->getConnection()->fetchOne($maxSourceItemIdQuery);
+        $autoIncrementValue = (int)$maxSourceItemId + 1;
+        $setIncrementQuery = sprintf("ALTER TABLE %s AUTO_INCREMENT = %s", $sourceItemTableName, $autoIncrementValue);
+        $resourceConnection->getConnection()->query($setIncrementQuery);
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
### Description (*)
In \Magento\Inventory\Model\ResourceModel\SourceItem\SaveMultiple the "INSERT ... ON DUPLICATE KEY UPDATE" statement is used to save records in inventory_source_item table. Since inventory_source_item table has more than one unique/primary key this statement is unsafe (see https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html at the bottom). In this particular case when the auto increment value is reached and new record is being inserted it will update the last record in the table instead of creating new one, no errors is thrown. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/inventory#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#32540: API - No error when updating stock when auto increment is exceeded in inventory_source_item

### Manual testing scenarios (*)
1. Insert record to `inventory_source_item` table with max source_item_id 4294967295, e. g:
`INSERT INTO `inventory_source_item` (`source_item_id`, `source_code`, `sku`, `quantity`, `status`) VALUES
(4294967295, 'default', 'test', '100.0000', '1');`
2. Create a new product via Magento Admin or API

**Expected result**: error is thrown.

**Actual Result**: no error is thrown, stock item is not saved. The item with source_item_id 4294967295 is updated instead.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
