### PR TITLE
Incorrect Backorder Quantity Handling When Adding Same Product to Cart With Different Custom Options

### DIFF
--- a/InventorySales/Model/GetBackorder.php
+++ b/InventorySales/Model/GetBackorder.php
@@ -76,6 +76,13 @@ class GetBackorder
     private $getBackorderQty;
 
     /**
+     * Product backorder qty's checked
+     *
+     * @var array
+     */
+    private $backorderQty = [];
+
+    /**
      * @param ObjectFactory $objectFactory
      * @param FormatInterface $format
      * @param AreProductsSalableForRequestedQtyInterface $areProductsSalableForRequestedQty
@@ -161,6 +168,11 @@ class GetBackorder
                 }
             }
             $backorderQty = $this->getBackorderQty->execute($productSku, (int)$stockId, $qty);
+            if (isset($this->backorderQty[$productSku])) {
+                $backorderQty -= $this->backorderQty[$productSku];
+            } else {
+                $this->backorderQty[$productSku] = $backorderQty;
+            }
             if ($backorderQty > 0) {
                 $result->setItemBackorders($backorderQty);
             }

--- a/InventorySales/Model/IsProductSalableCondition/BackOrderNotifyCustomerCondition.php
+++ b/InventorySales/Model/IsProductSalableCondition/BackOrderNotifyCustomerCondition.php
@@ -46,6 +46,13 @@ class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQt
     private $getBackorderQty;
 
     /**
+     * Product backorder qty's checked
+     *
+     * @var array
+     */
+    private $backorderQty = [];
+
+    /**
      * @param GetStockItemConfigurationInterface $getStockItemConfiguration
      * @param GetStockItemDataInterface $getStockItemData @deprecated
      * @param ProductSalableResultInterfaceFactory $productSalableResultFactory
@@ -80,6 +87,12 @@ class BackOrderNotifyCustomerCondition implements IsProductSalableForRequestedQt
             && $stockItemConfiguration->getBackorders() === StockItemConfigurationInterface::BACKORDERS_YES_NOTIFY
         ) {
             $backorderQty = $this->getBackorderQty->execute($sku, $stockId, $requestedQty);
+
+            if (isset($this->backorderQty[$sku])) {
+                $backorderQty -= $this->backorderQty[$sku];
+            } else {
+                $this->backorderQty[$sku] = $backorderQty;
+            }
 
             if ($backorderQty > 0) {
                 $errors = [


### PR DESCRIPTION
### Fixed Issues
1. Fixes magento/inventory#3446: Incorrect Backorder Quantity Handling When Adding Same Product to Cart With Different Custom Options

### Manual testing scenarios

1. Create a simple product with custom options.
2. Set product stock quantity to 10.

<img width="1813" height="2187" alt="image" src="https://github.com/user-attachments/assets/67bd4e3c-197f-4a3d-836b-367a0d83821d" />

3. Enable backorders: Catalog > Products > Advanced Inventory > Backorders > Allow Qty Below 0 and Notify Customer
4. On frontend, add the same product to the cart twice, each with a different custom option. For each cart item, set quantity to 20.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
