### PR TITLE
Correct grammar and spelling in error message

### DIFF
--- a/InventoryBundleProduct/Plugin/Bundle/Model/LinkManagement/ValidateSourceItemsBeforeAddBundleSelectionPlugin.php
+++ b/InventoryBundleProduct/Plugin/Bundle/Model/LinkManagement/ValidateSourceItemsBeforeAddBundleSelectionPlugin.php
@@ -73,7 +73,7 @@ class ValidateSourceItemsBeforeAddBundleSelectionPlugin
                 __(
                     'Product "%1" cannot be added to bundle product as '
                     . 'bundle product has "Ship Bundle Items Together" and "%1" product assigned to multiple sources'
-                    . ' or has different source then rest of bundle items',
+                    . ' or has a different source than the rest of the bundle items',
                     [$link->getSku()]
                 )
             );

--- a/InventoryBundleProduct/Plugin/Bundle/Model/LinkManagement/ValidateSourceItemsBeforeSaveBundleSelectionPlugin.php
+++ b/InventoryBundleProduct/Plugin/Bundle/Model/LinkManagement/ValidateSourceItemsBeforeSaveBundleSelectionPlugin.php
@@ -81,7 +81,7 @@ class ValidateSourceItemsBeforeSaveBundleSelectionPlugin
                 __(
                     'Product "%1" cannot be added to bundle product as '
                     . 'bundle product has "Ship Bundle Items Together" and "%1" product assigned to multiple sources'
-                    . ' or has different source then rest of bundle items',
+                    . ' or has a different source than the rest of the bundle items',
                     [$link->getSku()]
                 )
             );


### PR DESCRIPTION
### Description
The error message does not make sense currently. Confusing 'then' for 'than' and vice-versa is a common mistake made in English. This pull request corrects both the grammar (inserting articles 'a' and 'the') and spelling (replace 'then' with 'than') in the error message so that it now makes sense.

https://www.merriam-webster.com/words-at-play/when-to-use-then-and-than

### Manual testing scenarios
1. Set up a catalogue with (at least) two inventory sources and (at least) one simple product in each (we only need two).
1. Create a new bundle product and set this to 'ship bundle items together'
1. Add one simple product and save the bundle product.
1. Add another simple product (from a different inventory source) and save the bundle product.
1. Observe text of error message.
Note that we are intentionally triggering the error so that we can read the message. We do not expect the bundle product to be saved with both simple products attached.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)