### PR TITLE
Changed restrictions for php to "~7.4.0||~8.1.0" into `composer.json` files

### DIFF
--- a/Inventory/composer.json
+++ b/Inventory/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-api": "*"
     },

--- a/InventoryAdminUi/Test/Mftf/composer.json
+++ b/InventoryAdminUi/Test/Mftf/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/magento2-functional-testing-framework": "2.2.0",
         "magento/functional-test-module-inventory-api": "100.0.0-dev",
         "magento/functional-test-module-backend": "100.0.0-dev",

--- a/InventoryAdminUi/composer.json
+++ b/InventoryAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory": "*",
         "magento/module-inventory-api": "*",

--- a/InventoryAdvancedCheckout/composer.json
+++ b/InventoryAdvancedCheckout/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-advanced-checkout",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-store": "*",
         "magento/module-inventory-catalog-api": "*",

--- a/InventoryApi/composer.json
+++ b/InventoryApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/InventoryBundleImportExport/composer.json
+++ b/InventoryBundleImportExport/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-bundle-import-export",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-bundle-import-export": "*",
         "magento/module-inventory-catalog-api": "*",

--- a/InventoryBundleProduct/composer.json
+++ b/InventoryBundleProduct/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-bundle-product",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-bundle": "*",
         "magento/module-catalog": "*",

--- a/InventoryBundleProductAdminUi/Test/Mftf/composer.json
+++ b/InventoryBundleProductAdminUi/Test/Mftf/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/magento2-functional-testing-framework": "2.2.0",
         "magento/functional-test-module-bundle": "100.0.0-dev"
     },

--- a/InventoryBundleProductAdminUi/composer.json
+++ b/InventoryBundleProductAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-bundle-product-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-bundle": "*",
         "magento/module-catalog": "*",

--- a/InventoryBundleProductIndexer/composer.json
+++ b/InventoryBundleProductIndexer/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-bundle-product-indexer",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-bundle": "*",
         "magento/module-catalog": "*",

--- a/InventoryCache/composer.json
+++ b/InventoryCache/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-cache",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-catalog-api": "*",
         "magento/module-inventory-indexer": "*"

--- a/InventoryCatalog/composer.json
+++ b/InventoryCatalog/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-catalog",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-catalog-inventory": "*",

--- a/InventoryCatalogAdminUi/Test/Mftf/composer.json
+++ b/InventoryCatalogAdminUi/Test/Mftf/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/magento2-functional-testing-framework": "2.2.0",
         "magento/functional-test-module-catalog": "100.0.0-dev",
         "magento/functional-test-module-catalog-inventory": "100.0.0-dev",

--- a/InventoryCatalogAdminUi/composer.json
+++ b/InventoryCatalogAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-catalog-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-catalog-inventory": "*",

--- a/InventoryCatalogApi/composer.json
+++ b/InventoryCatalogApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-catalog-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/InventoryCatalogFrontendUi/composer.json
+++ b/InventoryCatalogFrontendUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-catalog-frontend-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-sales-api": "*",
         "magento/module-inventory-configuration-api": "*"

--- a/InventoryCatalogSearch/composer.json
+++ b/InventoryCatalogSearch/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-catalog-search",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog-inventory": "*",
         "magento/module-inventory-catalog-api": "*",

--- a/InventoryCatalogSearchBundleProduct/composer.json
+++ b/InventoryCatalogSearchBundleProduct/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-catalog-search-bundle-product",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-bundle": "*",
         "magento/module-catalog": "*",

--- a/InventoryCatalogSearchConfigurableProduct/composer.json
+++ b/InventoryCatalogSearchConfigurableProduct/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-catalog-search-configurable-product",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-configurable-product": "*",

--- a/InventoryConfigurableProduct/composer.json
+++ b/InventoryConfigurableProduct/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-configurable-product",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-inventory-sales-api": "*",

--- a/InventoryConfigurableProductAdminUi/Test/Mftf/composer.json
+++ b/InventoryConfigurableProductAdminUi/Test/Mftf/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/magento2-functional-testing-framework": "2.2.0",
         "magento/functional-test-module-catalog": "100.0.0-dev",
         "magento/functional-test-module-configurable-product": "100.0.0-dev",

--- a/InventoryConfigurableProductAdminUi/composer.json
+++ b/InventoryConfigurableProductAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-configurable-product-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-configurable-product": "*",

--- a/InventoryConfigurableProductFrontendUi/composer.json
+++ b/InventoryConfigurableProductFrontendUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-configurable-product-frontend-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-sales-api": "*",
         "magento/module-store": "*",

--- a/InventoryConfigurableProductIndexer/composer.json
+++ b/InventoryConfigurableProductIndexer/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-configurable-product-indexer",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-inventory-api": "*",

--- a/InventoryConfiguration/composer.json
+++ b/InventoryConfiguration/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-configuration",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog-inventory": "*",
         "magento/module-inventory-api": "*",

--- a/InventoryConfigurationApi/composer.json
+++ b/InventoryConfigurationApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-configuration-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/InventoryDistanceBasedSourceSelection/composer.json
+++ b/InventoryDistanceBasedSourceSelection/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-distance-based-source-selection",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-distance-based-source-selection-api": "*",
         "magento/module-inventory-source-selection-api": "*",

--- a/InventoryDistanceBasedSourceSelectionAdminUi/composer.json
+++ b/InventoryDistanceBasedSourceSelectionAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-distance-based-source-selection-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/InventoryDistanceBasedSourceSelectionApi/composer.json
+++ b/InventoryDistanceBasedSourceSelectionApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-distance-based-source-selection-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-source-selection-api": "*"
     },

--- a/InventoryElasticsearch/composer.json
+++ b/InventoryElasticsearch/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-elasticsearch",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog-inventory": "*",
         "magento/module-catalog-search": "*",

--- a/InventoryExportStock/composer.json
+++ b/InventoryExportStock/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-export-stock",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-api": "*",
         "magento/module-inventory-export-stock-api": "*",

--- a/InventoryExportStockApi/composer.json
+++ b/InventoryExportStockApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-export-stock-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-sales-api": "*"
     },

--- a/InventoryGraphQl/composer.json
+++ b/InventoryGraphQl/composer.json
@@ -3,7 +3,7 @@
     "description": "N/A",
     "type": "magento2-module",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-inventory-catalog": "*",

--- a/InventoryGroupedProduct/composer.json
+++ b/InventoryGroupedProduct/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-grouped-product",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-grouped-product": "*"
     },

--- a/InventoryGroupedProductAdminUi/Test/Mftf/composer.json
+++ b/InventoryGroupedProductAdminUi/Test/Mftf/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/magento2-functional-testing-framework": "2.2.0",
         "magento/functional-test-module-grouped-product": "100.0.0-dev"
     },

--- a/InventoryGroupedProductAdminUi/composer.json
+++ b/InventoryGroupedProductAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-grouped-product-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-grouped-product": "*",

--- a/InventoryGroupedProductIndexer/composer.json
+++ b/InventoryGroupedProductIndexer/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-grouped-product-indexer",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-inventory-api": "*",

--- a/InventoryImportExport/composer.json
+++ b/InventoryImportExport/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-import-export",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-eav": "*",
         "magento/module-import-export": "*",

--- a/InventoryInStorePickup/composer.json
+++ b/InventoryInStorePickup/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-in-store-pickup-api": "*",
         "magento/module-inventory-distance-based-source-selection-api": "*",

--- a/InventoryInStorePickupAdminUi/composer.json
+++ b/InventoryInStorePickupAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-ui": "*",
         "magento/module-inventory-in-store-pickup-api": "*",

--- a/InventoryInStorePickupApi/composer.json
+++ b/InventoryInStorePickupApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-api": "*"
     },

--- a/InventoryInStorePickupFrontend/composer.json
+++ b/InventoryInStorePickupFrontend/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-frontend",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-checkout": "*",
         "magento/module-inventory-in-store-pickup-api": "*",

--- a/InventoryInStorePickupGraphQl/composer.json
+++ b/InventoryInStorePickupGraphQl/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-graph-ql",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-in-store-pickup-api": "*",
         "magento/module-inventory-api": "*",

--- a/InventoryInStorePickupMultishipping/composer.json
+++ b/InventoryInStorePickupMultishipping/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-multishipping",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-in-store-pickup-shipping-api": "*",
         "magento/module-checkout": "*",

--- a/InventoryInStorePickupQuote/composer.json
+++ b/InventoryInStorePickupQuote/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-quote",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-in-store-pickup": "*",
         "magento/module-inventory-in-store-pickup-api": "*",

--- a/InventoryInStorePickupQuoteGraphQl/composer.json
+++ b/InventoryInStorePickupQuoteGraphQl/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-quote-graph-ql",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-quote-graph-ql": "*",
         "magento/module-quote": "*",

--- a/InventoryInStorePickupSales/composer.json
+++ b/InventoryInStorePickupSales/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-sales",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-in-store-pickup-sales-api": "*",
         "magento/module-inventory-in-store-pickup-api": "*",

--- a/InventoryInStorePickupSalesAdminUi/composer.json
+++ b/InventoryInStorePickupSalesAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-sales-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-in-store-pickup-sales-api": "*",
         "magento/module-inventory-in-store-pickup-sales": "*",

--- a/InventoryInStorePickupSalesApi/composer.json
+++ b/InventoryInStorePickupSalesApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-sales-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/InventoryInStorePickupShipping/composer.json
+++ b/InventoryInStorePickupShipping/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-shipping",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-in-store-pickup-shipping-api": "*",
         "magento/module-inventory-in-store-pickup-api": "*",

--- a/InventoryInStorePickupShippingAdminUi/composer.json
+++ b/InventoryInStorePickupShippingAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-shipping-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-in-store-pickup-shipping-api": "*"
     },

--- a/InventoryInStorePickupShippingApi/composer.json
+++ b/InventoryInStorePickupShippingApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-shipping-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-quote": "*",
         "magento/module-shipping": "*",

--- a/InventoryInStorePickupWebapiExtension/composer.json
+++ b/InventoryInStorePickupWebapiExtension/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-in-store-pickup-webapi-extension",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-webapi": "*"
     },

--- a/InventoryIndexer/composer.json
+++ b/InventoryIndexer/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-indexer",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/framework-message-queue": "*",
         "magento/module-inventory-multi-dimensional-indexer-api": "*",

--- a/InventoryLowQuantityNotification/composer.json
+++ b/InventoryLowQuantityNotification/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-low-quantity-notification",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-eav": "*",

--- a/InventoryLowQuantityNotificationAdminUi/Test/Mftf/composer.json
+++ b/InventoryLowQuantityNotificationAdminUi/Test/Mftf/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/magento2-functional-testing-framework": "2.2.0",
         "magento/functional-test-module-catalog": "100.0.0-dev",
         "magento/functional-test-module-backend": "100.0.0-dev",

--- a/InventoryLowQuantityNotificationAdminUi/composer.json
+++ b/InventoryLowQuantityNotificationAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-low-quantity-notification-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-backend": "*",

--- a/InventoryLowQuantityNotificationApi/composer.json
+++ b/InventoryLowQuantityNotificationApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-low-quantity-notification-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/InventoryMultiDimensionalIndexerApi/composer.json
+++ b/InventoryMultiDimensionalIndexerApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-multi-dimensional-indexer-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/InventoryProductAlert/composer.json
+++ b/InventoryProductAlert/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-product-alert",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-store": "*",

--- a/InventoryQuoteGraphQl/composer.json
+++ b/InventoryQuoteGraphQl/composer.json
@@ -3,7 +3,7 @@
     "description": "N/A",
     "type": "magento2-module",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-quote": "*",
         "magento/module-quote-graph-ql": "*",

--- a/InventoryRequisitionList/composer.json
+++ b/InventoryRequisitionList/composer.json
@@ -9,7 +9,7 @@
         "magento/module-catalog": "*",
         "magento/module-inventory-sales-api": "*",
         "magento/module-inventory-configuration-api": "*",
-        "php": "~7.4.0||~8.0.0||~8.1.0"
+        "php": "~7.4.0||~8.1.0"
     },
     "suggest": {
         "magento/module-requisition-list": "*"

--- a/InventoryReservationCli/composer.json
+++ b/InventoryReservationCli/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-reservation-cli",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-sales": "*",
         "magento/module-inventory-api": "*",

--- a/InventoryReservations/composer.json
+++ b/InventoryReservations/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-reservations",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-reservations-api": "*"
     },

--- a/InventoryReservationsApi/composer.json
+++ b/InventoryReservationsApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-reservations-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/InventorySales/composer.json
+++ b/InventorySales/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-sales",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog-inventory": "*",
         "magento/module-catalog": "*",

--- a/InventorySalesAdminUi/Test/Mftf/composer.json
+++ b/InventorySalesAdminUi/Test/Mftf/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/magento2-functional-testing-framework": "2.2.0",
         "magento/functional-test-module-backend": "100.0.0-dev",
         "magento/functional-test-module-catalog-inventory": "100.0.0-dev",

--- a/InventorySalesAdminUi/composer.json
+++ b/InventorySalesAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-sales-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-backend": "*",
         "magento/module-catalog-inventory": "*",

--- a/InventorySalesApi/composer.json
+++ b/InventorySalesApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-sales-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-api": "*",
         "magento/module-sales": "*"

--- a/InventorySalesFrontendUi/Test/Mftf/composer.json
+++ b/InventorySalesFrontendUi/Test/Mftf/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/magento2-functional-testing-framework": "2.2.0",
         "magento/functional-test-module-catalog-inventory": "100.0.0-dev",
         "magento/functional-test-module-inventory-sales-api": "100.0.0-dev",

--- a/InventorySalesFrontendUi/composer.json
+++ b/InventorySalesFrontendUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-sales-frontend-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog-inventory": "*",
         "magento/module-inventory-sales-api": "*",

--- a/InventorySetupFixtureGenerator/composer.json
+++ b/InventorySetupFixtureGenerator/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-setup-fixture-generator",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/InventoryShipping/composer.json
+++ b/InventoryShipping/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-shipping",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-api": "*",
         "magento/module-inventory-catalog-api": "*",

--- a/InventoryShippingAdminUi/Test/Mftf/composer.json
+++ b/InventoryShippingAdminUi/Test/Mftf/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/magento2-functional-testing-framework": "2.2.0",
         "magento/functional-test-module-backend": "100.0.0-dev",
         "magento/functional-test-module-inventory-api": "100.0.0-dev",

--- a/InventoryShippingAdminUi/composer.json
+++ b/InventoryShippingAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-shipping-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-backend": "*",
         "magento/module-inventory-api": "*",

--- a/InventorySourceDeductionApi/composer.json
+++ b/InventorySourceDeductionApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-source-deduction-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory": "*",
         "magento/module-inventory-api": "*",

--- a/InventorySourceSelection/composer.json
+++ b/InventorySourceSelection/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-source-selection",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-inventory-source-selection-api": "*",
         "magento/module-inventory-api": "*"

--- a/InventorySourceSelectionApi/composer.json
+++ b/InventorySourceSelectionApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-source-selection-api",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/module-inventory-api": "*",
         "magento/module-inventory-sales-api": "*",
         "magento/module-store": "*",

--- a/InventorySwatchesFrontendUi/composer.json
+++ b/InventorySwatchesFrontendUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-swatches-frontend-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "suggest": {

--- a/InventoryVisualMerchandiser/composer.json
+++ b/InventoryVisualMerchandiser/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-visual-merchandiser",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-catalog": "*",
         "magento/module-inventory": "*",

--- a/InventoryWishlist/Test/Mftf/composer.json
+++ b/InventoryWishlist/Test/Mftf/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/magento2-functional-testing-framework": "2.2.0",
         "magento/functional-test-module-backend": "100.0.0-dev",
         "magento/functional-test-module-catalog": "100.0.0-dev",

--- a/InventoryWishlist/composer.json
+++ b/InventoryWishlist/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-inventory-wishlist",
     "description": "N/A",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "suggest": {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request (PR) provides fixes for `composer.json` files

1. remove restriction `"~8.0.0"` for `"php"` requirements

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/partners-magento2b2b#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#34852

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
