### PR TITLE
Enable Sortable for lowstock grid

### DIFF
--- a/InventoryLowQuantityNotificationAdminUi/view/adminhtml/layout/inventorylowquantitynotification_lowstock_grid.xml
+++ b/InventoryLowQuantityNotificationAdminUi/view/adminhtml/layout/inventorylowquantitynotification_lowstock_grid.xml
@@ -32,7 +32,7 @@
                     <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.product.inventory.lowstock.grid.columnSet.name" as="name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Product</argument>
-                            <argument name="sortable" xsi:type="string">0</argument>
+                            <argument name="sortable" xsi:type="string">1</argument>
                             <argument name="index" xsi:type="string">product_name</argument>
                             <argument name="filter_index" xsi:type="string">product_name</argument>
                             <argument name="header_css_class" xsi:type="string">col-product</argument>
@@ -42,7 +42,7 @@
                     <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.product.inventory.lowstock.grid.columnSet.sku" as="sku">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">SKU</argument>
-                            <argument name="sortable" xsi:type="string">0</argument>
+                            <argument name="sortable" xsi:type="string">1</argument>
                             <argument name="index" xsi:type="string">sku</argument>
                             <argument name="filter_index" xsi:type="string">sku</argument>
                             <argument name="header_css_class" xsi:type="string">col-sku</argument>
@@ -53,7 +53,7 @@
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Quantity</argument>
                             <argument name="filter" xsi:type="string">Magento\Backend\Block\Widget\Grid\Column\Filter\Range</argument>
-                            <argument name="sortable" xsi:type="string">0</argument>
+                            <argument name="sortable" xsi:type="string">1</argument>
                             <argument name="index" xsi:type="string">quantity</argument>
                             <argument name="type" xsi:type="string">number</argument>
                             <argument name="header_css_class" xsi:type="string">col-qty</argument>
@@ -63,7 +63,7 @@
                     <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.product.inventory.lowstock.grid.columnSet.sourceCode" as="sourceCode">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Source Code</argument>
-                            <argument name="sortable" xsi:type="string">0</argument>
+                            <argument name="sortable" xsi:type="string">1</argument>
                             <argument name="filter_index" xsi:type="string">source_code</argument>
                             <argument name="index" xsi:type="string">source_code</argument>
                             <argument name="type" xsi:type="string">options</argument>


### PR DESCRIPTION
Enable Sortable for lowstock grid

### Description (*)
Enable Sortable for lowstock grid, i don't see a reason why it was disabled in the first place.

### Manual testing scenarios (*)
1. Open a magento Admin interface
2. Goto Reports -> Products -> Low Stock
3. Click on one of the headers (SKU for example) it will not sort

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
