### PR TITLE
Fix stock qty is not displayed

### DIFF
--- a/InventoryCatalogFrontendUi/Model/IsSalableQtyAvailableForDisplaying.php
+++ b/InventoryCatalogFrontendUi/Model/IsSalableQtyAvailableForDisplaying.php
@@ -15,18 +15,11 @@ use Magento\InventoryConfigurationApi\Api\Data\StockItemConfigurationInterface;
 class IsSalableQtyAvailableForDisplaying
 {
     /**
-     * @var StockItemConfigurationInterface
-     */
-    private $stockItemConfig;
-
-    /**
      * @param StockItemConfigurationInterface $stockItemConfiguration
      */
     public function __construct(
-        StockItemConfigurationInterface $stockItemConfiguration
-    ) {
-        $this->stockItemConfig = $stockItemConfiguration;
-    }
+        private StockItemConfigurationInterface $stockItemConfiguration
+    ) {}
 
     /**
      * Is salable quantity available for displaying.
@@ -37,8 +30,8 @@ class IsSalableQtyAvailableForDisplaying
     public function execute(float $productSalableQty): bool
     {
         return ($this->stockItemConfig->getBackorders() === StockItemConfigurationInterface::BACKORDERS_NO
-                || $this->stockItemConfig->getBackorders() !== StockItemConfigurationInterface::BACKORDERS_NO
-                && $this->stockItemConfig->getMinQty() < 0)
+                || ($this->stockItemConfig->getBackorders() !== StockItemConfigurationInterface::BACKORDERS_NO
+                && $this->stockItemConfig->getMinQty() < 0))
             && $productSalableQty <= (float) $this->stockItemConfig->getStockThresholdQty()
             && $productSalableQty > 0;
     }


### PR DESCRIPTION
### Description (*)
This change fix the priority in condition for the minQty.
Before this change, wether or not the backorder were enabled, it had the same result (basically it was if has no backorder, or has backorder).

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
