### PR TITLE
Improve the performance of the SQL query generated for updating stock…

### DIFF
--- a/InventoryIndexer/Model/ResourceModel/UpdateIsSalable.php
+++ b/InventoryIndexer/Model/ResourceModel/UpdateIsSalable.php
@@ -51,7 +51,7 @@ class UpdateIsSalable
         $connection = $this->resourceConnection->getConnection($connectionName);
         $tableName = $this->indexNameResolver->resolveName($indexName);
         foreach ($dataForUpdate as $sku => $isSalable) {
-            $connection->update($tableName, [IndexStructure::IS_SALABLE => $isSalable], ['sku = ?' => $sku]);
+            $connection->update($tableName, [IndexStructure::IS_SALABLE => $isSalable], ['sku = ?' => (string)$sku]);
         }
     }
 }


### PR DESCRIPTION
… status after an order is placed

The input parameter `$dataForUpdate` uses SKU as the array key. Since SKUs can be numeric, PHP will automatically cast such keys to integers when used in an array. Reference: https://www.php.net/manual/en/language.types.array.php "Specifically, strings that represent valid decimal integers will be converted to integers"

As a result, the generated SQL query may contain `sku=3938599` instead of `sku='3938599'`. This leads MySQL to perform implicit type conversion, causing a full table scan where every row is loaded into memory and compared by converting string values to numbers one by one. Reference: https://dev.mysql.com/doc/refman/8.0/en/type-conversion.html

We cannot fix the issue at the point where `$dataForUpdate` is generated (`\Magento\InventoryIndexer\Model\Queue\GetSalabilityDataForUpdate::execute`), since this logic is reused elsewhere and changing the data type could introduce side effects. However, in this specific function—where the data is used to build the SQL query—we can explicitly cast the SKU to a string. This prevents MySQL from performing a full table scan and ensures proper query behavior.
