### PR TITLE
Configurable stock status is not correct when using custom stock (MSI)

### DIFF
--- a/InventoryConfigurableProduct/Model/Inventory/ChangeParentProductStockStatus.php
+++ b/InventoryConfigurableProduct/Model/Inventory/ChangeParentProductStockStatus.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryConfigurableProduct\Model\Inventory;
+
+use Magento\CatalogInventory\Api\StockItemRepositoryInterface;
+use Magento\CatalogInventory\Api\StockRegistryInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\App\RequestInterface;
+use Magento\Inventory\Model\ResourceModel\Source\CollectionFactory;
+use Magento\InventoryApi\Api\Data\SourceInterface;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\SourceItemRepositoryInterface;
+use Magento\InventoryCatalogApi\Model\GetSkusByProductIdsInterface;
+
+/**
+ * @inheritDoc
+ */
+class ChangeParentProductStockStatus
+{
+    /**
+     * @var RequestInterface
+     */
+    private RequestInterface $request;
+
+    /**
+     * @var Configurable
+     */
+    private Configurable $configurableType;
+
+    /**
+     * @var StockRegistryInterface
+     */
+    private StockRegistryInterface $stockRegistry;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private SearchCriteriaBuilder $searchCriteriaBuilder;
+
+    /**
+     * @var SourceItemRepositoryInterface
+     */
+    private SourceItemRepositoryInterface $sourceItemRepository;
+
+    /**
+     * @var StockItemRepositoryInterface
+     */
+    private StockItemRepositoryInterface $stockItemRepository;
+
+    /**
+     * @var GetSkusByProductIdsInterface
+     */
+    private GetSkusByProductIdsInterface $getSkusByProductIds;
+
+    /**
+     * @var CollectionFactory
+     */
+    private CollectionFactory $collectionFactory;
+
+    /**
+     * @param RequestInterface $request
+     * @param Configurable $configurableType
+     */
+    public function __construct(
+        RequestInterface $request,
+        Configurable $configurableType,
+        StockRegistryInterface $stockRegistry,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        SourceItemRepositoryInterface $sourceItemRepository,
+        StockItemRepositoryInterface $stockItemRepository,
+        GetSkusByProductIdsInterface $getSkusByProductIds,
+        CollectionFactory $collectionFactory
+    ) {
+        $this->request = $request;
+        $this->configurableType = $configurableType;
+        $this->stockRegistry = $stockRegistry;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->sourceItemRepository = $sourceItemRepository;
+        $this->stockItemRepository = $stockItemRepository;
+        $this->getSkusByProductIds = $getSkusByProductIds;
+        $this->collectionFactory = $collectionFactory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute($childproductId): void
+    {
+        $parentIds = $this->configurableType->getParentIdsByChild($childproductId);
+        foreach (array_unique($parentIds) as $productId) {
+            $this->processStockForParent((int)$childproductId, (int)$productId);
+        }
+    }
+
+    /**
+     * Update stock status of configurable product based on children products stock status
+     *
+     * @param int $childproductId
+     * @param int $productId
+     * @return void
+     */
+    private function processStockForParent(int $childproductId, int $productId): void
+    {
+        $childrenIsInStock = false;
+
+        if ($sources = $this->request->getParam('sources')) {
+            if ($currentsourceItems = $sources['assigned_sources']) {
+                foreach ($currentsourceItems as $childItem) {
+                    if ($childItem['status'] && $childItem['quantity'] > 0 && $childItem['source_status']) {
+                        $childrenIsInStock = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!$childrenIsInStock) {
+            $sourceCodes = $this->collectionFactory->create()
+                ->addFieldToFilter(SourceInterface::ENABLED, 1)
+                ->addFieldToSelect('source_code')
+                ->getColumnValues('source_code');
+            $childrenIds = $this->configurableType->getChildrenIds($productId);
+            $childrenSkus = $this->getSkusByProductIds->execute($childrenIds[0]);
+
+            $searchCriteria = $this->searchCriteriaBuilder
+                ->addFilter(SourceItemInterface::SOURCE_CODE, $sourceCodes, 'in')
+                ->addFilter(SourceItemInterface::SKU, $childrenSkus, 'in')
+                ->addFilter(SourceItemInterface::SKU, $childrenSkus[$childproductId], 'neq')
+                ->addFilter(SourceItemInterface::STATUS, 1)
+                ->create();
+
+            $sourceItems = $this->sourceItemRepository->getList($searchCriteria)->getItems();
+            foreach ($sourceItems as $childItem) {
+                if ($childItem->getStatus()) {
+                    $childrenIsInStock = true;
+                    break;
+                }
+            }
+        }
+
+        $parentStockItem = $this->stockRegistry->getStockItem($productId);
+        $parentStockItem->setIsInStock($childrenIsInStock);
+        $parentStockItem->setStockStatusChangedAuto(1);
+        $this->stockItemRepository->save($parentStockItem);
+    }
+}

--- a/InventoryConfigurableProduct/Test/Unit/Model/Inventory/ChangeParentProductStockStatusTest.php
+++ b/InventoryConfigurableProduct/Test/Unit/Model/Inventory/ChangeParentProductStockStatusTest.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\InventoryConfigurableProduct\Test\Unit\Model\Inventory;
+
+use Magento\CatalogInventory\Api\Data\StockItemInterface;
+use Magento\CatalogInventory\Api\StockItemRepositoryInterface;
+use Magento\CatalogInventory\Api\StockRegistryInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Inventory\Model\ResourceModel\Source\CollectionFactory;
+use Magento\InventoryApi\Api\SourceItemRepositoryInterface;
+use Magento\InventoryCatalogApi\Model\GetSkusByProductIdsInterface;
+use Magento\InventoryConfigurableProduct\Model\Inventory\ChangeParentProductStockStatus;
+use Magento\InventoryApi\Api\Data\SourceItemSearchResultsInterface;
+use PHPUnit\Framework\TestCase;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+
+/**
+ * @inheritDoc
+ */
+class ChangeParentProductStockStatusTest extends TestCase
+{
+    /**
+     * @var RequestInterface
+     */
+    private $requestMock;
+
+    /**
+     * @var Configurable
+     */
+    private $configurableTypeMock;
+
+    /**
+     * @var StockRegistryInterface
+     */
+    private $stockRegistryMock;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilderMock;
+
+    /**
+     * @var SourceItemRepositoryInterface
+     */
+    private $sourceItemRepositoryMock;
+
+    /**
+     * @var StockItemRepositoryInterface
+     */
+    private $stockItemRepositoryMock;
+
+    /**
+     * @var GetSkusByProductIdsInterface
+     */
+    private $getSkusByProductIdsMock;
+
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactoryMock;
+
+    /**
+     * @var ChangeParentProductStockStatus
+     */
+    private $changeParentProductStockStatus;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $objectManager = new ObjectManager($this);
+        $this->requestMock = $this->getMockBuilder(RequestInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->configurableTypeMock = $this->getMockBuilder(Configurable::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->stockRegistryMock = $this->getMockBuilder(StockRegistryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->searchCriteriaBuilderMock = $this->getMockBuilder(SearchCriteriaBuilder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->sourceItemRepositoryMock = $this->getMockBuilder(SourceItemRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->stockItemRepositoryMock = $this->getMockBuilder(StockItemRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->getSkusByProductIdsMock = $this->getMockBuilder(GetSkusByProductIdsInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->collectionFactoryMock = $this->getMockBuilder(CollectionFactory::class)
+            ->setMethods(['addFieldToFilter','create','addFieldToSelect','getColumnValues'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->changeParentProductStockStatus = $this->getMockBuilder(ChangeParentProductStockStatus::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->changeParentProductStockStatus = new ChangeParentProductStockStatus(
+            $this->requestMock,
+            $this->configurableTypeMock,
+            $this->stockRegistryMock,
+            $this->searchCriteriaBuilderMock,
+            $this->sourceItemRepositoryMock,
+            $this->stockItemRepositoryMock,
+            $this->getSkusByProductIdsMock,
+            $this->collectionFactoryMock
+        );
+    }
+
+    public function testChangeParentProductStockStatus()
+    {
+        $parentIds = [14];
+        $childproductId = 13;
+        $childrenIds = [[13 => 13]];
+        $childrenSkus = [13 => 'config-parent-blue'];
+        $sourcecodes = [0 => 'default',1 =>'north'];
+        $childrenIsInStock = false;
+        $sources = [
+            'assigned_sources' =>[
+                [
+                    'source_code' => 'north',
+                    'quantity' =>1
+                ]
+            ]
+        ];
+        $this->configurableTypeMock->expects($this->once())
+            ->method('getParentIdsByChild')
+            ->with($childproductId)
+            ->willReturn($parentIds);
+
+        $this->requestMock
+            ->expects($this->any())
+            ->method('getParam')
+            ->willReturnMap(
+                [
+                    ['sources', [], $sources]
+                ]
+            );
+
+        $this->collectionFactoryMock->expects($this->any())->method('create')->willReturn($this->collectionFactoryMock);
+        $this->collectionFactoryMock->expects($this->any())->method('addFieldToFilter')
+            ->with('enabled', 1)
+            ->willReturnSelf();
+        $this->collectionFactoryMock->expects($this->any())->method('addFieldToSelect')
+            ->with('source_code')
+            ->willReturnSelf();
+        $this->collectionFactoryMock->expects($this->any())->method('getColumnValues')
+            ->with('source_code')
+            ->willReturn($sourcecodes);
+//
+        $this->configurableTypeMock->expects($this->any())
+            ->method('getChildrenIds')
+            ->with($parentIds[0])
+            ->willReturn($childrenIds);
+        $this->getSkusByProductIdsMock->expects($this->once())
+            ->method('execute')
+            ->with($childrenIds[0])
+            ->willReturn($childrenSkus);
+
+
+        $searchCriteriaMock = $this->createMock(SearchCriteria::class);
+
+        $this->searchCriteriaBuilderMock->expects($this->any())->method('addFilter')
+            ->willReturnSelf();
+        $this->searchCriteriaBuilderMock->expects($this->any())->method('create')->willReturn($searchCriteriaMock);
+        $searchResultsMock = $this->getMockForAbstractClass(SourceItemSearchResultsInterface::class);
+        $this->sourceItemRepositoryMock->expects($this->any())
+            ->method('getList')
+            ->with($searchCriteriaMock)
+            ->willReturn($searchResultsMock);
+
+        $sourceItems = $this->getMockForAbstractClass(SourceItemInterface::class);
+        $searchResultsMock->expects($this->once())
+            ->method('getItems')
+            ->willReturn($sourceItems);
+
+        $stockItemMock = $this->getMockBuilder(StockItemInterface::class)
+            ->setMethods(['setIsInStock', 'setStockStatusChangedAuto'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $this->stockRegistryMock->expects($this->any())
+            ->method('getStockItem')
+            ->with($parentIds[0])
+            ->willReturn($stockItemMock);
+        $stockItemMock->expects($this->any())->method('setIsInStock')->with($childrenIsInStock)->willReturnSelf();
+        $stockItemMock->expects($this->any())->method('setStockStatusChangedAuto')->with(1)->willReturnSelf();
+        $this->stockItemRepositoryMock->expects($this->any())
+            ->method('save')
+            ->with($stockItemMock);
+        $this->changeParentProductStockStatus->execute($childproductId);
+    }
+}


### PR DESCRIPTION
### Description (*)
This PR fix when MSI enabled to product ,the configurable product status must be updated when a child's product status is changed.

### Fixed Issues (if relevant)

1. Fixes #36154

https://github.com/magento/magento2/issues/36154

### Manual testing scenarios (*)

- create new source in admin > store > sources, i.e : source A
- create new stock in admin > store > stock, i.e : custom stock
- assign source A to Custom stock, and also assign custom stock to main website
- create new configurable product, i.e : test product
        - add simple product to the configurable product in configuration tab
        - assign simple product to source A
        - fill quantity, i.e : 1
- and save new created configurable product. (in this step the configurable product stock = In Stock)
- now change the simple product :
      - Source Item Status : from In Stock to Out Of Stock
      - Qty : from 1 to 0
      - save simple product
- check configurable product (the stock status is still In Stock, it must be Out Of Stock)



### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
