### PR TITLE
Grouped product indexer | cache clear fix

### DIFF
--- a/InventoryGroupedProductIndexer/Indexer/SelectBuilder.php
+++ b/InventoryGroupedProductIndexer/Indexer/SelectBuilder.php
@@ -20,13 +20,14 @@ use Magento\InventoryIndexer\Indexer\InventoryIndexer;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\Alias;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\IndexNameBuilder;
 use Magento\InventoryMultiDimensionalIndexerApi\Model\IndexNameResolverInterface;
+use Magento\InventoryIndexer\Indexer\SelectBuilderInterface;
 
 /**
  * Class to prepare select for partial reindex
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class SelectBuilder
+class SelectBuilder implements SelectBuilderInterface
 {
     /**
      * @var ResourceConnection

--- a/InventoryGroupedProductIndexer/etc/di.xml
+++ b/InventoryGroupedProductIndexer/etc/di.xml
@@ -10,10 +10,6 @@
     <type name="Magento\InventoryIndexer\Indexer\SourceItem\Strategy\Sync">
         <plugin name="grouped_product_index" type="Magento\InventoryGroupedProductIndexer\Plugin\InventoryIndexer\Indexer\SourceItem\Strategy\Sync\SourceItemIndexerPlugin" />
     </type>
-    <type name="Magento\InventoryIndexer\Indexer\Stock\Strategy\Sync">
-        <plugin name="grouped_product_index_list" type="Magento\InventoryGroupedProductIndexer\Plugin\InventoryIndexer\Indexer\Stock\Strategy\Sync\ReindexListPlugin" />
-        <plugin name="grouped_product_index_full" type="Magento\InventoryGroupedProductIndexer\Plugin\InventoryIndexer\Indexer\Stock\Strategy\Sync\ReindexFullPlugin" />
-    </type>
     <type name="Magento\InventoryGroupedProductIndexer\Indexer\Stock\StockIndexer">
         <arguments>
             <argument name="indexHandler" xsi:type="object">Magento\InventoryIndexer\Indexer\IndexHandler</argument>
@@ -30,6 +26,13 @@
         <arguments>
             <argument name="tableNameSourceItem" xsi:type="const">Magento\Inventory\Model\ResourceModel\SourceItem::TABLE_NAME_SOURCE_ITEM</argument>
             <argument name="tableNameStockSourceLink" xsi:type="const">Magento\Inventory\Model\ResourceModel\StockSourceLink::TABLE_NAME_STOCK_SOURCE_LINK</argument>
+        </arguments>
+    </type>
+    <type name="Magento\InventoryIndexer\Indexer\Stock\IndexDataProviderByStockId">
+        <arguments>
+            <argument name="selectBuilders" xsi:type="array">
+                <item name="grouped_product" xsi:type="object">Magento\InventoryGroupedProductIndexer\Indexer\SelectBuilder</item>
+            </argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento Inventory version (example: 2.3.2) and any important information on the environment where bug is reproducible.
-->
1. `magento/module-inventory-cache`
2. Magento 2.4.7-p2


### What is happening?
MSI has this function in place as `around` method. Which gets the product IDs from `inventory_stock_ID` table before and after.
Pay attention to `around` method here.
https://github.com/magento/inventory/blob/790c7ff267be04be6cc57f4502e005bec560a2b3/InventoryCache/Plugin/InventoryIndexer/Indexer/Stock/Strategy/Sync/CacheFlush.php#L51


Then, it also has this function as `after` method to index grouped products, which happens after the above function (around) runs, meaning at this time, the system has already sent all the grouped product IDs to clear the cache.
https://github.com/magento/inventory/blob/790c7ff267be04be6cc57f4502e005bec560a2b3/InventoryGroupedProductIndexer/Plugin/InventoryIndexer/Indexer/Stock/Strategy/Sync/ReindexFullPlugin.php#L43

### What this means?
If I have 200 grouped products in my system, every time a single product's (not related to grouped whatsoever) sources deleted/added, then it will send the cache clear request for this product PLUS that 200 grouped products. 

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Make sure you have some grouped products
2. Run `bin/magento indexer:reindex inventory`

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. System should only send impacted products to clear the cache

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. System should never send unrelated product to clear the cache
